### PR TITLE
Fix errors

### DIFF
--- a/client/src/util/MathScope/Evaluator.spec.ts
+++ b/client/src/util/MathScope/Evaluator.spec.ts
@@ -3,7 +3,9 @@ import Evaluator, {
   UnmetDependencyError as UnmetDepErr,
   getId,
   DuplicateAssignmentError,
+  CyclicAssignmentError,
 } from "./Evaluator";
+import { assertIsGeneralAssignmentNode } from "./util";
 
 const node = (id: string, parseable: string) => {
   const parsed = parse(parseable);
@@ -71,21 +73,46 @@ describe("Evaluator", () => {
       });
     });
 
-    it.only("records duplicate assignment errors", () => {
+    it("records duplicate assignment errors", () => {
       const x1 = node("id-x1", "x = 1");
       const x2 = node("id-x2", "x = 1");
+      assertIsGeneralAssignmentNode(x1);
+      assertIsGeneralAssignmentNode(x2);
+
       const evaluator = new Evaluator();
       evaluator.enqueueAddExpressions([x1, x2]);
       const diff = evaluator.evaluate();
       expect(evaluator.results).toStrictEqual(asMap({}));
       expect(evaluator.errors).toStrictEqual(
         asMap({
-          "id-x1": new DuplicateAssignmentError("x"),
-          "id-x2": new DuplicateAssignmentError("x"),
+          "id-x1": new DuplicateAssignmentError(x1),
+          "id-x2": new DuplicateAssignmentError(x2),
         })
       );
       expect(diff.errors).toStrictEqual({
         added: new Set(["id-x1", "id-x2"]),
+        updated: new Set(),
+        deleted: new Set(),
+      });
+    });
+
+    it("records cyclic assignment errors", () => {
+      const x = node("id-x", "x = y^2");
+      const y = node("id-y", "y = x^2");
+      assertIsGeneralAssignmentNode(x);
+      assertIsGeneralAssignmentNode(y);
+      const evaluator = new Evaluator();
+      evaluator.enqueueAddExpressions([x, y]);
+      const diff = evaluator.evaluate();
+      expect(evaluator.results).toStrictEqual(asMap({}));
+      expect(evaluator.errors).toStrictEqual(
+        asMap({
+          "id-x": new CyclicAssignmentError([y, x]),
+          "id-y": new CyclicAssignmentError([y, x]),
+        })
+      );
+      expect(diff.errors).toStrictEqual({
+        added: new Set(["id-x", "id-y"]),
         updated: new Set(),
         deleted: new Set(),
       });

--- a/client/src/util/MathScope/Evaluator.ts
+++ b/client/src/util/MathScope/Evaluator.ts
@@ -40,15 +40,15 @@ export class UnmetDependencyError extends EvaluationError {
 export class AssignmentError extends EvaluationError {}
 export class CyclicAssignmentError extends AssignmentError {
   constructor(cycle: GeneralAssignmentNode[]) {
-    const nodeNames = cycle.map((n) => n.name);
+    const nodeNames = cycle.map((n) => `'${n.name}'`).join(", ");
     const message = `Cyclic dependencies: ${nodeNames}`;
     super(message);
   }
 }
 
 export class DuplicateAssignmentError extends AssignmentError {
-  constructor(name: string) {
-    const message = `Name ${name} has been assigned multiple times.`;
+  constructor(node: GeneralAssignmentNode) {
+    const message = `Name ${node.name} has been assigned multiple times.`;
     super(message);
   }
 }
@@ -57,8 +57,8 @@ const makeAssignmentError = (
   node: GeneralAssignmentNode,
   cycle: GeneralAssignmentNode[]
 ) => {
-  const isDuplicate = cycle.some((c) => c.name === node.name);
-  if (isDuplicate) return new DuplicateAssignmentError(node.name);
+  const isDuplicate = cycle.some((c) => c.name === node.name && c !== node);
+  if (isDuplicate) return new DuplicateAssignmentError(node);
   return new CyclicAssignmentError(cycle);
 };
 

--- a/client/src/util/MathScope/util.ts
+++ b/client/src/util/MathScope/util.ts
@@ -16,6 +16,13 @@ export const isGeneralAssignmentNode = (
   return false;
 };
 
+export const assertIsGeneralAssignmentNode: (
+  node: unknown
+) => asserts node is GeneralAssignmentNode = (node: unknown) => {
+  if (isGeneralAssignmentNode(node)) return;
+  throw new Error("Node is not a GeneralAssignmentNode");
+};
+
 /**
  * Get the symbol dependencies of a given node. For example,
  * ```ts


### PR DESCRIPTION
This fixes two issues (and adds tests for the fixes):
- AssignmentErrors were not being recorded in the diff returned by `evaluate`
- Cyclic assignments were being incorrectly recorded as DuplicateAssignments