### PR TITLE
add autosize text widget

### DIFF
--- a/client/src/features/sceneControls/mathItems/FieldWidget/AutosizeText.tsx
+++ b/client/src/features/sceneControls/mathItems/FieldWidget/AutosizeText.tsx
@@ -1,0 +1,44 @@
+import React, { useCallback, useContext } from "react";
+import classNames from "classnames";
+import { TextareaAutoWidthHeight } from "util/components";
+import { IWidgetProps, WidgetChangeEvent } from "./types";
+import { MathContext } from "../mathScope";
+import styles from "./widget.module.css";
+
+const EXTRA_WIDTH = 20;
+
+const AutosizeText: React.FC<IWidgetProps> = (props: IWidgetProps) => {
+  const mathScope = useContext(MathContext);
+  const { onChange, name, title, error, itemId, style = {}, ...others } = props;
+  const { width, height, ...styleWithoutSize } = style;
+  const onInputChange: React.ChangeEventHandler<HTMLTextAreaElement> =
+    useCallback(
+      (e) => {
+        const event: WidgetChangeEvent = {
+          name,
+          value: e.target.value,
+          mathScope,
+        };
+        onChange(event);
+      },
+      [onChange, name, mathScope]
+    );
+  return (
+    <TextareaAutoWidthHeight
+      extraWidth={EXTRA_WIDTH}
+      title={title}
+      className={classNames(
+        {
+          [styles["has-error"]]: error,
+        },
+        styles["field-widget"]
+      )}
+      name={name}
+      onChange={onInputChange}
+      style={styleWithoutSize}
+      {...others}
+    />
+  );
+};
+
+export default AutosizeText;

--- a/client/src/features/sceneControls/mathItems/FieldWidget/MathAssignment.tsx
+++ b/client/src/features/sceneControls/mathItems/FieldWidget/MathAssignment.tsx
@@ -60,7 +60,8 @@ const MathAssignment: React.FC<IWidgetProps> = (props: IWidgetProps) => {
       <SmallMathField
         title={lhsTitle}
         className={classNames(
-          style["math-input"],
+          style["field-widget"],
+          style["math-widget"],
           { [style["has-error"]]: lhsError },
           className
         )}
@@ -79,7 +80,8 @@ const MathAssignment: React.FC<IWidgetProps> = (props: IWidgetProps) => {
       <SmallMathField
         title={rhsTitle}
         className={classNames(
-          style["math-input"],
+          style["field-widget"],
+          style["math-widget"],
           { [style["has-error"]]: rhsError },
           className,
           "flex-1"

--- a/client/src/features/sceneControls/mathItems/FieldWidget/MathBoolean.tsx
+++ b/client/src/features/sceneControls/mathItems/FieldWidget/MathBoolean.tsx
@@ -72,7 +72,7 @@ const MathBoolean: React.FC<IWidgetProps> = (props: IWidgetProps) => {
           title={`Math Expression for: ${title}`}
           style={style}
           className={classNames(
-            styles["math-input"],
+            styles["math-widget"],
             { [styles["has-error"]]: error },
             "flex-1"
           )}

--- a/client/src/features/sceneControls/mathItems/FieldWidget/MathValue.tsx
+++ b/client/src/features/sceneControls/mathItems/FieldWidget/MathValue.tsx
@@ -27,7 +27,8 @@ const MathValue: React.FC<IWidgetProps> = (props: IWidgetProps) => {
       title={title}
       style={style}
       className={classNames(
-        styles["math-input"],
+        styles["field-widget"],
+        styles["math-widget"],
         { [styles["has-error"]]: error },
         className
       )}

--- a/client/src/features/sceneControls/mathItems/FieldWidget/index.tsx
+++ b/client/src/features/sceneControls/mathItems/FieldWidget/index.tsx
@@ -16,6 +16,7 @@ import styles from "./widget.module.css";
 import MathValue from "./MathValue";
 import MathBoolean from "./MathBoolean";
 import MathAssignment from "./MathAssignment";
+import AutosizeText from "./AutosizeText";
 
 const PlaceholderInput: React.FC<IWidgetProps> = (props: IWidgetProps) => {
   const mathScope = useContext(MathContext);
@@ -45,8 +46,6 @@ const PlaceholderInput: React.FC<IWidgetProps> = (props: IWidgetProps) => {
 };
 
 const ColorPicker = PlaceholderInput;
-
-const AutosizeText = PlaceholderInput;
 
 const TextInput = PlaceholderInput;
 

--- a/client/src/features/sceneControls/mathItems/FieldWidget/widget.module.css
+++ b/client/src/features/sceneControls/mathItems/FieldWidget/widget.module.css
@@ -11,15 +11,29 @@
   font-size: 1.25em;
 }
 
-.math-input {
+.field-widget {
   font-size: 1.25em;
+  border-top: none;
+  border-left: none;
+  border-right: none;
   border-bottom: 1pt solid var(--color-secondary);
-  margin-bottom: -1pt;
+  
 }
 
-.math-input:focus {
+textarea.field-widget {
+  resize: none;
+}
+
+
+.field-widget:focus {
   outline: none;
   border-bottom: 2pt solid var(--color-primary);
+}
+
+.math-widget {
+  margin-bottom: -1pt;
+}
+.math-widget:focus {
   margin-bottom: -2pt;
 }
 

--- a/client/src/setupTests.ts
+++ b/client/src/setupTests.ts
@@ -8,12 +8,14 @@ import "@testing-library/jest-dom";
  * Jest does not support enough ShadowDOM for MathLive to function properly, so
  * this mocks it with a textarea.
  */
-import "./util/components/MathLive/MockMathField";
+jest.mock("./util/components/MathLive/MathField");
 
 /**
  * And since we're not using a ShadowDOM, we can't change the ShadowDOM styles.
  */
 jest.mock("./util/hooks/useShadowStylesheet");
+
+jest.mock("./util/components/TextareaAutoWidthHeight/TextMeasurer");
 
 /**
  * Suppress deprecration warnings from React due to antd

--- a/client/src/util/components/MathLive/__mocks__/MathField.tsx
+++ b/client/src/util/components/MathLive/__mocks__/MathField.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable global-require */
-import React from "react";
-import { MathfieldProps } from ".";
+import React, { forwardRef } from "react";
+import { MathfieldProps } from "..";
 
 const MockMathFieldForwardRef = (
   props: MathfieldProps,
@@ -21,9 +21,4 @@ const MockMathFieldForwardRef = (
   );
 };
 
-jest.mock(".", () => {
-  const { forwardRef } = require("react");
-  return {
-    MathField: forwardRef(MockMathFieldForwardRef),
-  };
-});
+export default forwardRef(MockMathFieldForwardRef);

--- a/client/src/util/components/TextareaAutoWidthHeight/TextMeasurer.ts
+++ b/client/src/util/components/TextareaAutoWidthHeight/TextMeasurer.ts
@@ -1,4 +1,8 @@
-export default class TextMeasurer {
+export interface ITextMeasurer {
+  measure: (texts: string[], element: HTMLElement) => TextMetrics[];
+}
+
+export default class TextMeasurer implements ITextMeasurer {
   canvas: HTMLCanvasElement;
 
   constructor() {
@@ -11,7 +15,6 @@ export default class TextMeasurer {
     if (context === null) {
       throw new Error("context is null");
     }
-    context.font = style.font;
     return texts.map((text) => context.measureText(text));
   }
 }

--- a/client/src/util/components/TextareaAutoWidthHeight/TextareaAutoWidthHeight.tsx
+++ b/client/src/util/components/TextareaAutoWidthHeight/TextareaAutoWidthHeight.tsx
@@ -20,6 +20,7 @@ const TextareaAutoWidthHeight: React.FC<Props> = (props) => {
 
   const lines = (props.value ?? "").split("\n");
   const textarea = useRef<HTMLTextAreaElement>(null);
+
   const widths =
     textarea.current === null
       ? [0]

--- a/client/src/util/components/TextareaAutoWidthHeight/__mocks__/TextMeasurer.ts
+++ b/client/src/util/components/TextareaAutoWidthHeight/__mocks__/TextMeasurer.ts
@@ -1,0 +1,16 @@
+/* eslint-disable class-methods-use-this */
+import { ITextMeasurer } from "../TextMeasurer";
+
+const fakeTextMetrics = (): TextMetrics => ({
+  actualBoundingBoxAscent: 1,
+  actualBoundingBoxDescent: 1,
+  actualBoundingBoxLeft: 1,
+  actualBoundingBoxRight: 1,
+  fontBoundingBoxAscent: 1,
+  fontBoundingBoxDescent: 1,
+  width: 1,
+});
+
+export default class TextMeasurer implements ITextMeasurer {
+  measure = () => [fakeTextMetrics()];
+}


### PR DESCRIPTION
The component has a small dependency on canvas measurement APIs, so we need to mock TextMeasurer in jest. So this also adds that mock and reorganizes a few other global mocks to use __mocks__ directory