### PR TITLE
Customizable param names

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -12,6 +12,16 @@ module.exports = {
   ],
   plugins: ["react", "@typescript-eslint"],
   rules: {
+    "@typescript-eslint/naming-convention": [
+      "warn",
+      {
+        "selector": "default",
+        "modifiers": ["unused"],
+        "format": ["camelCase"],
+        "leadingUnderscore": "allow" // do not require... it's annoying when required for object destructuring.
+      }
+    ],
+    "@typescript-eslint/no-unused-vars": ["warn", { varsIgnorePattern: "^_", destructuredArrayIgnorePattern: "^_"  }],
     "max-classes-per-file": "off",
     "react/function-component-definition": [
       "error",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -18,6 +18,7 @@
         "lodash": "4.17.21",
         "mathjs": "10.6.1",
         "mathlive": "0.74.0",
+        "ordinal": "^1.0.3",
         "ramda": "0.28.0",
         "react": "18.1.0",
         "react-bootstrap": "2.4.0",
@@ -25957,6 +25958,11 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/ordinal": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ordinal/-/ordinal-1.0.3.tgz",
+      "integrity": "sha512-cMddMgb2QElm8G7vdaa02jhUNbTSrhsgAGUz1OokD83uJTwSUn+nKoNoKVVaRa08yF6sgfO7Maou1+bgLd9rdQ=="
     },
     "node_modules/os-browserify": {
       "version": "0.3.0",
@@ -54272,6 +54278,11 @@
           }
         }
       }
+    },
+    "ordinal": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ordinal/-/ordinal-1.0.3.tgz",
+      "integrity": "sha512-cMddMgb2QElm8G7vdaa02jhUNbTSrhsgAGUz1OokD83uJTwSUn+nKoNoKVVaRa08yF6sgfO7Maou1+bgLd9rdQ=="
     },
     "os-browserify": {
       "version": "0.3.0",

--- a/client/package.json
+++ b/client/package.json
@@ -35,6 +35,7 @@
     "lodash": "4.17.21",
     "mathjs": "10.6.1",
     "mathlive": "0.74.0",
+    "ordinal": "^1.0.3",
     "ramda": "0.28.0",
     "react": "18.1.0",
     "react-bootstrap": "2.4.0",

--- a/client/src/features/sceneControls/mathItems/FieldWidget/MathAssignment.tsx
+++ b/client/src/features/sceneControls/mathItems/FieldWidget/MathAssignment.tsx
@@ -4,20 +4,11 @@ import classNames from "classnames";
 import SmallMathField, { makeReadOnly } from "util/components/SmallMathField";
 import { OnMathFieldChange } from "util/components/MathLive";
 import { ParseAssignmentLHSError } from "util/parsing/rules";
+import { splitAtFirstEquality } from "util/parsing";
 import type { IWidgetProps, WidgetChangeEvent } from "./types";
 import style from "./widget.module.css";
 import { MathContext } from "../mathScope";
-
-const splitAtFirstEquality = (text: string) => {
-  const pieces = text.split("=");
-  if (pieces.length < 2) {
-    // They should have eactly one, but if they have more, that's an issue for the parser
-    throw new Error(`Fatal error: Assignments should have an equality sign.`);
-  }
-  const [lhs, ...others] = pieces;
-  const rhs = others.join("=");
-  return [lhs, rhs];
-};
+import ReadonlyMathField from "./ReadonlyMathField";
 
 const MathAssignment: React.FC<IWidgetProps> = (props: IWidgetProps) => {
   const { onChange, name, value, error, title, className, ...others } = props;
@@ -68,6 +59,7 @@ const MathAssignment: React.FC<IWidgetProps> = (props: IWidgetProps) => {
         onChange={onChangeLHS}
         defaultValue={lhs}
       />
+      <ReadonlyMathField value="=" />
       <SmallMathField
         className={classNames(
           style["static-math"],

--- a/client/src/features/sceneControls/mathItems/FieldWidget/MathValue.tsx
+++ b/client/src/features/sceneControls/mathItems/FieldWidget/MathValue.tsx
@@ -33,9 +33,8 @@ const MathValue: React.FC<IWidgetProps> = (props: IWidgetProps) => {
         className
       )}
       onChange={handleChange}
-    >
-      {value}
-    </SmallMathField>
+      defaultValue={value}
+    />
   );
 };
 

--- a/client/src/features/sceneControls/mathItems/FieldWidget/ReadonlyMathField.tsx
+++ b/client/src/features/sceneControls/mathItems/FieldWidget/ReadonlyMathField.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import classNames from "classnames";
+import SmallMathField, { makeReadOnly } from "util/components/SmallMathField";
+import styles from "./widget.module.css";
+
+interface Props {
+  value: string;
+}
+
+const ReadonlyMathField: React.FC<Props> = ({ value }) => (
+  <SmallMathField
+    className={classNames(styles["static-math"], "align-self-center", "px-1")}
+    makeOptions={makeReadOnly}
+    defaultValue={value}
+  />
+);
+
+export default ReadonlyMathField;

--- a/client/src/features/sceneControls/mathItems/FieldWidget/index.tsx
+++ b/client/src/features/sceneControls/mathItems/FieldWidget/index.tsx
@@ -68,7 +68,7 @@ export const useOnWidgetChange = <T extends MIT>(item: MathItem<T>) => {
         const config = mathItemConfigs[item.type];
         // @ts-expect-error ... string can't index config.properties
         const propConfig: PropertyConfig<string> = config.properties[e.name];
-        assertNotNil(propConfig);
+        assertNotNil(propConfig, "Property config should not be nil.");
         e.mathScope.setExpressions([
           {
             id: mathScopeId(item.id, e.name),

--- a/client/src/features/sceneControls/mathItems/__tests__/colorpicker.spec.tsx
+++ b/client/src/features/sceneControls/mathItems/__tests__/colorpicker.spec.tsx
@@ -1,13 +1,6 @@
 import { MathItemType as MIT } from "configs";
 import { Point, PointProperties } from "configs/items/point";
-import {
-  IntegrationTest,
-  user,
-  screen,
-  makeItem,
-  nodeId,
-  within,
-} from "test_util";
+import { IntegrationTest, user, screen, makeItem, nodeId } from "test_util";
 
 /**
  * Press and hold pointer on element for `ms` seconds.

--- a/client/src/features/sceneControls/mathItems/__tests__/parametricSurface.spec.tsx
+++ b/client/src/features/sceneControls/mathItems/__tests__/parametricSurface.spec.tsx
@@ -1,0 +1,135 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { MathItem, MathItemType as MIT } from "configs";
+import {
+  IntegrationTest,
+  user,
+  screen,
+  makeItem,
+  nodeId,
+  typeText,
+  within,
+  patchConsoleError,
+  prettyDOM,
+  assertInstanceOf,
+} from "test_util";
+import { UnmetDependencyError } from "util/MathScope";
+
+const getParamNameInputs = (): HTMLTextAreaElement[] => {
+  const zeroth = screen.getByTitle("Name for 1st parameter");
+  const first = screen.getByTitle("Name for 2nd parameter");
+  assertInstanceOf(zeroth, HTMLTextAreaElement);
+  assertInstanceOf(first, HTMLTextAreaElement);
+  return [zeroth, first];
+};
+
+test.each([
+  {
+    expression: {
+      initial: "_f(x,y)=[1+abc, 0, 0]",
+      expectedFinal: "_f(abc,y)=[1+abc, 0, 0]",
+    },
+    evaluations: [
+      { parmaValues: [1, 0], expectedOutput: [2, 0, 0] },
+      { parmaValues: [0, 1], expectedOutput: [1, 0, 0] },
+    ],
+    param: { name: "abc", index: 0 },
+  },
+  {
+    expression: {
+      initial: "_f(x,y)=[1+abc, 0, 0]",
+      expectedFinal: "_f(x,abc)=[1+abc, 0, 0]",
+    },
+    evaluations: [
+      { parmaValues: [1, 0], expectedOutput: [1, 0, 0] },
+      { parmaValues: [0, 1], expectedOutput: [2, 0, 0] },
+    ],
+    param: { name: "abc", index: 1 },
+  },
+])(
+  "Updating parameter names to valid values updates expression appropriately",
+  async ({ expression, param, evaluations }) => {
+    const item = makeItem(MIT.ParametricSurface, { expr: expression.initial });
+    const id = nodeId(item);
+    const helper = new IntegrationTest();
+    helper.patchMathItems([item]);
+    const { mathScope, store } = helper.render();
+    // initiall there is an error since the expr RHS contains "abc" which is not a param name or defined variable
+    expect(mathScope.evalErrors.has(id("expr"))).toBe(true);
+    const inputs = getParamNameInputs();
+    await user.type(inputs[param.index], param.name);
+
+    // assert store is updated correctly
+    const editedItem = store.getState().mathItems[
+      item.id
+    ] as MathItem<MIT.ParametricSurface>;
+    expect(editedItem.properties.expr).toBe(expression.expectedFinal);
+
+    // assert MathScope updated correctly
+    const f = mathScope.results.get(id("expr"));
+    assertInstanceOf(f, Function);
+    const actuals = evaluations.map((e) => f(...e.parmaValues));
+    const expecteds = evaluations.map((e) => e.expectedOutput);
+    expect(actuals).toHaveLength(2);
+    expect(actuals).toStrictEqual(expecteds);
+  }
+);
+
+test.each([
+  {
+    expression: {
+      initial: "_f(x,y)=[x, y, 0]",
+      // When typing "a+b" the last valid varname will be "a"
+      expectedFinal: "_f(a,y)=[x, y, 0]",
+    },
+    expectedError: new UnmetDependencyError(["x"]),
+    param: { name: "a+b", index: 0 },
+  },
+  {
+    expression: {
+      initial: "_f(x,y)=[x, y, 0]",
+      expectedFinal: "_f(x,a)=[x, y, 0]",
+    },
+    expectedError: new UnmetDependencyError(["y"]),
+    param: { name: "a+b", index: 1 },
+  },
+])(
+  "invalid var names do not update the expression",
+  async ({ expression, param, expectedError }) => {
+    const item = makeItem(MIT.ParametricSurface, { expr: expression.initial });
+    const id = nodeId(item);
+    const helper = new IntegrationTest();
+    helper.patchMathItems([item]);
+    const { mathScope, store } = helper.render();
+
+    const inputs = getParamNameInputs();
+    await user.type(inputs[param.index], param.name);
+
+    const itemAfterEdit = store.getState().mathItems[
+      item.id
+    ] as MathItem<MIT.ParametricSurface>;
+    expect(itemAfterEdit.properties.expr).toBe(expression.expectedFinal);
+
+    const fError = mathScope.evalErrors.get(id("expr"));
+    expect(fError).toStrictEqual(expectedError);
+  }
+);
+
+test.each([{ paramIndex: 0 }, { paramIndex: 1 }])(
+  "when param name is invalid, error class is added, then removed when valid again",
+  async ({ paramIndex }) => {
+    const item = makeItem(MIT.ParametricSurface);
+    const helper = new IntegrationTest();
+    helper.patchMathItems([item]);
+    helper.render();
+
+    const paramInput = getParamNameInputs()[paramIndex];
+    await user.type(paramInput, "a+b");
+    expect(paramInput).toHaveClass("has-error");
+
+    // selectRange approach https://github.com/testing-library/user-event/issues/232#issuecomment-640791105 was not working?
+    await user.clear(paramInput);
+    await user.type(paramInput, "ab");
+    expect(paramInput).not.toHaveClass("has-error");
+  }
+);

--- a/client/src/features/sceneControls/mathItems/forms/ItemForms.module.css
+++ b/client/src/features/sceneControls/mathItems/forms/ItemForms.module.css
@@ -1,0 +1,6 @@
+.parameters {
+  display: grid;
+  padding: 6px;
+  grid-template-columns: min-content min-content;
+  justify-content: end;
+}

--- a/client/src/features/sceneControls/mathItems/forms/ParametricCurve/index.tsx
+++ b/client/src/features/sceneControls/mathItems/forms/ParametricCurve/index.tsx
@@ -1,10 +1,17 @@
 import React from "react";
-import { MathItemType as MIT, mathItemConfigs as configs } from "configs";
-import ItemTemplate from "../../templates/ItemTemplate";
+import { MathItemType as MIT } from "configs";
 import { MathItemForm } from "../interfaces";
+import RangedMathItemForm from "../RangedMathItemForm";
 
-const ParametricCurve: MathItemForm<MIT.ParametricCurve> = ({ item }) => (
-  <ItemTemplate item={item} config={configs[MIT.ParametricCurve]} />
+const rangePropNames = ["range"] as const;
+const errorNames = ["expr", ...rangePropNames] as const;
+
+const ParametricSurface: MathItemForm<MIT.ParametricCurve> = ({ item }) => (
+  <RangedMathItemForm
+    item={item}
+    errorNames={errorNames}
+    rangePropNames={rangePropNames}
+  />
 );
 
-export default ParametricCurve;
+export default ParametricSurface;

--- a/client/src/features/sceneControls/mathItems/forms/ParametricSurface/index.tsx
+++ b/client/src/features/sceneControls/mathItems/forms/ParametricSurface/index.tsx
@@ -1,10 +1,17 @@
 import React from "react";
-import { MathItemType as MIT, mathItemConfigs as configs } from "configs";
-import ItemTemplate from "../../templates/ItemTemplate";
+import { MathItemType as MIT } from "configs";
 import { MathItemForm } from "../interfaces";
+import RangedMathItemForm from "../RangedMathItemForm";
+
+const rangePropNames = ["rangeU", "rangeV"] as const;
+const errorNames = ["expr", ...rangePropNames] as const;
 
 const ParametricSurface: MathItemForm<MIT.ParametricSurface> = ({ item }) => (
-  <ItemTemplate item={item} config={configs[MIT.ParametricSurface]} />
+  <RangedMathItemForm
+    item={item}
+    errorNames={errorNames}
+    rangePropNames={rangePropNames}
+  />
 );
 
 export default ParametricSurface;

--- a/client/src/features/sceneControls/mathItems/forms/RangedMathItemForm.tsx
+++ b/client/src/features/sceneControls/mathItems/forms/RangedMathItemForm.tsx
@@ -1,0 +1,93 @@
+import React, { useMemo } from "react";
+import ordinal from "ordinal";
+import {
+  MathItemType as MIT,
+  mathItemConfigs as configs,
+  MathItem,
+} from "configs";
+import ItemTemplate from "../templates/ItemTemplate";
+import { MathValue, useOnWidgetChange } from "../FieldWidget";
+import { useMathErrors } from "../mathScope";
+import { OnWidgetChange } from "../FieldWidget/types";
+import {
+  ParameterContainer,
+  ParameterForm,
+  useExpressionAndParameters,
+} from "./expressionHelpers";
+
+interface GenericRangedMathItemFormProps<T extends MIT> {
+  item: MathItem<T>;
+  errorNames: readonly (keyof MathItem<T>["properties"] & string)[];
+  rangePropNames: readonly (keyof MathItem<T>["properties"] & string)[];
+}
+
+type RangedMathItemFormProps =
+  | GenericRangedMathItemFormProps<MIT.ParametricCurve>
+  | GenericRangedMathItemFormProps<MIT.ParametricSurface>
+  | GenericRangedMathItemFormProps<MIT.ExplicitSurface>
+  | GenericRangedMathItemFormProps<MIT.ExplicitSurfacePolar>;
+
+const RangedMathItemForm = ({
+  item,
+  rangePropNames,
+  errorNames,
+}: RangedMathItemFormProps) => {
+  const config = configs[item.type];
+  const onWidgetChange = useOnWidgetChange(item);
+  const {
+    onParamNameChange,
+    onRhsChange,
+    exprRef,
+    paramNameErrors: paramErrors,
+  } = useExpressionAndParameters(item.properties.expr, onWidgetChange);
+  const errors = useMathErrors(item.id, errorNames);
+
+  const onParamChanges = useMemo(
+    () =>
+      rangePropNames.map((_x, i) => {
+        const cb: OnWidgetChange = (e) => onParamNameChange(e.value, i);
+        return cb;
+      }),
+    [onParamNameChange, rangePropNames]
+  );
+  return (
+    <ItemTemplate item={item} config={config}>
+      <MathValue
+        title={config.properties.expr.label}
+        name="expr"
+        error={errors.expr}
+        value={exprRef.current.rhs}
+        onChange={onRhsChange}
+      />
+      <ParameterContainer>
+        {rangePropNames.map((rangeProp, i) => (
+          <ParameterForm
+            key={rangeProp}
+            nameInput={
+              <MathValue
+                title={`Name for ${ordinal(i + 1)} parameter`}
+                name={`${ordinal(i + 1)}-parameter-name`}
+                error={paramErrors[i]}
+                value={exprRef.current.params[i]}
+                onChange={onParamChanges[i]}
+              />
+            }
+            rangeInput={
+              <MathValue
+                // @ts-expect-error need to figure out this error
+                title={config.properties[rangeProp].label}
+                name={rangeProp}
+                error={errors[rangeProp]}
+                // @ts-expect-error need to figure out this error
+                value={item.properties[rangeProp]}
+                onChange={onWidgetChange}
+              />
+            }
+          />
+        ))}
+      </ParameterContainer>
+    </ItemTemplate>
+  );
+};
+
+export default RangedMathItemForm;

--- a/client/src/features/sceneControls/mathItems/forms/expressionHelpers.tsx
+++ b/client/src/features/sceneControls/mathItems/forms/expressionHelpers.tsx
@@ -1,0 +1,147 @@
+import React, {
+  MutableRefObject,
+  useRef,
+  useCallback,
+  useContext,
+  useState,
+} from "react";
+import { assertInstanceOf } from "util/predicates";
+import { getParameters, latexParser, splitAtFirstEquality } from "util/parsing";
+import ReadonlyMathField from "../FieldWidget/ReadonlyMathField";
+import { OnWidgetChange } from "../FieldWidget/types";
+import { MathContext } from "../mathScope";
+import styles from "./ItemForms.module.css";
+
+interface ParameterContainerProps {
+  children: React.ReactNode;
+}
+const ParameterContainer: React.FC<ParameterContainerProps> = ({
+  children,
+}) => {
+  return <div className={styles.parameters}>{children}</div>;
+};
+
+interface ParameterFormProps {
+  nameInput: React.ReactNode;
+  rangeInput: React.ReactNode;
+}
+
+const ParameterForm: React.FC<ParameterFormProps> = (props) => {
+  return (
+    <>
+      <div className="d-flex justify-content-end">
+        {props.nameInput}
+        <ReadonlyMathField value="\in" />
+      </div>
+      <div className="d-flex">{props.rangeInput}</div>
+    </>
+  );
+};
+
+interface ExprData {
+  params: string[];
+  rhs: string;
+}
+
+type OnParamNameChange = (value: string, index: number) => void;
+
+const validateSymbolName = (value: string): void => {
+  if (value.startsWith("_")) {
+    throw new Error("Parameter names should not begin with underscores.");
+  }
+  const mjsNode = latexParser.mjsParse(value);
+  if (mjsNode.type === "SymbolNode") return;
+  throw new Error(`String "${value}" is not a valid parameter name`);
+};
+
+/**
+ * Several math items include an "expr" property whose values should be
+ * parseable as functions, e.g., `"f(x, y) = x^2 + y^2"`.
+ *
+ * We'd like a UI that:
+ *  - displays only the right-hand-side
+ *  - allows editing the parameter names (e.g., change x, y to x1, x2).
+ *
+ * This hook provides callbacks and data to assist with this.
+ *
+ */
+const useExpressionAndParameters = (
+  initialExpr: string,
+  onWidgetChange: OnWidgetChange
+): {
+  /**
+   * A ref which holds the RHS and parameters separately.
+   */
+  exprRef: MutableRefObject<ExprData>;
+  /**
+   * An OnWidgetChange handler that updates `exprRef` and re-combines the params
+   * and RHS to a function-like expression, updating the store and MathScope
+   * with the function-like expression value.
+   */
+  onRhsChange: OnWidgetChange;
+  /**
+   * An event handler (value, i) => void that updates the i'th parameter name
+   * to the provided value. Updates `exprRef`, `paramNameErrors`, the store, and MathScope.
+   */
+  onParamNameChange: OnParamNameChange;
+  /**
+   * Stores errors related to parameter names. E.g., `"a + b"` is not a valid
+   * parameter name, and attempting to provide it to `onParamNameChange` will
+   * result an an error stored in this object. Errors are indexed by parameter
+   * numbers.
+   */
+  paramNameErrors: Record<number, Error>;
+} => {
+  const mathScope = useContext(MathContext);
+  const [paramErrors, setParamErrors] = useState<Record<number, Error>>({});
+  const exprRef: MutableRefObject<ExprData> = useRef({
+    rhs: splitAtFirstEquality(initialExpr)[1],
+    params: getParameters(initialExpr),
+  });
+
+  const onExprChange = useCallback(() => {
+    const { current } = exprRef;
+    const value = `_f(${current.params.join(",")})=${current.rhs}`;
+    const event = {
+      name: "expr",
+      value,
+      mathScope,
+    };
+    onWidgetChange(event);
+  }, [onWidgetChange, mathScope]);
+
+  const onParamNameChange: OnParamNameChange = useCallback(
+    (value, index) => {
+      try {
+        validateSymbolName(value);
+        exprRef.current.params[index] = value;
+        onExprChange();
+        setParamErrors((state) => {
+          const { [index]: _thisError, ...others } = state;
+          return others;
+        });
+      } catch (err) {
+        setParamErrors((state) => {
+          assertInstanceOf(err, Error);
+          return { ...state, [index]: err };
+        });
+      }
+    },
+    [onExprChange]
+  );
+  const onRhsChange: OnWidgetChange = useCallback(
+    (e) => {
+      exprRef.current.rhs = e.value;
+      onExprChange();
+    },
+    [onExprChange]
+  );
+  return {
+    onRhsChange,
+    onParamNameChange,
+    exprRef,
+    paramNameErrors: paramErrors,
+  };
+};
+
+export { ParameterContainer, ParameterForm, useExpressionAndParameters };

--- a/client/src/features/sceneControls/mathItems/util.ts
+++ b/client/src/features/sceneControls/mathItems/util.ts
@@ -1,6 +1,5 @@
 import { MathItem, MathItemType, mathItemConfigs } from "configs";
 import idGenerator from "util/idGenerator";
-import React from "react";
 
 const makeItem = <T extends MathItemType>(
   type: T,

--- a/client/src/test_util/test_util.ts
+++ b/client/src/test_util/test_util.ts
@@ -3,6 +3,7 @@ import user from "@testing-library/user-event";
 import { mathScopeId } from "features/sceneControls/mathItems/mathScope";
 import { testId } from "features/sceneControls/mathItems/util";
 import { MathItem } from "configs";
+import { assertInstanceOf } from "util/predicates";
 
 const permutations = <T>(tokens: T[], subperms: T[][] = [[]]): T[][] =>
   R.isEmpty(tokens)
@@ -27,20 +28,6 @@ const nodeId =
 const typeText = (element: Element, text: string): Promise<void> => {
   const escaped = text.replaceAll("[", "[[");
   return user.type(element, escaped);
-};
-
-/**
- * Type assertion that asserts value is not null or undefined.
- *
- * Unlike jest assertions, this will refine the type.
- * See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/41179
- */
-const assertInstanceOf: <C extends { new (...args: any): any }>(
-  value: unknown,
-  Class: C
-) => asserts value is InstanceType<C> = (value, Class) => {
-  if (value instanceof Class) return;
-  throw new Error(`Expected value to be instanceof ${Class}`);
 };
 
 export { permutations, nodeId, typeText, assertInstanceOf, testId };

--- a/client/src/util/parsing/MathJsParser.ts
+++ b/client/src/util/parsing/MathJsParser.ts
@@ -53,15 +53,18 @@ class MathJsParser implements IMathJsParser {
     return expressionFinal;
   };
 
-  parse: IMathJsParser["parse"] = (expression, id, options): MathNode => {
+  mjsParse: IMathJsParser["mjsParse"] = (expression) => {
     const preprocessed = this.preprocess(expression);
     const mjsRules = this.rules.filter(isMathJsRule);
-    const mjsFinal = mjsRules.reduce(
+    return mjsRules.reduce(
       (mjsNode, rule) => rule.transform(mjsNode),
       mjs.parse(preprocessed)
     );
+  };
 
-    const node = msAdapter.convertNode(mjsFinal, options) as MathNode;
+  parse: IMathJsParser["parse"] = (expression, id, options): MathNode => {
+    const mjsNode = this.mjsParse(expression);
+    const node = msAdapter.convertNode(mjsNode, options) as MathNode;
     node.id = id;
     return node;
   };

--- a/client/src/util/parsing/helpers.ts
+++ b/client/src/util/parsing/helpers.ts
@@ -1,0 +1,32 @@
+import { parse as mjsParse } from "mathjs";
+import { latexParser } from "./parsers";
+/**
+ * This file includes helpers for parsing mathematical expressions, not
+ * necessarily related to the MathScope adapter.
+ */
+
+const splitAtFirstEquality = (text: string): [string, string] => {
+  const pieces = text.split("=");
+  if (pieces.length < 2) {
+    // They should have eactly one, but if they have more, that's an issue for the parser
+    throw new Error(`Fatal error: Assignments should have an equality sign.`);
+  }
+  const [lhs, ...others] = pieces;
+  const rhs = others.join("=");
+  return [lhs, rhs];
+};
+
+const getParameters = (expr: string): string[] => {
+  /**
+   * Expr should parse to a FunctionAssignmentNode, but let's discard the RHS
+   * and use LHS = 1 in case the RHS includes a parsing error.
+   */
+  const [lhs] = splitAtFirstEquality(expr);
+  const node = latexParser.mjsParse(`${lhs} = 1`);
+  if (node.type !== "FunctionAssignmentNode") {
+    throw new Error("Expected a FunctionAssignmentNode");
+  }
+  return node.params;
+};
+
+export { splitAtFirstEquality, getParameters };

--- a/client/src/util/parsing/index.ts
+++ b/client/src/util/parsing/index.ts
@@ -1,1 +1,2 @@
 export * from "./parsers";
+export * from "./helpers";

--- a/client/src/util/parsing/interfaces.ts
+++ b/client/src/util/parsing/interfaces.ts
@@ -30,6 +30,7 @@ type ParserRule = TextParserRule | TextParserRegexRule | MathJsRule;
 
 interface IMathJsParser {
   preprocess: (text: string) => string;
+  mjsParse: (text: string) => MJsNode;
   parse: Parse<ParseOptions>;
 }
 

--- a/client/src/util/predicates.ts
+++ b/client/src/util/predicates.ts
@@ -23,9 +23,27 @@ export const isNotNil = <T>(x: T): x is NonNullable<T> => {
   return true;
 };
 
-export const assertNotNil: <T>(value: T) => asserts value is NonNullable<T> = (
-  value
-) => {
+export const assertNotNil: <T>(
+  value: T,
+  msg?: string
+) => asserts value is NonNullable<T> = (value, msg) => {
   if (isNotNil(value)) return;
+  if (msg) {
+    throw new Error(msg);
+  }
   throw new Error(`Value ${value} should not be nil.`);
+};
+
+/**
+ * Type assertion that asserts value is not null or undefined.
+ *
+ * Unlike jest assertions, this will refine the type.
+ * See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/41179
+ */
+export const assertInstanceOf: <C extends { new (...args: any): any }>(
+  value: unknown,
+  Class: C
+) => asserts value is InstanceType<C> = (value, Class) => {
+  if (value instanceof Class) return;
+  throw new Error(`Expected value to be instanceof ${Class}`);
 };


### PR DESCRIPTION
Changes:
- fleshes out ParametricSurface, ParametricCurve, ExplicitSurface, and ExplicitSurfacePolar item forms (using same underlrying component)
- Improvement over v1...Make parameter names customizable!

<img width="382" alt="Screen Shot 2022-06-20 at 4 48 31 PM" src="https://user-images.githubusercontent.com/9010790/174675871-3202bc76-b3f8-4053-8465-e30ce9f9d29c.png">

