### PR TITLE
Mathscope

### DIFF
--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -1,34 +1,25 @@
 import React from "react";
 import { Provider } from "react-redux";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
-import MathScope from "util/MathScope";
 
-import { MathContext } from "./features/sceneControls/mathItems";
 import * as routes from "./routes";
 import type { AppStore } from "./store/store";
 
 interface Props {
   store: AppStore;
-  mathScope: MathScope;
 }
 
-const App: React.FC<Props> = ({ store, mathScope }) => (
+const App: React.FC<Props> = ({ store }) => (
   <React.StrictMode>
     <Provider store={store}>
-      {/**
-       * MathScope doesn't necessary need to be so high in the tree, but it
-       * doesn't hurt since the instance value never change.
-       */}
-      <MathContext.Provider value={mathScope}>
-        <BrowserRouter>
-          <Routes>
-            <Route path="/">
-              <Route path="/:sceneId" element={<routes.MainPage />} />
-              <Route path="" element={<routes.MainPage />} />
-            </Route>
-          </Routes>
-        </BrowserRouter>
-      </MathContext.Provider>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/">
+            <Route path="/:sceneId" element={<routes.MainPage />} />
+            <Route path="" element={<routes.MainPage />} />
+          </Route>
+        </Routes>
+      </BrowserRouter>
     </Provider>
   </React.StrictMode>
 );

--- a/client/src/configs/configs.ts
+++ b/client/src/configs/configs.ts
@@ -77,8 +77,9 @@ type MathItems = {
 type MathItem<T extends MathItemType = MathItemType> = MathItems[T];
 type MathGraphic<T extends MathGraphicType = MathGraphicType> = MathItems[T];
 
-type MathItemPatch<T extends MathItemType> = {
+type MathItemPatch<T extends MathItemType = MathItemType> = {
   id: MathItem<T>["id"];
+  type: MathItem<T>["type"];
 } & { properties: Partial<MathItem<T>["properties"]> };
 
 const addableTypes = [

--- a/client/src/features/sceneControls/SceneControls.tsx
+++ b/client/src/features/sceneControls/SceneControls.tsx
@@ -11,6 +11,7 @@ import {
   FolderWithContents,
   mathItemsSlice,
   select,
+  actions,
 } from "./mathItems";
 import style from "./SceneControls.module.css";
 
@@ -31,6 +32,10 @@ const AxesNav: React.FC = () => (
 const MathItemsList: React.FC<{ rootId: string }> = ({ rootId }) => {
   const { children = [] } = useAppSelector(select.subtree(rootId));
   const mathItems = useAppSelector(select.mathItems());
+  const dispatch = useAppDispatch();
+  useEffect(() => {
+    dispatch(actions.initializeMathScope());
+  }, [dispatch]);
   return (
     <>
       {children.map((folder, folderIndex) => {

--- a/client/src/features/sceneControls/SceneControls.tsx
+++ b/client/src/features/sceneControls/SceneControls.tsx
@@ -10,8 +10,7 @@ import ControlTabs from "./controlTabs";
 import {
   FolderWithContents,
   mathItemsSlice,
-  selectMathItems,
-  selectSubtree,
+  select,
 } from "./mathItems";
 import style from "./SceneControls.module.css";
 
@@ -30,8 +29,8 @@ const AxesNav: React.FC = () => (
 );
 
 const MathItemsList: React.FC<{ rootId: string }> = ({ rootId }) => {
-  const { children = [] } = useAppSelector(selectSubtree(rootId));
-  const mathItems = useAppSelector(selectMathItems());
+  const { children = [] } = useAppSelector(select.subtree(rootId));
+  const mathItems = useAppSelector(select.mathItems());
   return (
     <>
       {children.map((folder, folderIndex) => {

--- a/client/src/features/sceneControls/mathItems/ColorStatus/ColorDialog.tsx
+++ b/client/src/features/sceneControls/mathItems/ColorStatus/ColorDialog.tsx
@@ -6,7 +6,7 @@ import ColorPicker, { OnColorChange } from "util/components/ColorPicker";
 
 import FieldWidget, { useOnWidgetChange } from "../FieldWidget";
 import { OnWidgetChange } from "../FieldWidget/types";
-import { useMathErrors } from "../mathScope";
+import { useMathErrors, useMathScope } from "../mathScope";
 
 const { TabPane } = Tabs;
 
@@ -29,7 +29,8 @@ const COLOR_EXPR = ["colorExpr"] as const;
 
 const ColorExprInput: React.FC<ColorExprProps> = (props) => {
   const { onChange, item } = props;
-  const { colorExpr } = useMathErrors(item.id, COLOR_EXPR);
+  const mathScope = useMathScope();
+  const { colorExpr } = useMathErrors(mathScope, item.id, COLOR_EXPR);
   return (
     <div>
       <FieldWidget

--- a/client/src/features/sceneControls/mathItems/ColorStatus/ColorDialog.tsx
+++ b/client/src/features/sceneControls/mathItems/ColorStatus/ColorDialog.tsx
@@ -6,7 +6,8 @@ import ColorPicker, { OnColorChange } from "util/components/ColorPicker";
 
 import FieldWidget, { useOnWidgetChange } from "../FieldWidget";
 import { OnWidgetChange } from "../FieldWidget/types";
-import { useMathErrors, useMathScope } from "../mathScope";
+import { useMathScope } from "../mathItemsSlice";
+import { useMathErrors } from "../mathScope";
 
 const { TabPane } = Tabs;
 

--- a/client/src/features/sceneControls/mathItems/ColorStatus/ColorStatus.tsx
+++ b/client/src/features/sceneControls/mathItems/ColorStatus/ColorStatus.tsx
@@ -2,14 +2,14 @@ import { Popover } from "antd";
 import classNames from "classnames";
 import { MathGraphic } from "configs";
 import { colorsAndGradients, makeColorConfig } from "configs/colors";
-import React, { useCallback, useContext, useMemo } from "react";
+import React, { useCallback, useMemo } from "react";
 import { useToggle } from "util/hooks";
 import { useLongAndShortPress } from "util/hooks/useLongAndShortPress";
 
 import { positioning } from "util/styles";
 import { useOnWidgetChange } from "../FieldWidget";
 import { WidgetChangeEvent } from "../FieldWidget/types";
-import { MathContext, useMathResults } from "../mathScope";
+import { useMathResults, useMathScope } from "../mathScope";
 import ColorDialog from "./ColorDialog";
 import styles from "./ColorStatus.module.css";
 
@@ -28,8 +28,8 @@ const ColorStatus: React.FC<Props> = (props) => {
   const { item } = props;
   const [dialogVisible, setDialogVisible] = useToggle(false);
   const { color } = item.properties;
-  const mathScope = useContext(MathContext);
-  const results = useMathResults(item.id, VISIBLE);
+  const mathScope = useMathScope();
+  const results = useMathResults(mathScope, item.id, VISIBLE);
   const onChange = useOnWidgetChange(item);
   const visible = !!results.visible;
   const colorAndStyle = useMemo(() => getColor(color), [color]);
@@ -54,11 +54,10 @@ const ColorStatus: React.FC<Props> = (props) => {
     if (lastPressWasLong()) return;
     const event: WidgetChangeEvent = {
       name: "visible",
-      mathScope,
       value: `${!visible}`,
     };
     onChange(event);
-  }, [visible, onChange, mathScope, lastPressWasLong]);
+  }, [visible, onChange, lastPressWasLong]);
 
   return (
     <Popover

--- a/client/src/features/sceneControls/mathItems/ColorStatus/ColorStatus.tsx
+++ b/client/src/features/sceneControls/mathItems/ColorStatus/ColorStatus.tsx
@@ -9,7 +9,8 @@ import { useLongAndShortPress } from "util/hooks/useLongAndShortPress";
 import { positioning } from "util/styles";
 import { useOnWidgetChange } from "../FieldWidget";
 import { WidgetChangeEvent } from "../FieldWidget/types";
-import { useMathResults, useMathScope } from "../mathScope";
+import { useMathScope } from "../mathItemsSlice";
+import { useMathResults } from "../mathScope";
 import ColorDialog from "./ColorDialog";
 import styles from "./ColorStatus.module.css";
 

--- a/client/src/features/sceneControls/mathItems/FieldWidget/AutosizeText.tsx
+++ b/client/src/features/sceneControls/mathItems/FieldWidget/AutosizeText.tsx
@@ -1,15 +1,13 @@
 import classNames from "classnames";
-import React, { useCallback, useContext } from "react";
+import React, { useCallback } from "react";
 import { TextareaAutoWidthHeight } from "util/components";
 
-import { MathContext } from "../mathScope";
 import { IWidgetProps, WidgetChangeEvent } from "./types";
 import styles from "./widget.module.css";
 
 const EXTRA_WIDTH = 20;
 
 const AutosizeText: React.FC<IWidgetProps> = (props: IWidgetProps) => {
-  const mathScope = useContext(MathContext);
   const { onChange, name, title, error, itemId, style = {}, ...others } = props;
   const { width, height, ...styleWithoutSize } = style;
   const onInputChange: React.ChangeEventHandler<HTMLTextAreaElement> =
@@ -18,11 +16,10 @@ const AutosizeText: React.FC<IWidgetProps> = (props: IWidgetProps) => {
         const event: WidgetChangeEvent = {
           name,
           value: e.target.value,
-          mathScope,
         };
         onChange(event);
       },
-      [onChange, name, mathScope]
+      [onChange, name]
     );
   return (
     <TextareaAutoWidthHeight

--- a/client/src/features/sceneControls/mathItems/FieldWidget/MathAssignment.tsx
+++ b/client/src/features/sceneControls/mathItems/FieldWidget/MathAssignment.tsx
@@ -1,12 +1,11 @@
 import classNames from "classnames";
-import React, { useCallback, useContext } from "react";
+import React, { useCallback } from "react";
 import { OnMathFieldChange } from "util/components/MathLive";
 import SmallMathField from "util/components/SmallMathField";
 import { AssignmentError } from "util/MathScope/Evaluator";
 import { splitAtFirstEquality } from "util/parsing";
 import { ParseAssignmentLHSError } from "util/parsing/rules";
 
-import { MathContext } from "../mathScope";
 import ReadonlyMathField from "./ReadonlyMathField";
 import type { IWidgetProps, WidgetChangeEvent } from "./types";
 import ErrorTooltip from "./ErrorTooltip";
@@ -15,18 +14,16 @@ import style from "./widget.module.css";
 const MathAssignment: React.FC<IWidgetProps> = (props: IWidgetProps) => {
   const { onChange, name, value, error, title, className, ...others } = props;
   const [lhs, rhs] = splitAtFirstEquality(value);
-  const mathScope = useContext(MathContext);
   const onChangeLHS: OnMathFieldChange = useCallback(
     (e) => {
       const newValue = [e.target.value, rhs].join("=");
       const event: WidgetChangeEvent = {
         name,
         value: newValue,
-        mathScope,
       };
       onChange(event);
     },
-    [rhs, onChange, name, mathScope]
+    [rhs, onChange, name]
   );
   const onChangeRHS: OnMathFieldChange = useCallback(
     (e) => {
@@ -34,11 +31,10 @@ const MathAssignment: React.FC<IWidgetProps> = (props: IWidgetProps) => {
       const event: WidgetChangeEvent = {
         name,
         value: newValue,
-        mathScope,
       };
       onChange(event);
     },
-    [lhs, onChange, name, mathScope]
+    [lhs, onChange, name]
   );
 
   const hasLhsError =

--- a/client/src/features/sceneControls/mathItems/FieldWidget/MathBoolean.tsx
+++ b/client/src/features/sceneControls/mathItems/FieldWidget/MathBoolean.tsx
@@ -5,8 +5,9 @@ import { SubtleButton } from "util/components";
 import { OnMathFieldChange } from "util/components/MathLive";
 import SmallMathField from "util/components/SmallMathField";
 import { assertNotNil } from "util/predicates";
+import { useMathScope } from "../mathItemsSlice";
 
-import { useMathResults, useMathScope } from "../mathScope";
+import { useMathResults } from "../mathScope";
 import { IWidgetProps } from "./types";
 import styles from "./widget.module.css";
 

--- a/client/src/features/sceneControls/mathItems/FieldWidget/MathBoolean.tsx
+++ b/client/src/features/sceneControls/mathItems/FieldWidget/MathBoolean.tsx
@@ -1,12 +1,12 @@
 import { Switch, Tooltip } from "antd";
 import classNames from "classnames";
-import React, { useCallback, useContext, useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { SubtleButton } from "util/components";
 import { OnMathFieldChange } from "util/components/MathLive";
 import SmallMathField from "util/components/SmallMathField";
 import { assertNotNil } from "util/predicates";
 
-import { MathContext, useMathResults } from "../mathScope";
+import { useMathResults, useMathScope } from "../mathScope";
 import { IWidgetProps } from "./types";
 import styles from "./widget.module.css";
 
@@ -21,14 +21,14 @@ const MathBoolean: React.FC<IWidgetProps> = (props: IWidgetProps) => {
     !LITERAL_BOOLEAN_STRINGS.includes(value)
   );
 
-  const mathScope = useContext(MathContext);
+  const mathScope = useMathScope();
 
   const triggerChange = useCallback(
     (newValue: string) => {
-      const widgetChangeEvent = { name, value: newValue, mathScope };
+      const widgetChangeEvent = { name, value: newValue };
       onChange(widgetChangeEvent);
     },
-    [name, mathScope, onChange]
+    [name, onChange]
   );
 
   const handleChange: OnMathFieldChange = useCallback(
@@ -39,7 +39,7 @@ const MathBoolean: React.FC<IWidgetProps> = (props: IWidgetProps) => {
   );
 
   const names = useMemo(() => [name], [name]);
-  const result = !!useMathResults(itemId, names)[name];
+  const result = !!useMathResults(mathScope, itemId, names)[name];
 
   const handleSwitchChange = useCallback(
     (e: boolean) => triggerChange(e ? "true" : "false"),

--- a/client/src/features/sceneControls/mathItems/FieldWidget/MathValue.tsx
+++ b/client/src/features/sceneControls/mathItems/FieldWidget/MathValue.tsx
@@ -1,26 +1,23 @@
 import classNames from "classnames";
-import React, { useCallback, useContext } from "react";
+import React, { useCallback } from "react";
 import { OnMathFieldChange } from "util/components/MathLive";
 import SmallMathField from "util/components/SmallMathField";
 
-import { MathContext } from "../mathScope";
 import { IWidgetProps } from "./types";
 import styles from "./widget.module.css";
 
 const MathValue: React.FC<IWidgetProps> = (props: IWidgetProps) => {
   const { name, title, value, onChange, error, style, className } = props;
-  const mathScope = useContext(MathContext);
 
   const handleChange: OnMathFieldChange = useCallback(
     (e) => {
       const widgetChangeEvent = {
         name,
         value: e.target.value,
-        mathScope,
       };
       onChange(widgetChangeEvent);
     },
-    [name, mathScope, onChange]
+    [name, onChange]
   );
 
   return (

--- a/client/src/features/sceneControls/mathItems/FieldWidget/index.tsx
+++ b/client/src/features/sceneControls/mathItems/FieldWidget/index.tsx
@@ -1,16 +1,8 @@
-import {
-  MathItem,
-  mathItemConfigs,
-  MathItemType as MIT,
-  PropertyConfig,
-  WidgetType,
-} from "configs";
+import { MathItem, MathItemType as MIT, WidgetType } from "configs";
 import React, { useCallback } from "react";
 import { useAppDispatch } from "store/hooks";
-import { assertNotNil } from "util/predicates";
 
 import { actions } from "../mathItemsSlice";
-import { mathScopeId } from "../mathScope";
 import AutosizeText from "./AutosizeText";
 import ColorWidget from "./ColorWidget";
 import MathAssignment from "./MathAssignment";
@@ -66,23 +58,8 @@ export const useOnWidgetChange = <T extends MIT>(item: MathItem<T>) => {
   const onWidgetChange: OnWidgetChange = useCallback(
     (e) => {
       const properties = { [e.name]: e.value };
-      const patch = { id: item.id, properties };
+      const patch = { id: item.id, properties, type: item.type };
       dispatch(actions.setProperties(patch));
-      if (e.mathScope) {
-        const config = mathItemConfigs[item.type];
-        // @ts-expect-error ... string can't index config.properties
-        const propConfig: PropertyConfig<string> = config.properties[e.name];
-        assertNotNil(propConfig, "Property config should not be nil.");
-        e.mathScope.setExpressions([
-          {
-            id: mathScopeId(item.id, e.name),
-            expr: e.value,
-            parseOptions: {
-              validate: propConfig.validate,
-            },
-          },
-        ]);
-      }
     },
     [dispatch, item.id, item.type]
   );

--- a/client/src/features/sceneControls/mathItems/FieldWidget/index.tsx
+++ b/client/src/features/sceneControls/mathItems/FieldWidget/index.tsx
@@ -9,7 +9,7 @@ import React, { useCallback } from "react";
 import { useAppDispatch } from "store/hooks";
 import { assertNotNil } from "util/predicates";
 
-import { actions } from "../mathItems.slice";
+import { actions } from "../mathItemsSlice";
 import { mathScopeId } from "../mathScope";
 import AutosizeText from "./AutosizeText";
 import ColorWidget from "./ColorWidget";

--- a/client/src/features/sceneControls/mathItems/FieldWidget/types.d.ts
+++ b/client/src/features/sceneControls/mathItems/FieldWidget/types.d.ts
@@ -1,5 +1,4 @@
 import React from "react";
-import MathScope from "util/MathScope";
 
 interface IWidgetProps {
   /**
@@ -20,7 +19,6 @@ interface IWidgetProps {
 interface WidgetChangeEvent {
   name: string;
   value: string;
-  mathScope?: MathScope;
 }
 type OnWidgetChange = (e: WidgetChangeEvent) => void;
 

--- a/client/src/features/sceneControls/mathItems/FolderWithContents/FolderWithContents.tsx
+++ b/client/src/features/sceneControls/mathItems/FolderWithContents/FolderWithContents.tsx
@@ -4,8 +4,9 @@ import { MathItem, MathItemType } from "configs";
 import classNames from "classnames";
 import { useCollapsible } from "util/hooks";
 import MathItemComponent from "../MathItem";
-import { useMathResults, useMathScope } from "../mathScope";
+import { useMathResults } from "../mathScope";
 import style from "./FolderWithContents.module.css";
+import { useMathScope } from "../mathItemsSlice";
 
 interface Props {
   folder: MathItem<MathItemType.Folder>;

--- a/client/src/features/sceneControls/mathItems/FolderWithContents/FolderWithContents.tsx
+++ b/client/src/features/sceneControls/mathItems/FolderWithContents/FolderWithContents.tsx
@@ -4,7 +4,7 @@ import { MathItem, MathItemType } from "configs";
 import classNames from "classnames";
 import { useCollapsible } from "util/hooks";
 import MathItemComponent from "../MathItem";
-import { useMathResults } from "../mathScope";
+import { useMathResults, useMathScope } from "../mathScope";
 import style from "./FolderWithContents.module.css";
 
 interface Props {
@@ -20,7 +20,8 @@ const FolderWithContents: React.FC<Props> = ({
   items,
   contentsClassName,
 }) => {
-  const evaluated = useMathResults(folder.id, EVALUATED_PROPS);
+  const mathScope = useMathScope();
+  const evaluated = useMathResults(mathScope, folder.id, EVALUATED_PROPS);
   const isOpen = !evaluated.isCollapsed;
   const hasEvaluated = evaluated.isCollapsed !== undefined;
   const collapseRef = useCollapsible(isOpen);

--- a/client/src/features/sceneControls/mathItems/MathItem.tsx
+++ b/client/src/features/sceneControls/mathItems/MathItem.tsx
@@ -50,4 +50,4 @@ const MathItemComponent = <T extends MIT>(props: Props<T>) => {
   return <Component item={props.item} />;
 };
 
-export default MathItemComponent;
+export default React.memo(MathItemComponent);

--- a/client/src/features/sceneControls/mathItems/__tests__/parametricSurface.spec.tsx
+++ b/client/src/features/sceneControls/mathItems/__tests__/parametricSurface.spec.tsx
@@ -17,7 +17,7 @@ const getParamNameInputs = (): HTMLTextAreaElement[] => {
   return [zeroth, first];
 };
 
-test.each([
+test.only.each([
   {
     expression: {
       initial: "_f(x,y)=[1+abc, 0, 0]",
@@ -29,17 +29,17 @@ test.each([
     ],
     param: { name: "abc", index: 0 },
   },
-  {
-    expression: {
-      initial: "_f(x,y)=[1+abc, 0, 0]",
-      expectedFinal: "_f(x,abc)=[1+abc, 0, 0]",
-    },
-    evaluations: [
-      { parmaValues: [1, 0], expectedOutput: [1, 0, 0] },
-      { parmaValues: [0, 1], expectedOutput: [2, 0, 0] },
-    ],
-    param: { name: "abc", index: 1 },
-  },
+  // {
+  //   expression: {
+  //     initial: "_f(x,y)=[1+abc, 0, 0]",
+  //     expectedFinal: "_f(x,abc)=[1+abc, 0, 0]",
+  //   },
+  //   evaluations: [
+  //     { parmaValues: [1, 0], expectedOutput: [1, 0, 0] },
+  //     { parmaValues: [0, 1], expectedOutput: [2, 0, 0] },
+  //   ],
+  //   param: { name: "abc", index: 1 },
+  // },
 ])(
   "Updating parameter names to valid values updates expression appropriately",
   async ({ expression, param, evaluations }) => {
@@ -48,6 +48,9 @@ test.each([
     const helper = new IntegrationTest();
     helper.patchMathItemsInFolder([item]);
     const { mathScope, store } = helper.render();
+    await new Promise((resolve) => {
+      setTimeout(resolve);
+    });
     // initiall there is an error since the expr RHS contains "abc" which is not a param name or defined variable
     expect(mathScope.evalErrors.has(id("expr"))).toBe(true);
     const inputs = getParamNameInputs();

--- a/client/src/features/sceneControls/mathItems/__tests__/parametricSurface.spec.tsx
+++ b/client/src/features/sceneControls/mathItems/__tests__/parametricSurface.spec.tsx
@@ -17,7 +17,7 @@ const getParamNameInputs = (): HTMLTextAreaElement[] => {
   return [zeroth, first];
 };
 
-test.only.each([
+test.each([
   {
     expression: {
       initial: "_f(x,y)=[1+abc, 0, 0]",
@@ -29,17 +29,17 @@ test.only.each([
     ],
     param: { name: "abc", index: 0 },
   },
-  // {
-  //   expression: {
-  //     initial: "_f(x,y)=[1+abc, 0, 0]",
-  //     expectedFinal: "_f(x,abc)=[1+abc, 0, 0]",
-  //   },
-  //   evaluations: [
-  //     { parmaValues: [1, 0], expectedOutput: [1, 0, 0] },
-  //     { parmaValues: [0, 1], expectedOutput: [2, 0, 0] },
-  //   ],
-  //   param: { name: "abc", index: 1 },
-  // },
+  {
+    expression: {
+      initial: "_f(x,y)=[1+abc, 0, 0]",
+      expectedFinal: "_f(x,abc)=[1+abc, 0, 0]",
+    },
+    evaluations: [
+      { parmaValues: [1, 0], expectedOutput: [1, 0, 0] },
+      { parmaValues: [0, 1], expectedOutput: [2, 0, 0] },
+    ],
+    param: { name: "abc", index: 1 },
+  },
 ])(
   "Updating parameter names to valid values updates expression appropriately",
   async ({ expression, param, evaluations }) => {

--- a/client/src/features/sceneControls/mathItems/forms/Folder/index.tsx
+++ b/client/src/features/sceneControls/mathItems/forms/Folder/index.tsx
@@ -8,9 +8,10 @@ import { positioning } from "util/styles";
 import ItemTemplate from "../../templates/ItemTemplate";
 import { MathItemForm } from "../interfaces";
 import styles from "./Folder.module.css";
-import { useMathResults, useMathScope } from "../../mathScope";
+import { useMathResults } from "../../mathScope";
 import { useOnWidgetChange } from "../../FieldWidget";
 import { WidgetChangeEvent } from "../../FieldWidget/types";
+import { useMathScope } from "../../mathItemsSlice";
 
 interface FolderButtonProps {
   onClick: React.MouseEventHandler;

--- a/client/src/features/sceneControls/mathItems/forms/Folder/index.tsx
+++ b/client/src/features/sceneControls/mathItems/forms/Folder/index.tsx
@@ -1,14 +1,14 @@
 import classNames from "classnames";
 import { DownOutlined } from "@ant-design/icons";
 import { mathItemConfigs as configs, MathItemType as MIT } from "configs";
-import React, { useCallback, useContext } from "react";
+import React, { useCallback } from "react";
 
 import { SubtleButton } from "util/components";
 import { positioning } from "util/styles";
 import ItemTemplate from "../../templates/ItemTemplate";
 import { MathItemForm } from "../interfaces";
 import styles from "./Folder.module.css";
-import { MathContext, useMathResults } from "../../mathScope";
+import { useMathResults, useMathScope } from "../../mathScope";
 import { useOnWidgetChange } from "../../FieldWidget";
 import { WidgetChangeEvent } from "../../FieldWidget/types";
 
@@ -41,19 +41,18 @@ const FolderButton: React.FC<FolderButtonProps> = ({
 const EVALUATED_PROPS = ["isCollapsed"];
 
 const Folder: MathItemForm<MIT.Folder> = ({ item }) => {
-  const evaluated = useMathResults(item.id, EVALUATED_PROPS);
+  const mathScope = useMathScope();
+  const evaluated = useMathResults(mathScope, item.id, EVALUATED_PROPS);
   const isCollapsed = !!evaluated.isCollapsed;
-  const mathScope = useContext(MathContext);
   const onWidgetChange = useOnWidgetChange(item);
   const onClick = useCallback(() => {
     const value = String(!isCollapsed);
     const event: WidgetChangeEvent = {
       value,
       name: "isCollapsed",
-      mathScope,
     };
     onWidgetChange(event);
-  }, [isCollapsed, onWidgetChange, mathScope]);
+  }, [isCollapsed, onWidgetChange]);
   return (
     <ItemTemplate
       item={item}

--- a/client/src/features/sceneControls/mathItems/forms/Point/index.tsx
+++ b/client/src/features/sceneControls/mathItems/forms/Point/index.tsx
@@ -6,7 +6,7 @@ import {
 import React from "react";
 
 import FieldWidget, { useOnWidgetChange } from "../../FieldWidget";
-import { useMathErrors } from "../../mathScope";
+import { useMathErrors, useMathScope } from "../../mathScope";
 import ItemTemplate from "../../templates/ItemTemplate";
 import { MathItemForm } from "../interfaces";
 
@@ -18,7 +18,8 @@ const configProps = config.properties;
 
 const Point: MathItemForm<MIT.Point> = ({ item }) => {
   const onWidgetChange = useOnWidgetChange(item);
-  const errors = useMathErrors(item.id, errorNames);
+  const mathScope = useMathScope();
+  const errors = useMathErrors(mathScope, item.id, errorNames);
   return (
     <ItemTemplate item={item} config={config}>
       <FieldWidget

--- a/client/src/features/sceneControls/mathItems/forms/Point/index.tsx
+++ b/client/src/features/sceneControls/mathItems/forms/Point/index.tsx
@@ -6,7 +6,8 @@ import {
 import React from "react";
 
 import FieldWidget, { useOnWidgetChange } from "../../FieldWidget";
-import { useMathErrors, useMathScope } from "../../mathScope";
+import { useMathScope } from "../../mathItemsSlice";
+import { useMathErrors } from "../../mathScope";
 import ItemTemplate from "../../templates/ItemTemplate";
 import { MathItemForm } from "../interfaces";
 

--- a/client/src/features/sceneControls/mathItems/forms/RangedMathItemForm.tsx
+++ b/client/src/features/sceneControls/mathItems/forms/RangedMathItemForm.tsx
@@ -9,7 +9,8 @@ import React, { useMemo } from "react";
 
 import FieldWidget, { useOnWidgetChange } from "../FieldWidget";
 import { OnWidgetChange } from "../FieldWidget/types";
-import { useMathErrors, useMathScope } from "../mathScope";
+import { useMathScope } from "../mathItemsSlice";
+import { useMathErrors } from "../mathScope";
 import ItemTemplate from "../templates/ItemTemplate";
 import {
   ParameterContainer,

--- a/client/src/features/sceneControls/mathItems/forms/RangedMathItemForm.tsx
+++ b/client/src/features/sceneControls/mathItems/forms/RangedMathItemForm.tsx
@@ -9,7 +9,7 @@ import React, { useMemo } from "react";
 
 import FieldWidget, { useOnWidgetChange } from "../FieldWidget";
 import { OnWidgetChange } from "../FieldWidget/types";
-import { useMathErrors } from "../mathScope";
+import { useMathErrors, useMathScope } from "../mathScope";
 import ItemTemplate from "../templates/ItemTemplate";
 import {
   ParameterContainer,
@@ -42,7 +42,8 @@ const RangedMathItemForm = ({
     exprRef,
     paramNameErrors: paramErrors,
   } = useExpressionAndParameters(item.properties.expr, onWidgetChange);
-  const errors = useMathErrors(item.id, errorNames);
+  const mathScope = useMathScope();
+  const errors = useMathErrors(mathScope, item.id, errorNames);
 
   const onParamChanges = useMemo(
     () =>

--- a/client/src/features/sceneControls/mathItems/forms/Variable/index.tsx
+++ b/client/src/features/sceneControls/mathItems/forms/Variable/index.tsx
@@ -2,7 +2,7 @@ import { mathItemConfigs as configs, MathItemType as MIT } from "configs";
 import React from "react";
 
 import { MathAssignment, useOnWidgetChange } from "../../FieldWidget";
-import { useMathErrors } from "../../mathScope";
+import { useMathErrors, useMathScope } from "../../mathScope";
 import ItemTemplate from "../../templates/ItemTemplate";
 import { MathItemForm } from "../interfaces";
 
@@ -14,7 +14,8 @@ const errorNames = ["value"] as const;
 
 const Variable: MathItemForm<MIT.Variable> = ({ item }) => {
   const onWidgetChange = useOnWidgetChange(item);
-  const errors = useMathErrors(item.id, errorNames);
+  const mathScope = useMathScope();
+  const errors = useMathErrors(mathScope, item.id, errorNames);
   return (
     <ItemTemplate item={item} config={config}>
       <MathAssignment

--- a/client/src/features/sceneControls/mathItems/forms/Variable/index.tsx
+++ b/client/src/features/sceneControls/mathItems/forms/Variable/index.tsx
@@ -2,7 +2,8 @@ import { mathItemConfigs as configs, MathItemType as MIT } from "configs";
 import React from "react";
 
 import { MathAssignment, useOnWidgetChange } from "../../FieldWidget";
-import { useMathErrors, useMathScope } from "../../mathScope";
+import { useMathScope } from "../../mathItemsSlice";
+import { useMathErrors } from "../../mathScope";
 import ItemTemplate from "../../templates/ItemTemplate";
 import { MathItemForm } from "../interfaces";
 

--- a/client/src/features/sceneControls/mathItems/forms/expressionHelpers.tsx
+++ b/client/src/features/sceneControls/mathItems/forms/expressionHelpers.tsx
@@ -4,7 +4,7 @@ import { assertInstanceOf } from "util/predicates";
 
 import ReadonlyMathField from "../FieldWidget/ReadonlyMathField";
 import { OnWidgetChange } from "../FieldWidget/types";
-import { useMathScope } from "../mathScope";
+import { useMathScope } from "../mathItemsSlice";
 import styles from "./ItemForms.module.css";
 
 interface ParameterContainerProps {

--- a/client/src/features/sceneControls/mathItems/forms/expressionHelpers.tsx
+++ b/client/src/features/sceneControls/mathItems/forms/expressionHelpers.tsx
@@ -1,16 +1,10 @@
-import React, {
-  MutableRefObject,
-  useCallback,
-  useContext,
-  useRef,
-  useState,
-} from "react";
+import React, { MutableRefObject, useCallback, useRef, useState } from "react";
 import { getParameters, latexParser, splitAtFirstEquality } from "util/parsing";
 import { assertInstanceOf } from "util/predicates";
 
 import ReadonlyMathField from "../FieldWidget/ReadonlyMathField";
 import { OnWidgetChange } from "../FieldWidget/types";
-import { MathContext } from "../mathScope";
+import { useMathScope } from "../mathScope";
 import styles from "./ItemForms.module.css";
 
 interface ParameterContainerProps {
@@ -93,7 +87,7 @@ const useExpressionAndParameters = (
    */
   paramNameErrors: Record<number, Error>;
 } => {
-  const mathScope = useContext(MathContext);
+  const mathScope = useMathScope();
   const [paramErrors, setParamErrors] = useState<Record<number, Error>>({});
   const exprRef: MutableRefObject<ExprData> = useRef({
     rhs: splitAtFirstEquality(initialExpr)[1],

--- a/client/src/features/sceneControls/mathItems/index.tsx
+++ b/client/src/features/sceneControls/mathItems/index.tsx
@@ -1,9 +1,8 @@
 import MathItem from "./MathItem";
 import type { MathItemsState } from "./mathItemsSlice";
 import mathItemsSlice, { reducer, actions, select } from "./mathItemsSlice";
-import { MathContext } from "./mathScope";
 
 export { default as FolderWithContents } from "./FolderWithContents/FolderWithContents";
 
 export type { MathItemsState };
-export { MathContext, MathItem, mathItemsSlice, reducer, actions, select };
+export { MathItem, mathItemsSlice, reducer, actions, select };

--- a/client/src/features/sceneControls/mathItems/index.tsx
+++ b/client/src/features/sceneControls/mathItems/index.tsx
@@ -1,20 +1,9 @@
 import MathItem from "./MathItem";
-import type { MathItemsState } from "./mathItems.slice";
-import mathItemsSlice, {
-  useMathItem,
-  selectMathItems,
-  selectSubtree,
-} from "./mathItems.slice";
+import type { MathItemsState } from "./mathItemsSlice";
+import mathItemsSlice, { reducer, actions, select } from "./mathItemsSlice";
 import { MathContext } from "./mathScope";
 
 export { default as FolderWithContents } from "./FolderWithContents/FolderWithContents";
 
 export type { MathItemsState };
-export {
-  MathContext,
-  MathItem,
-  mathItemsSlice,
-  useMathItem,
-  selectMathItems,
-  selectSubtree,
-};
+export { MathContext, MathItem, mathItemsSlice, reducer, actions, select };

--- a/client/src/features/sceneControls/mathItems/mathItemsSlice/hooks.ts
+++ b/client/src/features/sceneControls/mathItems/mathItemsSlice/hooks.ts
@@ -1,0 +1,9 @@
+import { useAppSelector } from "store/hooks";
+import MathScope from "util/MathScope";
+import * as select from "./selectors";
+
+const useMathScope = (): MathScope => {
+  return useAppSelector(select.mathScope());
+};
+
+export { useMathScope };

--- a/client/src/features/sceneControls/mathItems/mathItemsSlice/index.ts
+++ b/client/src/features/sceneControls/mathItems/mathItemsSlice/index.ts
@@ -1,0 +1,8 @@
+import * as select from "./selectors";
+import type { MathItemsState } from "./mathItems.slice";
+import mathItemsSlice, { actions, reducer } from "./mathItems.slice";
+
+export { select, actions, reducer };
+
+export type { MathItemsState };
+export default mathItemsSlice;

--- a/client/src/features/sceneControls/mathItems/mathItemsSlice/index.ts
+++ b/client/src/features/sceneControls/mathItems/mathItemsSlice/index.ts
@@ -3,6 +3,7 @@ import type { MathItemsState } from "./mathItems.slice";
 import mathItemsSlice, { actions, reducer } from "./mathItems.slice";
 
 export { select, actions, reducer };
+export * from "./hooks";
 
 export type { MathItemsState };
 export default mathItemsSlice;

--- a/client/src/features/sceneControls/mathItems/mathItemsSlice/mathItems.slice.ts
+++ b/client/src/features/sceneControls/mathItems/mathItemsSlice/mathItems.slice.ts
@@ -1,18 +1,12 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-import {
-  MathItem,
-  mathItemConfigs,
-  MathItemPatch,
-  MathItemType,
-} from "configs";
+import { mathItemConfigs } from "configs";
+import type { MathItem, MathItemPatch, MathItemType } from "configs";
 import { keyBy } from "lodash";
-import { useAppSelector } from "store/hooks";
-import type { RootState, SelectorReturn } from "store/store";
 import { assertNotNil } from "util/predicates";
 
-import defaultScene from "../defaultScene";
+import defaultScene from "../../defaultScene";
 
-export interface MathItemsState {
+interface MathItemsState {
   items: {
     [id: string]: MathItem;
   };
@@ -110,60 +104,6 @@ const mathItemsSlice = createSlice({
   },
 });
 
-export const selectMathItems =
-  (): SelectorReturn<MathItemsState["items"]> => (state: RootState) =>
-    state.mathItems.items;
-
-export const selectMathItem =
-  (id: string): SelectorReturn<MathItem> =>
-  (state: RootState) =>
-    state.mathItems.items[id];
-
-export const useMathItem = (id: string) => {
-  const mathItem = useAppSelector(selectMathItem(id));
-  return mathItem;
-};
-
-interface Subtree {
-  id: string;
-  children?: Subtree[];
-}
-
-const getSubtree = (
-  state: MathItemsState,
-  node: Subtree,
-  depth = 0
-): Subtree => {
-  if (node.children) return node;
-  if (!state.order[node.id]) return node;
-  if (depth > 2) {
-    /**
-     * Sanity check. Math3d UI does not support nesting folders.
-     * Max depth should be 2:
-     * root
-     *    userFolder1
-     *      item1a
-     *      item1b
-     *    userFolder2
-     *      ...etc
-     */
-    throw new Error("Depth should not be greater than 2.");
-  }
-  const children = state.order[node.id].map((id) => {
-    return getSubtree(state, { id }, depth + 1);
-  });
-  return { ...node, children };
-};
-
-export const selectSubtree =
-  (rootId: string): SelectorReturn<Subtree> =>
-  (state: RootState) =>
-    getSubtree(state.mathItems, { id: rootId });
-
-export const selectIsActive =
-  (id: string): SelectorReturn<boolean> =>
-  (state: RootState) =>
-    state.mathItems.activeItemId === id;
-
+export type { MathItemsState };
 export const { actions, reducer } = mathItemsSlice;
 export default mathItemsSlice;

--- a/client/src/features/sceneControls/mathItems/mathItemsSlice/mathItems.slice.ts
+++ b/client/src/features/sceneControls/mathItems/mathItemsSlice/mathItems.slice.ts
@@ -13,12 +13,20 @@ import {
 } from "./syncMathScope";
 
 interface MathItemsState {
-  mathScope: () => MathScope;
   items: {
     [id: string]: MathItem;
   };
   order: Record<string, string[]>;
   activeItemId: string | undefined;
+  /**
+   * We need to sync the expressions in MathItem.properties with the MathScope.
+   * Putting mathScope in the redux store is a very convenient way to do this
+   * since actions are the centralized place for editing MathItem properties.
+   *
+   * This is a nonserializable value, so comes with some caveats. See
+   * https://redux-toolkit.js.org/usage/usage-guide#working-with-non-serializable-data
+   */
+  mathScope: () => MathScope;
 }
 
 const getInitialState = (): MathItemsState => {

--- a/client/src/features/sceneControls/mathItems/mathItemsSlice/mathItems.slice.ts
+++ b/client/src/features/sceneControls/mathItems/mathItemsSlice/mathItems.slice.ts
@@ -22,12 +22,9 @@ interface MathItemsState {
 }
 
 const getInitialState = (): MathItemsState => {
-  const { items } = defaultScene;
-  const mathScope = new MathScope({ parse: latexParser.parse });
-  syncItemsToMathScope(mathScope, items);
   return {
-    mathScope,
-    items: keyBy(items, (item) => item.id),
+    mathScope: new MathScope({ parse: latexParser.parse }),
+    items: keyBy(defaultScene.items, (item) => item.id),
     activeItemId: undefined,
     order: defaultScene.itemOrder,
   };
@@ -74,6 +71,11 @@ const mathItemsSlice = createSlice({
   reducers: {
     addItems: (_state, _action: PayloadAction<{ items: MathItem[] }>) => {
       throw new Error("Not implemented");
+    },
+    initializeMathScope: (state) => {
+      const items = Object.values(state.items);
+      console.log(`Initializing ${items.length} items`);
+      syncItemsToMathScope(rawMathScope(state), items);
     },
     addNewItem: (
       state,

--- a/client/src/features/sceneControls/mathItems/mathItemsSlice/selectors.ts
+++ b/client/src/features/sceneControls/mathItems/mathItemsSlice/selectors.ts
@@ -1,5 +1,6 @@
 import type { SelectorReturn, RootState } from "store/store";
 import type { MathItem } from "configs";
+import MathScope from "util/MathScope";
 import type { MathItemsState } from "./mathItems.slice";
 
 const mathItems =
@@ -52,4 +53,7 @@ const isActive =
   (state: RootState) =>
     state.mathItems.activeItemId === id;
 
-export { subtree, isActive, mathItems, mathItem };
+const mathScope = (): SelectorReturn<MathScope> => (state: RootState) =>
+  state.mathItems.mathScope;
+
+export { subtree, isActive, mathItems, mathItem, mathScope };

--- a/client/src/features/sceneControls/mathItems/mathItemsSlice/selectors.ts
+++ b/client/src/features/sceneControls/mathItems/mathItemsSlice/selectors.ts
@@ -1,0 +1,55 @@
+import type { SelectorReturn, RootState } from "store/store";
+import type { MathItem } from "configs";
+import type { MathItemsState } from "./mathItems.slice";
+
+const mathItems =
+  (): SelectorReturn<MathItemsState["items"]> => (state: RootState) =>
+    state.mathItems.items;
+
+const mathItem =
+  (id: string): SelectorReturn<MathItem> =>
+  (state: RootState) =>
+    state.mathItems.items[id];
+
+interface Subtree {
+  id: string;
+  children?: Subtree[];
+}
+
+const getSubtree = (
+  state: MathItemsState,
+  node: Subtree,
+  depth = 0
+): Subtree => {
+  if (node.children) return node;
+  if (!state.order[node.id]) return node;
+  if (depth > 2) {
+    /**
+     * Sanity check. Math3d UI does not support nesting folders.
+     * Max depth should be 2:
+     * root
+     *    userFolder1
+     *      item1a
+     *      item1b
+     *    userFolder2
+     *      ...etc
+     */
+    throw new Error("Depth should not be greater than 2.");
+  }
+  const children = state.order[node.id].map((id) => {
+    return getSubtree(state, { id }, depth + 1);
+  });
+  return { ...node, children };
+};
+
+const subtree =
+  (rootId: string): SelectorReturn<Subtree> =>
+  (state: RootState) =>
+    getSubtree(state.mathItems, { id: rootId });
+
+const isActive =
+  (id: string): SelectorReturn<boolean> =>
+  (state: RootState) =>
+    state.mathItems.activeItemId === id;
+
+export { subtree, isActive, mathItems, mathItem };

--- a/client/src/features/sceneControls/mathItems/mathItemsSlice/selectors.ts
+++ b/client/src/features/sceneControls/mathItems/mathItemsSlice/selectors.ts
@@ -54,6 +54,6 @@ const isActive =
     state.mathItems.activeItemId === id;
 
 const mathScope = (): SelectorReturn<MathScope> => (state: RootState) =>
-  state.mathItems.mathScope;
+  state.mathItems.mathScope();
 
 export { subtree, isActive, mathItems, mathItem, mathScope };

--- a/client/src/features/sceneControls/mathItems/mathItemsSlice/syncMathScope.ts
+++ b/client/src/features/sceneControls/mathItems/mathItemsSlice/syncMathScope.ts
@@ -1,0 +1,59 @@
+import {
+  WidgetType,
+  MathItemType,
+  MathItemConfig,
+  PropertyConfig,
+  MathItem,
+  mathItemConfigs,
+  MathItemPatch,
+} from "configs";
+import { filter as collectionFilter } from "lodash";
+import { isNotNil } from "util/predicates";
+import MathScope, { IdentifiedExpression } from "util/MathScope";
+
+const mathScopeId = (itemId: string, propName: string) =>
+  `${itemId}-${propName}`;
+
+const MATH_WIDGETS = new Set([
+  WidgetType.MathValue,
+  WidgetType.MathAssignment,
+  WidgetType.MathBoolean,
+]);
+
+const getMathProperties = <T extends MathItemType>(
+  config: MathItemConfig<T>
+): PropertyConfig<string>[] =>
+  collectionFilter(config.properties, (p) => MATH_WIDGETS.has(p.widget));
+
+const getIdentifiedExpressions = (
+  items: MathItemPatch[]
+): IdentifiedExpression[] =>
+  items.flatMap((item) => {
+    const config = mathItemConfigs[item.type];
+    const mathProperties = getMathProperties(config);
+    return (
+      mathProperties
+        // @ts-expect-error ... TS does not know config and item are correlated
+        .filter((prop) => isNotNil(item.properties[prop.name]))
+        .map((prop) => {
+          return {
+            id: mathScopeId(item.id, prop.name),
+            // @ts-expect-error ... TS does not know config and item are correlated
+            expr: item.properties[prop.name],
+            parseOptions: { validate: prop.validate },
+          };
+        })
+    );
+  });
+
+const syncItemsToMathScope = (mathScope: MathScope, items: MathItemPatch[]) => {
+  const identifiedExpressions = getIdentifiedExpressions(items);
+  mathScope.setExpressions(identifiedExpressions);
+};
+
+const removeItemsFromMathScope = (mathScope: MathScope, items: MathItem[]) => {
+  const identifiedExpressions = getIdentifiedExpressions(items);
+  mathScope.deleteExpressions(identifiedExpressions.map(({ id }) => id));
+};
+
+export { syncItemsToMathScope, removeItemsFromMathScope };

--- a/client/src/features/sceneControls/mathItems/mathScope.ts
+++ b/client/src/features/sceneControls/mathItems/mathScope.ts
@@ -10,7 +10,6 @@ import { useAppSelector } from "store/hooks";
 import MathScope, { OnChangeListener } from "util/MathScope";
 import { select } from "./mathItemsSlice";
 
-// TEMPORARY... moving this to redux store
 const useMathScope = (): MathScope => {
   return useAppSelector(select.mathScope());
 };

--- a/client/src/features/sceneControls/mathItems/mathScope.ts
+++ b/client/src/features/sceneControls/mathItems/mathScope.ts
@@ -6,13 +6,7 @@ import {
 } from "configs";
 import { filter as collectionFilter } from "lodash";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useAppSelector } from "store/hooks";
 import MathScope, { OnChangeListener } from "util/MathScope";
-import { select } from "./mathItemsSlice";
-
-const useMathScope = (): MathScope => {
-  return useAppSelector(select.mathScope());
-};
 
 type EvaluationResultsSlice<K extends string> = Partial<Record<K, unknown>>;
 type EvaluationErrorsSlice<K extends string> = Partial<Record<K, Error>>;
@@ -133,4 +127,4 @@ const getMathProperties = <T extends MathItemType>(
 ): PropertyConfig<string>[] =>
   collectionFilter(config.properties, (p) => MATH_WIDGETS.has(p.widget));
 
-export { getMathProperties, useMathScope, useMathErrors, useMathResults };
+export { getMathProperties, useMathErrors, useMathResults };

--- a/client/src/features/sceneControls/mathItems/templates/ItemTemplate.module.css
+++ b/client/src/features/sceneControls/mathItems/templates/ItemTemplate.module.css
@@ -49,18 +49,23 @@
   grid-column-end: 4;
   grid-row-start: 1;
   grid-row-end: 3;
+  padding-right: 0.25em;
 }
 .grid-right-gutter-top {
   grid-column-start: 3;
   grid-column-end: 4;
   grid-row-start: 1;
   grid-row-end: 2;
+  padding-top: 0.25em;
+  padding-right: 0.25em;
 }
 .grid-right-gutter-bottom {
   grid-column-start: 3;
   grid-column-end: 4;
   grid-row-start: 2;
   grid-row-end: 3;
+  padding-right: 0.25em;
+  padding-bottom: 0.25em;
 }
 
 .left-gutter {

--- a/client/src/features/sceneControls/mathItems/templates/ItemTemplate.tsx
+++ b/client/src/features/sceneControls/mathItems/templates/ItemTemplate.tsx
@@ -12,7 +12,6 @@ import { useAppDispatch, useAppSelector } from "store/hooks";
 import ColorStatus from "../ColorStatus";
 import FieldWidget, { useOnWidgetChange } from "../FieldWidget";
 import { actions, select } from "../mathItemsSlice";
-import { usePopulateMathScope } from "../mathScope";
 import { testId } from "../util";
 import CloseButton from "./CloseButton";
 import styles from "./ItemTemplate.module.css";
@@ -34,7 +33,7 @@ const ItemTemplate = <T extends MIT>({
   showAlignmentBar = true,
 }: Props<T>) => {
   const onWidgetChange = useOnWidgetChange(item);
-  usePopulateMathScope(item, config);
+
   const dispatch = useAppDispatch();
   const isActive = useAppSelector(select.isActive(item.id));
   const remove = useCallback(() => {

--- a/client/src/features/sceneControls/mathItems/templates/ItemTemplate.tsx
+++ b/client/src/features/sceneControls/mathItems/templates/ItemTemplate.tsx
@@ -11,7 +11,7 @@ import { useAppDispatch, useAppSelector } from "store/hooks";
 
 import ColorStatus from "../ColorStatus";
 import FieldWidget, { useOnWidgetChange } from "../FieldWidget";
-import { actions, selectIsActive } from "../mathItems.slice";
+import { actions, select } from "../mathItemsSlice";
 import { usePopulateMathScope } from "../mathScope";
 import { testId } from "../util";
 import CloseButton from "./CloseButton";
@@ -36,7 +36,7 @@ const ItemTemplate = <T extends MIT>({
   const onWidgetChange = useOnWidgetChange(item);
   usePopulateMathScope(item, config);
   const dispatch = useAppDispatch();
-  const isActive = useAppSelector(selectIsActive(item.id));
+  const isActive = useAppSelector(select.isActive(item.id));
   const remove = useCallback(() => {
     dispatch(actions.remove({ id: item.id }));
   }, [dispatch, item.id]);

--- a/client/src/features/sceneControls/mathItems/templates/ItemTemplate.tsx
+++ b/client/src/features/sceneControls/mathItems/templates/ItemTemplate.tsx
@@ -75,9 +75,7 @@ const ItemTemplate = <T extends MIT>({
           onChange={onWidgetChange}
         />
       </div>
-      <div className={classNames(styles["grid-center-bottom"], "pb-2")}>
-        {children}
-      </div>
+      <div className={styles["grid-center-bottom"]}>{children}</div>
       <div
         className={classNames(
           styles["grid-right-gutter-top"],

--- a/client/src/features/sceneControls/mathItems/templates/SettingsPopover.tsx
+++ b/client/src/features/sceneControls/mathItems/templates/SettingsPopover.tsx
@@ -10,7 +10,8 @@ import React, { useCallback, useMemo, useState } from "react";
 import { SubtleButton } from "util/components";
 
 import FieldWidget, { useOnWidgetChange } from "../FieldWidget";
-import { getMathProperties, useMathErrors, useMathScope } from "../mathScope";
+import { useMathScope } from "../mathItemsSlice";
+import { getMathProperties, useMathErrors } from "../mathScope";
 import CloseButton from "./CloseButton";
 import styles from "./SettingsPopover.module.css";
 

--- a/client/src/features/sceneControls/mathItems/templates/SettingsPopover.tsx
+++ b/client/src/features/sceneControls/mathItems/templates/SettingsPopover.tsx
@@ -10,7 +10,7 @@ import React, { useCallback, useMemo, useState } from "react";
 import { SubtleButton } from "util/components";
 
 import FieldWidget, { useOnWidgetChange } from "../FieldWidget";
-import { getMathProperties, useMathErrors } from "../mathScope";
+import { getMathProperties, useMathErrors, useMathScope } from "../mathScope";
 import CloseButton from "./CloseButton";
 import styles from "./SettingsPopover.module.css";
 
@@ -28,7 +28,8 @@ const SettingsForm = <T extends MathItemType>({
     () => getMathProperties(config).map((p) => p.name),
     [config]
   );
-  const errors = useMathErrors(item.id, mathPropNames);
+  const mathScope = useMathScope();
+  const errors = useMathErrors(mathScope, item.id, mathPropNames);
   const fields = useMemo(() => {
     return config.settingsProperties.map((name) => {
       // @ts-expect-error ts does not know name is correlated with properties

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -9,19 +9,15 @@ import { createRoot } from "react-dom/client";
 
 import App from "./app";
 import { getStore } from "./store/store";
-import MathScope from "./util/MathScope";
-import { latexParser } from "./util/parsing";
 
 window.math = math;
-
-const mathScope = new MathScope({ parse: latexParser.parse });
-// @ts-expect-error assign to window for debugging
-window.mathScope = mathScope;
 
 const container = document.getElementById("root");
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const root = createRoot(container!);
 
 const store = getStore();
+// @ts-expect-error for debugging
+window.store = store;
 
-root.render(<App store={store} mathScope={mathScope} />);
+root.render(<App store={store} />);

--- a/client/src/store/store.ts
+++ b/client/src/store/store.ts
@@ -20,6 +20,13 @@ const getStore = ({ preloadedState }: ConfigureStoreOptions = {}) =>
       [mathItemsSlice.name]: mathItemsSlice.reducer,
     },
     preloadedState,
+    middleware: (getDefaultMiddleware) => {
+      return getDefaultMiddleware({
+        serializableCheck: {
+          ignoredPaths: ["mathItems.mathScope"],
+        },
+      });
+    },
   });
 
 type AppStore = ReturnType<typeof getStore>;

--- a/client/src/store/store.ts
+++ b/client/src/store/store.ts
@@ -1,4 +1,4 @@
-import { Action, configureStore, ThunkAction } from "@reduxjs/toolkit";
+import { configureStore } from "@reduxjs/toolkit";
 import type { MathItemsState } from "features/sceneControls/mathItems";
 import { mathItemsSlice } from "features/sceneControls/mathItems";
 
@@ -25,14 +25,8 @@ const getStore = ({ preloadedState }: ConfigureStoreOptions = {}) =>
 type AppStore = ReturnType<typeof getStore>;
 
 type AppDispatch = AppStore["dispatch"];
-type AppThunk<ReturnType = void> = ThunkAction<
-  ReturnType,
-  RootState,
-  unknown,
-  Action<string>
->;
 
 type SelectorReturn<T> = (state: RootState) => T;
 
-export type { AppDispatch, AppStore, AppThunk, RootState, SelectorReturn };
+export type { AppDispatch, AppStore, RootState, SelectorReturn };
 export { getInitialState, getStore };

--- a/client/src/test_util/IntegrationTest.tsx
+++ b/client/src/test_util/IntegrationTest.tsx
@@ -5,8 +5,6 @@ import React from "react";
 import { getInitialState, getStore } from "store/store";
 import type { RootState } from "store/store";
 import { makeItem } from "test_util";
-import MathScope from "util/MathScope";
-import { getLatexParser } from "util/parsing";
 
 import App from "../app";
 

--- a/client/src/test_util/IntegrationTest.tsx
+++ b/client/src/test_util/IntegrationTest.tsx
@@ -59,7 +59,7 @@ class IntegrationTest {
   render = () => {
     const state = mergeStoreStates(getInitialState(), this.storePatch);
     const store = getStore({ preloadedState: state });
-    const { mathScope } = state.mathItems;
+    const mathScope = state.mathItems.mathScope();
     const result = render(<App store={store} />);
     return { result, mathScope, store };
   };

--- a/client/src/test_util/IntegrationTest.tsx
+++ b/client/src/test_util/IntegrationTest.tsx
@@ -14,6 +14,14 @@ type StorePatch = Partial<{
   [k in keyof RootState]: Partial<RootState[k]>;
 }>;
 
+const mergeStoreStates = (state: RootState, patch: StorePatch) => {
+  const copy = { ...state };
+  if (patch.mathItems) {
+    copy.mathItems = { ...copy.mathItems, ...patch.mathItems };
+  }
+  return copy;
+};
+
 class IntegrationTest {
   private storePatch: StorePatch = {};
 
@@ -49,7 +57,7 @@ class IntegrationTest {
   };
 
   render = () => {
-    const state = { ...getInitialState() };
+    const state = mergeStoreStates(getInitialState(), this.storePatch);
     const store = getStore({ preloadedState: state });
     const { mathScope } = state.mathItems;
     const result = render(<App store={store} />);


### PR DESCRIPTION
This moves the syncing between math-item-properties and MathScope into the redux store. Previously, it was in some hooks.

To do this, I've put the MathScope object into the redux store, which is nonserializable. See https://redux-toolkit.js.org/api/serializabilityMiddleware. I expect that this will break time travel debugging? I'm not sure, but I haven't found that super useful anyway.

In general, the necessity to sync between redux and the MathScope seems a little anti-redux... but:
- evaluated properties need to be in MathScope
- non-evaluated properties (like Description) don't make sense to be in MathScope 
- it's convenient to have ALL properties in redux.

So the syncing seems necessary to me.