### PR TITLE
Parse errors

### DIFF
--- a/client/src/features/sceneControls/mathItems/mathScope.spec.tsx
+++ b/client/src/features/sceneControls/mathItems/mathScope.spec.tsx
@@ -101,7 +101,7 @@ describe("useMathValues and useModifyMathEpressions", () => {
     expect(results.current).toStrictEqual({ a: 3, b: 9 });
   });
 
-  test("useMathErrors triggers re-renders when errors change", async () => {
+  test("useMathErrors triggers re-renders when eval errors change", async () => {
     const { errors, mathScope } = setup("id1", ["x", "y", "z"]);
 
     await act(() => {
@@ -120,5 +120,23 @@ describe("useMathValues and useModifyMathEpressions", () => {
       x: expect.any(CyclicAssignmentError),
       y: expect.any(CyclicAssignmentError),
     });
+  });
+
+  test("useMathErrors triggers re-renders when parse errors change", async () => {
+    const { errors, mathScope } = setup("id1", ["x"]);
+
+    await act(() => {
+      mathScope.setExpressions([{ id: "id1-x", expr: "x = 3^" }]);
+    });
+
+    expect(errors.current).toStrictEqual({
+      x: expect.any(Error),
+    });
+
+    await act(() => {
+      mathScope.setExpressions([{ id: "id1-x", expr: "x = 3^2" }]);
+    });
+
+    expect(errors.current).toStrictEqual({});
   });
 });

--- a/client/src/features/sceneControls/mathItems/mathScope.ts
+++ b/client/src/features/sceneControls/mathItems/mathScope.ts
@@ -38,8 +38,11 @@ const extractErrors = <K extends string>(
   const newErrors: EvaluationErrorsSlice<K> = {};
   (Object.keys(ids) as K[]).forEach((name) => {
     const id = ids[name];
-    if (scope.errors.has(id)) {
-      newErrors[name] = scope.errors.get(id);
+    if (scope.evalErrors.has(id)) {
+      newErrors[name] = scope.evalErrors.get(id);
+    }
+    if (scope.parseErrors.has(id)) {
+      newErrors[name] = scope.parseErrors.get(id);
     }
   });
   return newErrors;
@@ -99,8 +102,11 @@ const useMathErrors = <K extends string>(
   const onChange = useCallback<OnChangeListener>(
     (event) => {
       const { mathScope } = event;
-      const { errors } = event.changes;
-      if (names.some((name) => errors.touched.has(ids[name]))) {
+      const { evalErrors, parseErrors } = event.changes;
+      if (
+        names.some((name) => evalErrors.touched.has(ids[name])) ||
+        names.some((name) => parseErrors.touched.has(ids[name]))
+      ) {
         setErrors(extractErrors(mathScope, ids));
       }
     },

--- a/client/src/features/sceneControls/mathItems/templates/ItemTemplate.tsx
+++ b/client/src/features/sceneControls/mathItems/templates/ItemTemplate.tsx
@@ -1,11 +1,13 @@
-import React from "react";
+import React, { useCallback } from "react";
 import mergeClassNames from "classnames";
 import type { MathItem, MathItemConfig } from "types";
+import { useAppDispatch } from "app/hooks";
 import styles from "./ItemTemplate.module.css";
 import SettingsPopover from "./SettingsPopover";
 import CloseButton from "./CloseButton";
 import { AutosizeText, useOnWidgetChange } from "../FieldWidget";
 import { usePopulateMathScope } from "../mathScope";
+import { actions } from "../mathItems.slice";
 
 type Props = {
   showAlignmentBar?: boolean;
@@ -22,6 +24,10 @@ const ItemTemplate: React.FC<Props> = ({
 }) => {
   const onWidgetChange = useOnWidgetChange(item);
   usePopulateMathScope(item, config);
+  const dispatch = useAppDispatch();
+  const remove = useCallback(() => {
+    dispatch(actions.remove({ id: item.id }));
+  }, [dispatch, item.id]);
   return (
     <div className={styles.container}>
       <div
@@ -39,7 +45,6 @@ const ItemTemplate: React.FC<Props> = ({
           onChange={onWidgetChange}
         />
       </div>
-
       <div className={styles["grid-center-bottom"]}>{children}</div>
       <div
         className={mergeClassNames(
@@ -48,7 +53,7 @@ const ItemTemplate: React.FC<Props> = ({
           "justify-content-end"
         )}
       >
-        <CloseButton />
+        <CloseButton onClick={remove} />
       </div>
       <div className={styles["grid-right-gutter-bottom"]}>
         <SettingsPopover item={item} config={config} />

--- a/client/src/util/MathScope/types.ts
+++ b/client/src/util/MathScope/types.ts
@@ -10,6 +10,8 @@ export type EvaluationResult = Map<string, unknown>;
 
 export type EvaluationErrors = Map<string, Error>;
 
+export type ParsingErrors = Map<string, Error>;
+
 export type ParseErrors = Map<string, Error>;
 
 export interface EvaluationChange {
@@ -35,5 +37,3 @@ export interface FullDiff<T> extends Diff<T> {
   deleted: Set<T>;
   unchanged: Set<T>;
 }
-
-type Comparer<T> = (t1: T, t2: T) => boolean;


### PR DESCRIPTION
- store parse errors in MathScope and expose to react
    
    _The motivation here is to enable parse errors in `useMathErrors` for error tooltips_
- enable removing items with X button