### PR TITLE
fix mathitem overflows

### DIFF
--- a/client/src/features/sceneControls/mathItems/templates/ItemTemplate.module.css
+++ b/client/src/features/sceneControls/mathItems/templates/ItemTemplate.module.css
@@ -1,6 +1,7 @@
 .container {
+  background-color: var(--color-secondary-1);
   display: grid;
-  grid-template-columns: 50px auto min-content;
+  grid-template-columns: 50px minmax(0, 1fr) min-content;
   grid-template-rows: auto auto;
   /*
   avoid border-doubling. See https://stackoverflow.com/q/12692089/2747370
@@ -12,10 +13,15 @@
 
   Note: In some browsers, at some higher zoom levels, double borders show up sometimes.
   */
-  outline: 1px solid gray;
+  outline: 1px solid var(--color-secondary-7);
   margin-top: 1px;
   margin-left: 1px;
   margin-right: 1px;
+}
+.container:focus-within {
+  grid-template-columns: 50px 1fr min-content;
+  width: fit-content;
+  min-width: calc(100% - 2px);
 }
 
 .grid-left-gutter {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -40,6 +40,17 @@ html {
   --color-primary-9: var(--blue-9);
   --color-primary-10: var(--blue-10);
 
+  --color-secondary-1: var(--gray-1);
+  --color-secondary-2: var(--gray-2);
+  --color-secondary-3: var(--gray-3);
+  --color-secondary-4: var(--gray-4);
+  --color-secondary-5: var(--gray-5);
+  --color-secondary-6: var(--gray-6);
+  --color-secondary-7: var(--gray-7);
+  --color-secondary-8: var(--gray-8);
+  --color-secondary-9: var(--gray-9);
+  --color-secondary-10: var(--gray-10);
+
   --color-primary: var(--color-primary-6);
   --color-secondary: var(--gray-6);
   --color-error: red;


### PR DESCRIPTION
Goal:
  -only overflow when focused (really: focus-within)
  -width of sidebar when not focuse

<img width="673" alt="Screen Shot 2022-06-03 at 10 14 20 PM" src="https://user-images.githubusercontent.com/9010790/171974398-5da42432-49bb-4f99-b662-896bea075f6a.png">
d