### PR TITLE
Remove unnecessary ids from ExpressionGraphManager

### DIFF
--- a/client/src/util/MathScope/ExpressionGraphManager.ts
+++ b/client/src/util/MathScope/ExpressionGraphManager.ts
@@ -30,11 +30,11 @@ const defaultValidateAddExpr: ValidationHook = () => {};
  *
  * For example:
  * ```ts
- * // node implements (id: string, expr: string) => MathNode
+ * import { parse } from 'mathjs'
  * const manager = new ExpressionGraphManager()
- * const a = node('idA', 'a = 2')
- * const b = node('idB', 'b = a + 1')
- * const expr1 = node('idExpr1', 'a + b')
+ * const a = parse('a = 2')
+ * const b = parse('b = a + 1')
+ * const expr1 = parse('a + b')
  * manager.addExpressions([a, b, expr])
  * ```
  *
@@ -109,7 +109,7 @@ export default class ExpressionGraphManager {
      * Establish edges between all duplicates with same name. This means
      * duplicate assignments create cycles. Why is this desirable?
      *
-     * Our standard procedurate is that when nodes are added/removed from the
+     * Our standard procedure is that when nodes are added/removed from the
      * graph, we re-evaluate the reachable subgraph. So in this situation:
      *    Nodes:               current evaluation:
      *    --------------------------------------------

--- a/client/src/util/MathScope/ExpressionGraphManager.ts
+++ b/client/src/util/MathScope/ExpressionGraphManager.ts
@@ -18,13 +18,6 @@ const getAssignmentNodesByName = R.pipe<
   (e) => new Map(e)
 );
 
-type ValidationHook = (
-  expressions: MathNode[],
-  manager: ExpressionGraphManager
-) => void;
-
-const defaultValidateAddExpr: ValidationHook = () => {};
-
 /**
  * Helps manage a dependency graph for mathematical expressions.
  *
@@ -49,25 +42,19 @@ export default class ExpressionGraphManager {
 
   allowedDuplicateLeafRegex: RegExp;
 
-  private validateAddExpressions: ValidationHook;
-
   constructor(
     nodes: MathNode[] = [],
     {
-      validateAddExpressions = defaultValidateAddExpr,
       allowedDuplicateLeafRegex = /^_/,
     }: {
-      validateAddExpressions?: ValidationHook;
       allowedDuplicateLeafRegex?: RegExp;
     } = {}
   ) {
     this.allowedDuplicateLeafRegex = allowedDuplicateLeafRegex;
-    this.validateAddExpressions = validateAddExpressions;
     this.addExpressions(nodes);
   }
 
   addExpressions(nodes: MathNode[]): void {
-    this.validateAddExpressions(nodes, this);
     nodes.forEach((node) => {
       this.graph.addNode(node);
     });


### PR DESCRIPTION
The tests and docstring for ExpressionGraphManager were using identified MathNodes (nodes with node.comment = id). This was unnecessary. I suspect it was an oversight from when ExpressionGraphManager was factored out of Evaluator.