### PR TITLE
fix simplify parserrule

### DIFF
--- a/client/src/util/parsing/index.ts
+++ b/client/src/util/parsing/index.ts
@@ -1,0 +1,3 @@
+import { latexParser } from "./parsers";
+
+export { latexParser };

--- a/client/src/util/parsing/parsers.ts
+++ b/client/src/util/parsing/parsers.ts
@@ -45,7 +45,16 @@ const backslashRule: TextParserRegexRule = {
 
 const simplifyRule: MathJsRule = {
   type: ParserRuleType.MathJs,
-  transform: (node) => math.simplify(node),
+  transform: (node) => {
+    if (node.type === "FunctionAssignmentNode") {
+      // eslint-disable-next-line no-param-reassign
+      node.expr = math.simplify(node.expr);
+    } else if (node.type === "AssignmentNode") {
+      // eslint-disable-next-line no-param-reassign
+      node.value = math.simplify(node.value);
+    }
+    return node;
+  },
 };
 
 const parserRules: ParserRule[] = [

--- a/client/src/util/parsing/rules/index.ts
+++ b/client/src/util/parsing/rules/index.ts
@@ -1,6 +1,5 @@
 import fractionRule from "./fractionRule";
 import subscriptRule from "./subscriptRule";
 import operatornameRule from "./operatornameRule";
-import { TextParserRegexRule } from "../interfaces";
 
 export { fractionRule, subscriptRule, operatornameRule };


### PR DESCRIPTION
MathJS can't simplify assignment or function assignment nodes