### PR TITLE
add react wrapper around math-live

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -17,6 +17,7 @@
         "classnames": "2.3.1",
         "lodash": "4.17.21",
         "mathjs": "10.5.3",
+        "mathlive": "^0.73.0",
         "ramda": "0.28.0",
         "react": "18.1.0",
         "react-bootstrap": "2.4.0",
@@ -24539,6 +24540,19 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/mathlive": {
+      "version": "0.73.0",
+      "resolved": "https://registry.npmjs.org/mathlive/-/mathlive-0.73.0.tgz",
+      "integrity": "sha512-XX6PtF2OUSlyrgTBhpsavVzfQojPl6eIPjlxHGgtBRXnud0bUtCBCZNCZTiyAyzQDfS8i+psW/e3zI+Jn6RVyA==",
+      "engines": {
+        "node": ">=16.14.2",
+        "npm": ">=8.5.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paypal.me/arnogourdol"
       }
     },
     "node_modules/md5.js": {
@@ -53108,6 +53122,11 @@
         "tiny-emitter": "^2.1.0",
         "typed-function": "^2.1.0"
       }
+    },
+    "mathlive": {
+      "version": "0.73.0",
+      "resolved": "https://registry.npmjs.org/mathlive/-/mathlive-0.73.0.tgz",
+      "integrity": "sha512-XX6PtF2OUSlyrgTBhpsavVzfQojPl6eIPjlxHGgtBRXnud0bUtCBCZNCZTiyAyzQDfS8i+psW/e3zI+Jn6RVyA=="
     },
     "md5.js": {
       "version": "1.3.5",

--- a/client/package.json
+++ b/client/package.json
@@ -34,6 +34,7 @@
     "classnames": "2.3.1",
     "lodash": "4.17.21",
     "mathjs": "10.5.3",
+    "mathlive": "0.73.0",
     "ramda": "0.28.0",
     "react": "18.1.0",
     "react-bootstrap": "2.4.0",

--- a/client/src/features/sceneControls/mathItems/util.ts
+++ b/client/src/features/sceneControls/mathItems/util.ts
@@ -1,5 +1,6 @@
 import { MathItem, MathItemType, mathItemConfigs } from "configs";
 import idGenerator from "util/idGenerator";
+import React from "react";
 
 const makeItem = <T extends MathItemType>(
   type: T,

--- a/client/src/util/components/MathLive/MathField.stories.tsx
+++ b/client/src/util/components/MathLive/MathField.stories.tsx
@@ -1,0 +1,85 @@
+/* eslint-disable react/jsx-no-bind */
+import React, { useState } from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import MathField from "./MathField";
+
+export default {
+  title: "MathField",
+  component: MathField,
+  argTypes: { onChange: { action: "onChange" } },
+} as ComponentMeta<typeof MathField>;
+
+export const Simple: ComponentStory<typeof MathField> = (args) => (
+  <MathField
+    {...args}
+    style={{
+      border: "1pt solid blue",
+      borderRadius: "8px",
+      width: "min-content",
+    }}
+    makeOptions={() => ({ readOnly: true })}
+  >
+    {String.raw`1 + \frac{1}{4} + \frac{1}{9} + \frac{1}{16} + \cdots = \frac{\pi^2}{6}`}
+  </MathField>
+);
+
+export const Overflowing: ComponentStory<typeof MathField> = (args) => (
+  <div style={{ width: 100, border: "1pt solid red" }}>
+    <MathField
+      {...args}
+      style={{
+        border: "1pt solid blue",
+        borderRadius: "8px",
+        width: "min-content",
+      }}
+    >
+      {String.raw`1 + \frac{1}{4} + \frac{1}{9} + \frac{1}{16} + \cdots = \frac{\pi^2}{6}`}
+    </MathField>
+  </div>
+);
+
+export const Static: ComponentStory<typeof MathField> = (args) => (
+  <div
+    style={{
+      border: "1pt solid red",
+      width: 100,
+      height: 50,
+      overflowX: "visible",
+    }}
+  >
+    <MathField
+      {...args}
+      style={{ width: "min-content" }}
+      makeOptions={() => ({ readOnly: true })}
+    >
+      E=mc^2
+    </MathField>
+  </div>
+);
+
+export const Controlled: ComponentStory<typeof MathField> = (args) => {
+  const [latex, setLatex] = useState("E=mc^2");
+  return (
+    <div>
+      <MathField
+        {...args}
+        onChange={(event) => {
+          setLatex(event.target.value);
+        }}
+      >
+        {latex}
+      </MathField>
+      <textarea
+        name="latex"
+        id="latex"
+        cols={30}
+        rows={10}
+        value={latex}
+        onChange={(event) => {
+          setLatex(event.target.value);
+        }}
+      />
+      {latex}
+    </div>
+  );
+};

--- a/client/src/util/components/MathLive/MathField.tsx
+++ b/client/src/util/components/MathLive/MathField.tsx
@@ -1,0 +1,58 @@
+import React, { useEffect, useState } from "react";
+import { MathfieldElement, MathfieldOptions } from "mathlive";
+import { useListenToEvent } from "./util";
+import "./mathlive";
+import type {
+  FocusOutHandler,
+  KeystrokeHandler,
+  MathFieldWebComponentProps,
+} from "./types";
+
+export type MakeMathfieldOptions = (
+  options: MathfieldOptions
+) => Partial<MathfieldOptions>;
+
+interface MathfieldProps extends MathFieldWebComponentProps {
+  onKeystroke?: KeystrokeHandler;
+  onFocusOut?: FocusOutHandler;
+  makeOptions?: MakeMathfieldOptions;
+  children?: string;
+}
+
+/**
+ * A React component for MathLive's MathField.
+ *
+ * Note: Following React's convention, `props.onChange` is bound to the `input`
+ * event. See https://reactjs.org/docs/dom-elements.html#onchange
+ */
+const MathField = (props: MathfieldProps) => {
+  const {
+    onKeystroke,
+    onFocusOut,
+    onChange,
+    makeOptions,
+    className,
+    children,
+    ...others
+  } = props;
+  const [mf, setMf] = useState<MathfieldElement | null>(null);
+  useListenToEvent(mf, "keystroke", onKeystroke);
+  useListenToEvent(mf, "focus-out", onFocusOut);
+  useEffect(() => {
+    if (!mf) return;
+    if (!makeOptions) return;
+    const options = makeOptions(mf.getOptions());
+    mf.setOptions(options);
+  }, [makeOptions, mf]);
+
+  useEffect(() => {
+    mf?.setValue(children);
+  }, [mf, children]);
+
+  return (
+    <math-field {...others} class={className} onInput={onChange} ref={setMf} />
+  );
+};
+
+export default MathField;
+export type { MathfieldProps };

--- a/client/src/util/components/MathLive/mathlive.ts
+++ b/client/src/util/components/MathLive/mathlive.ts
@@ -1,0 +1,7 @@
+/**
+ * Putting this in a separate file because eslint gets confused about multiple
+ * js imports from same bundle
+ */
+import "mathlive/dist/mathlive-fonts.css";
+import "mathlive/dist/mathlive-static.css";
+import "mathlive/dist/mathlive.min";

--- a/client/src/util/components/MathLive/types.d.ts
+++ b/client/src/util/components/MathLive/types.d.ts
@@ -1,0 +1,39 @@
+import { MathfieldElement, KeystrokeEvent, FocusOutEvent } from "mathlive";
+
+export type KeystrokeHandler = (
+  this: MathfieldElement,
+  ev: CustomEvent<KeystrokeEvent>
+) => void;
+
+export type FocusOutHandler = (
+  this: MathfieldElement,
+  ev: CustomEvent<FocusOutEvent>
+) => void;
+
+export type MathfieldEventName = "keystroke" | "focus-out";
+
+export type MathfieldHandlers = {
+  keystroke: KeystrokeHandler;
+  "focus-out": FocusOutHandler;
+};
+
+export interface MathfieldHTMLAttributes
+  extends React.HTMLAttributes<MathfieldElement> {
+  onChange?: React.ChangeEventHandler<MathfieldElement> | undefined;
+}
+
+export type MathFieldWebComponentProps = React.DetailedHTMLProps<
+  MathfieldHTMLAttributes,
+  MathfieldElement
+>;
+
+declare global {
+  /** @internal */
+  namespace JSX {
+    interface IntrinsicElements {
+      "math-field": Omit<MathFieldWebComponentProps, "className" | "style"> & {
+        class: MathFieldWebComponentProps["className"];
+      };
+    }
+  }
+}

--- a/client/src/util/components/MathLive/util.ts
+++ b/client/src/util/components/MathLive/util.ts
@@ -1,0 +1,26 @@
+import { useEffect } from "react";
+import { MathfieldElement } from "mathlive";
+import { MathfieldEventName, MathfieldHandlers } from "./types";
+
+type AddEventListenerParams = Parameters<Element["addEventListener"]>;
+/**
+ * Add an event listener to a MathField element
+ */
+const useListenToEvent = <T extends MathfieldEventName>(
+  element: MathfieldElement | null,
+  name: T,
+  listener?: MathfieldHandlers[T],
+  options?: AddEventListenerParams[2]
+) => {
+  useEffect(() => {
+    if (!element) return () => {};
+    if (!listener) return () => {};
+    const h = listener as () => void;
+    element.addEventListener(name, h, options);
+    return () => {
+      element.removeEventListener(name, h, options);
+    };
+  }, [element, name, listener, options]);
+};
+
+export { useListenToEvent };


### PR DESCRIPTION
https://github.com/arnog/react-mathlive and https://github.com/concludio/react-mathlive both use an older version of math-live.

Would be nice to contrib back to Arnog's, but this will do for now.