### PR TITLE
add latex parser

### DIFF
--- a/client/src/util/MathScope/adapter.ts
+++ b/client/src/util/MathScope/adapter.ts
@@ -112,4 +112,4 @@ const parse: Parse<ParseOptions> = (
 
 export type { ParseOptions };
 
-export { anonParse, parse };
+export { anonParse, parse, convertNode };

--- a/client/src/util/MathScope/index.ts
+++ b/client/src/util/MathScope/index.ts
@@ -1,8 +1,10 @@
 import MathScope, { OnChangeListener, IdentifiedExpression } from "./MathScope";
 import { UnmetDependencyError, DuplicateAssignmentError } from "./Evaluator";
+import type { MathNode, Parse } from "./interfaces";
+import * as adapter from "./adapter";
 
-export type { OnChangeListener, IdentifiedExpression };
+export type { OnChangeListener, IdentifiedExpression, MathNode, Parse };
 
-export { UnmetDependencyError, DuplicateAssignmentError };
+export { UnmetDependencyError, DuplicateAssignmentError, adapter };
 
 export default MathScope;

--- a/client/src/util/parsing/MathJsParser.ts
+++ b/client/src/util/parsing/MathJsParser.ts
@@ -1,0 +1,87 @@
+import * as mjs from "mathjs";
+import {
+  ParserRuleType,
+  TextParserRule,
+  TextParserRegexRule,
+  MathJsRule,
+  ParserRule,
+  StrictRegepMatchArray,
+  IMathJsParser,
+} from "./interfaces";
+import { adapter as msAdapter, MathNode } from "../MathScope";
+
+const isBeforeMathjsRule = (
+  rule: ParserRule
+): rule is TextParserRule | TextParserRegexRule => {
+  if (rule.type === ParserRuleType.Text) return true;
+  if (rule.type === ParserRuleType.TextRegexp) return true;
+  return false;
+};
+
+const isMathJsRule = (rule: ParserRule): rule is MathJsRule => {
+  return rule.type === ParserRuleType.MathJs;
+};
+
+/**
+ * A parser that transforms strings into MathNodes for MathScope. The general
+ * process is:
+ *  1. pre-process the input string (string -> string) with user-provided rules.
+ *    This is good for things like turning LaTeX fractions into normal division.
+ *  2. parse with mathjs
+ *  3. process the mathjs node (mjsNode -> mjsNode) with user-provided rules.
+ *    This is good for things like simplifying the mjsNode or replacing unused
+ *    operator functions (e.g., use `%` for cross product.)
+ *
+ * The parser accepts `ParserRule`s which determine its behavior. For example,
+ * these can be used to
+ */
+class MathJsParser implements IMathJsParser {
+  private rules: ParserRule[];
+
+  constructor(rules: ParserRule[]) {
+    this.rules = rules;
+  }
+
+  preprocess = (expression: string): string => {
+    const textRules = this.rules.filter(isBeforeMathjsRule);
+    const expressionFinal = textRules.reduce((text, rule) => {
+      if (rule.type === ParserRuleType.Text) {
+        return rule.transform(text);
+      }
+      return MathJsParser.applyTextRegexpRule(text, rule);
+    }, expression);
+    return expressionFinal;
+  };
+
+  parse: IMathJsParser["parse"] = (expression, id, options): MathNode => {
+    const preprocessed = this.preprocess(expression);
+    const mjsRules = this.rules.filter(isMathJsRule);
+    const mjsFinal = mjsRules.reduce(
+      (mjsNode, rule) => rule.transform(mjsNode),
+      mjs.parse(preprocessed)
+    );
+
+    const node = msAdapter.convertNode(mjsFinal, options) as MathNode;
+    node.id = id;
+    return node;
+  };
+
+  private static applyTextRegexpRule = (
+    expr: string,
+    rule: TextParserRegexRule
+  ): string => {
+    const { regexp, replacement } = rule;
+    const matches = [
+      ...expr.matchAll(regexp),
+    ].reverse() as StrictRegepMatchArray[];
+    return matches.reduce((text, match) => {
+      return [
+        text.slice(0, match.index),
+        typeof replacement === "string" ? replacement : replacement(match),
+        text.slice(match.index + match[0].length),
+      ].join("");
+    }, expr);
+  };
+}
+
+export default MathJsParser;

--- a/client/src/util/parsing/interfaces.ts
+++ b/client/src/util/parsing/interfaces.ts
@@ -1,0 +1,44 @@
+import type { MathNode as MJsNode } from "mathjs";
+import type { Parse } from "../MathScope";
+import type { ParseOptions } from "../MathScope/adapter";
+
+enum ParserRuleType {
+  MathJs = "mathjs",
+  Text = "text",
+  TextRegexp = "text-regexp",
+}
+
+interface TextParserRule {
+  type: ParserRuleType.Text;
+  transform: (text: string) => string;
+}
+
+type StrictRegepMatchArray = RegExpMatchArray & { index: number };
+
+interface TextParserRegexRule {
+  type: ParserRuleType.TextRegexp;
+  regexp: RegExp;
+  replacement: string | ((match: StrictRegepMatchArray) => string);
+}
+
+interface MathJsRule {
+  type: ParserRuleType.MathJs;
+  transform: (node: MJsNode) => MJsNode;
+}
+
+type ParserRule = TextParserRule | TextParserRegexRule | MathJsRule;
+
+interface IMathJsParser {
+  preprocess: (text: string) => string;
+  parse: Parse<ParseOptions>;
+}
+
+export { ParserRuleType };
+export type {
+  TextParserRule,
+  TextParserRegexRule,
+  MathJsRule,
+  ParserRule,
+  IMathJsParser,
+  StrictRegepMatchArray,
+};

--- a/client/src/util/parsing/parsers.spec.ts
+++ b/client/src/util/parsing/parsers.spec.ts
@@ -1,0 +1,57 @@
+import { latexParser as parser } from "./parsers";
+
+describe("preprocesser fraction conversion", () => {
+  test("converts zero fractions correctly", () => {
+    const input = "a + b";
+    const expected = "a + b";
+    expect(parser.preprocess(input)).toBe(expected);
+  });
+
+  test("converts a single fraction correctly", () => {
+    const input = "1 + \\frac{1 + \\cos{x}}{1 - \\cos{x}}";
+    const expected = "1 + (1 + cos(x))/(1 - cos(x))";
+    expect(parser.preprocess(input)).toBe(expected);
+  });
+
+  test("converts multiple fractions correctly", () => {
+    const input = "x + \\frac{a + \\frac{b + c}{d - e}}{f + g}";
+    const expected = "x + (a + (b + c)/(d - e))/(f + g)";
+    expect(parser.preprocess(input)).toBe(expected);
+  });
+});
+
+describe("subscript conversion", () => {
+  test("does nothing to single character subscripts", () => {
+    const input = "x_1 + x_2";
+    const expected = "x_1 + x_2";
+    expect(parser.preprocess(input)).toBe(expected);
+  });
+
+  test("converts multi-character subscripts", () => {
+    const input = "x_{12foo} + y_{bar123}";
+    const expected = "x_12foo + y_bar123";
+    expect(parser.preprocess(input)).toBe(expected);
+  });
+
+  test("converts nested subscripts", () => {
+    const input = "x_{12foo_{bar123_{evenlower}}}";
+    const expected = "x_12foo_bar123_evenlower";
+    expect(parser.preprocess(input)).toBe(expected);
+  });
+});
+
+describe("operatorname conversion", () => {
+  test("operatorname is removed", () => {
+    const input = "1 + \\operatorname{sin}(1+\\operatorname{woof}(x)) + y";
+    const expected = "1 + sin(1+woof(x)) + y";
+    expect(parser.preprocess(input)).toBe(expected);
+  });
+});
+
+describe("backslash removal", () => {
+  test("backslashes are removed", () => {
+    const input = "1 + 3\\sin{\\pi x}";
+    const expected = "1 + 3 sin( pi x)";
+    expect(parser.preprocess(input)).toBe(expected);
+  });
+});

--- a/client/src/util/parsing/parsers.ts
+++ b/client/src/util/parsing/parsers.ts
@@ -1,0 +1,67 @@
+import * as math from "mathjs";
+import { subscriptRule, fractionRule, operatornameRule } from "./rules";
+import MathJsParser from "./MathJsParser";
+import {
+  ParserRuleType,
+  TextParserRegexRule,
+  ParserRule,
+  MathJsRule,
+} from "./interfaces";
+
+const cdotRule: TextParserRegexRule = {
+  type: ParserRuleType.TextRegexp,
+  regexp: /\\cdot/g,
+  replacement: " * ",
+};
+
+const fenceLRule: TextParserRegexRule = {
+  type: ParserRuleType.TextRegexp,
+  regexp: /\\left|\\right/g,
+  replacement: "",
+};
+
+const leftBraceRule: TextParserRegexRule = {
+  type: ParserRuleType.TextRegexp,
+  regexp: /\{/g,
+  replacement: "(",
+};
+const rightBraceRule: TextParserRegexRule = {
+  type: ParserRuleType.TextRegexp,
+  regexp: /\}/g,
+  replacement: ")",
+};
+
+const spaceRule: TextParserRegexRule = {
+  type: ParserRuleType.TextRegexp,
+  regexp: /[~\s]+/g,
+  replacement: " ",
+};
+
+const backslashRule: TextParserRegexRule = {
+  type: ParserRuleType.TextRegexp,
+  regexp: /\\/g,
+  replacement: " ",
+};
+
+const simplifyRule: MathJsRule = {
+  type: ParserRuleType.MathJs,
+  transform: (node) => math.simplify(node),
+};
+
+const parserRules: ParserRule[] = [
+  fractionRule,
+  subscriptRule,
+  operatornameRule,
+  cdotRule,
+  fenceLRule,
+  leftBraceRule,
+  rightBraceRule,
+  backslashRule,
+  spaceRule,
+  // MathJS rules
+  simplifyRule,
+];
+
+const latexParser = new MathJsParser(parserRules);
+
+export { latexParser };

--- a/client/src/util/parsing/rules/fractionRule.ts
+++ b/client/src/util/parsing/rules/fractionRule.ts
@@ -1,0 +1,17 @@
+import { CommandReplacer, replaceAllTexCommand } from "./util";
+import { ParserRuleType, TextParserRule } from "../interfaces";
+
+const fractionReplacer: CommandReplacer = (frac) => {
+  const [top, bottom] = frac.params;
+  return `(${top})/(${bottom})`;
+};
+
+/**
+ * Transform LaTeX fractions to division, \frac{a+b}{x+y} --> ((a+b)/(x+y))
+ */
+const fractionRule: TextParserRule = {
+  type: ParserRuleType.Text,
+  transform: (text) => replaceAllTexCommand(text, "frac", 2, fractionReplacer),
+};
+
+export default fractionRule;

--- a/client/src/util/parsing/rules/index.ts
+++ b/client/src/util/parsing/rules/index.ts
@@ -1,0 +1,6 @@
+import fractionRule from "./fractionRule";
+import subscriptRule from "./subscriptRule";
+import operatornameRule from "./operatornameRule";
+import { TextParserRegexRule } from "../interfaces";
+
+export { fractionRule, subscriptRule, operatornameRule };

--- a/client/src/util/parsing/rules/operatornameRule.ts
+++ b/client/src/util/parsing/rules/operatornameRule.ts
@@ -1,0 +1,18 @@
+import { TextParserRegexRule, ParserRuleType } from "../interfaces";
+
+/**
+ * Replace "\operatorname{thing}" with "thing"
+ */
+const operatornameRule: TextParserRegexRule = {
+  type: ParserRuleType.TextRegexp,
+  regexp: /\\operatorname\{(?<name>\w*)\}/g,
+  replacement: (match) => {
+    const name = match.groups?.name;
+    if (!name) {
+      throw new Error(`Unexpected undefined name.`);
+    }
+    return name;
+  },
+};
+
+export default operatornameRule;

--- a/client/src/util/parsing/rules/subscriptRule.ts
+++ b/client/src/util/parsing/rules/subscriptRule.ts
@@ -1,0 +1,34 @@
+import { findNestedExpression } from "./util";
+import { ParserRuleType, TextParserRule } from "../interfaces";
+
+const removeSubscriptBraces = (tex: string): string => {
+  const sub = "_{";
+  const subStart = tex.indexOf(sub);
+
+  if (subStart < 0) {
+    return tex;
+  }
+
+  const range = findNestedExpression(tex, "{", "}", subStart);
+  if (!range) {
+    throw new Error("Unexpected null range");
+  }
+  const replaced = [
+    tex.slice(0, range.start),
+    tex.slice(range.start + 1, range.end - 1),
+    tex.slice(range.end),
+  ].join("");
+
+  return removeSubscriptBraces(replaced);
+};
+
+/**
+ * Recursively removes braces from LaTeX subscripts
+ *   - example: x_{12foo_{bar123_{evenlower}}} --> x_12foo_bar123_evenlower
+ */
+const subscriptRule: TextParserRule = {
+  type: ParserRuleType.Text,
+  transform: removeSubscriptBraces,
+};
+
+export default subscriptRule;

--- a/client/src/util/parsing/rules/util.spec.ts
+++ b/client/src/util/parsing/rules/util.spec.ts
@@ -1,0 +1,103 @@
+import {
+  findNestedExpression,
+  findTexCommand,
+  replaceAllTexCommand,
+} from "./util";
+
+describe("findNestedExpression", () => {
+  test.each([
+    {
+      expected: { start: 2, end: 27 },
+      start: 0,
+    },
+    {
+      expected: { start: 28, end: 33 },
+      start: 27,
+    },
+  ])("finding balanced expressions", ({ expected, start }) => {
+    const opener = "<<";
+    const closer = ">>";
+    //            0         1         2         3
+    //            0123456789012345678901234567890123456789
+    const text = "a << hello << a >> << >> >> << >> b";
+    expect(findNestedExpression(text, opener, closer, start)).toStrictEqual(
+      expected
+    );
+  });
+
+  test("finding balanced expressions with unclosed, unopened delimiters", () => {
+    const opener = "<<";
+    const closer = ">>";
+    //            0         1         2         3
+    //            0123456789012345678901234567890123456789
+    const text = ">> << >> >> <<";
+    const expected = { start: 3, end: 8 };
+    expect(findNestedExpression(text, opener, closer, 0)).toStrictEqual(
+      expected
+    );
+  });
+
+  test("with no matches", () => {
+    const opener = "<<";
+    const closer = ">>";
+    //            0         1         2         3
+    //            0123456789012345678901234567890123456789
+    const text = ">> rats >> << cats";
+    expect(findNestedExpression(text, opener, closer, 0)).toStrictEqual(null);
+  });
+
+  test("with opener and closer of unequal lengths", () => {
+    const opener = "[[[";
+    const closer = ">";
+    //            0         1         2         3
+    //            0123456789012345678901234567890123456789
+    const text = "cats [[[ rats [[[]]] > [[[ >> bats";
+    const expected = { start: 5, end: 29 };
+    expect(findNestedExpression(text, opener, closer, 0)).toStrictEqual(
+      expected
+    );
+  });
+});
+
+describe("findTexCommand", () => {
+  it("finds the first instance of command", () => {
+    const text =
+      "The quick \\dog{barkbark} jumps over \\dog{woofwoof}{meow} the lazy fox.";
+    expect(findTexCommand(text, "dog", 1)).toStrictEqual({
+      start: 10,
+      end: 24,
+      name: "dog",
+      params: ["barkbark"],
+    });
+  });
+
+  it("finds the first instance of multi-param command", () => {
+    const text =
+      "The quick \\frac{barkbark}{woofwoof} jumps over \\frac{purrpurr}{meow} the lazy fox.";
+    expect(findTexCommand(text, "frac", 2)).toStrictEqual({
+      start: 10,
+      end: 35,
+      name: "frac",
+      params: ["barkbark", "woofwoof"],
+    });
+  });
+
+  it("Returns null if no matches", () => {
+    const text = "The quick dog and the lazy fox.";
+    expect(findTexCommand(text, "frac", 2)).toBe(null);
+  });
+
+  it.each([
+    {
+      text: "The quick \\dog{barkbark}{ jumps",
+      expected: /Too few/,
+    },
+    {
+      text: "The quick \\dog{barkbark} jumps",
+      expected: /Start character should/,
+    },
+  ])("Throws an error if command has too few params", ({ text, expected }) => {
+    const shouldThrow = () => findTexCommand(text, "dog", 2);
+    expect(shouldThrow).toThrow(expected);
+  });
+});

--- a/client/src/util/parsing/rules/util.ts
+++ b/client/src/util/parsing/rules/util.ts
@@ -1,0 +1,125 @@
+import { escapeRegExp } from "lodash";
+
+interface SubstringRange {
+  start: number;
+  end: number;
+}
+
+/**
+ * Find the next balanced instance of opener...closer in text starting at the
+ * specified index within text.
+ *
+ * @example
+ * ```
+ *            // 0         1         2         3         4
+ *            // 01234567890123456789012345678901234567890123456789
+ * const text = "hello [ b [ ] ] world [ [ ] [ ] ] bye"
+ * const startingFrom = 16
+ * const range = findNestedExpression(text, "[", "]", startingFrom)
+ * expect(range).toEqual({ start: 22, end: 33 })
+ * ```
+ */
+const findNestedExpression = (
+  text: string,
+  opener: string,
+  closer: string,
+  startingFrom = 0,
+  escapeChar = "\\"
+): SubstringRange | null => {
+  const start = text.indexOf(opener, startingFrom);
+  if (start < 0) return null;
+  let scanningIndex = start + opener.length;
+  let numOpen = 1;
+  const regex = new RegExp(
+    String.raw`(?<!${escapeRegExp(escapeChar)})(?<delimiter>${escapeRegExp(
+      opener
+    )}|${escapeRegExp(closer)})`
+  );
+  while (numOpen > 0) {
+    const nextDelimiter = text.substring(scanningIndex).match(regex);
+    if (nextDelimiter === null) return null;
+    if (nextDelimiter[0] === opener) {
+      numOpen += 1;
+    }
+    if (nextDelimiter[0] === closer) {
+      numOpen -= 1;
+    }
+    // The index will never be null since the regexp has matched and is not global.
+    if (nextDelimiter.index === undefined) {
+      throw new Error("Unexpected undefined index");
+    }
+    scanningIndex += nextDelimiter.index + nextDelimiter[0].length;
+  }
+  return { start, end: scanningIndex };
+};
+
+const captureParam = (text: string, start: number): null | [number, string] => {
+  const opener = "{";
+  const closer = "}";
+  if (text[start] !== opener) {
+    throw new Error(`Start character should be "${opener}"`);
+  }
+  const range = findNestedExpression(text, opener, closer, start);
+  if (range === null) return null;
+  const param = text.slice(range.start + 1, range.end - 1);
+  return [range.end, param];
+};
+
+interface TexCommand {
+  params: string[];
+  name: string;
+  start: number;
+  end: number;
+}
+
+const findTexCommand = (
+  tex: string,
+  name: string,
+  numArgs: number
+): TexCommand | null => {
+  const command = `\\${name}`;
+  const start = tex.indexOf(command);
+  if (start < 0) return null;
+  const params = [];
+  let currentIndex = start + command.length;
+  while (params.length < numArgs) {
+    const result = captureParam(tex, currentIndex);
+    if (result === null) {
+      throw new Error("Too few params.");
+    }
+    const [paramEnd, param] = result;
+    params.push(param);
+    currentIndex = paramEnd;
+  }
+  return {
+    start,
+    end: currentIndex,
+    name,
+    params,
+  };
+};
+
+type CommandReplacer = (command: TexCommand) => string;
+
+const replaceAllTexCommand = (
+  tex: string,
+  name: string,
+  numArgs: number,
+  replacer: CommandReplacer
+) => {
+  let withReplacements = tex;
+  let command: TexCommand | null;
+  // eslint-disable-next-line no-cond-assign
+  while ((command = findTexCommand(withReplacements, name, numArgs))) {
+    const replacement = replacer(command);
+    withReplacements = [
+      withReplacements.slice(0, command.start),
+      replacement,
+      withReplacements.slice(command.end),
+    ].join("");
+  }
+  return withReplacements;
+};
+
+export { findNestedExpression, findTexCommand, replaceAllTexCommand };
+export type { TexCommand, CommandReplacer };


### PR DESCRIPTION
Adds a parser for turning LaTeX into MathNodes consumable by MathScope.

Certainly does not parse all LaTeX—goal is to parse stuff generated by MathLive.