### PR TITLE
Mathscope updates

### DIFF
--- a/client/src/api/defaultScene.ts
+++ b/client/src/api/defaultScene.ts
@@ -13,8 +13,6 @@ const defaultScene: Omit<Scene, "id"> = {
         grid1: "8",
         grid2: "8",
         zBias: "0",
-        param1: "x",
-        param2: "y",
         range1: "\\left[-2,\\ 2\\right]",
         range2: "\\left[-2,\\ 2\\right]",
         shaded: "true",

--- a/client/src/configs/items/explicitSurface.ts
+++ b/client/src/configs/items/explicitSurface.ts
@@ -12,8 +12,6 @@ import {
   grid2,
   gridWidth,
   opacity,
-  param1,
-  param2,
   range1,
   range2,
   shaded,
@@ -33,8 +31,6 @@ interface ExplicitSurfaceProperties {
   zBias: string;
   shaded: string; // eval to boolean;
   expr: string;
-  param1: string;
-  param2: string;
   range1: string;
   range2: string;
   colorExpr: string;
@@ -55,8 +51,6 @@ const defaultValues: ExplicitSurfaceProperties = {
   zBias: "0",
   shaded: "true",
   expr: "_f(x,y)=x^2-y^2",
-  param1: "x",
-  param2: "y",
   range1: "[-2, 2]",
   range2: "[-2, 2]",
   colorExpr: "_f(X, Y, Z, x, y)=mod(Z, 1)",
@@ -101,8 +95,6 @@ const config: IMathItemConfig<
     grid2,
     gridWidth,
     opacity,
-    param1,
-    param2,
     range1,
     range2,
     shaded,

--- a/client/src/configs/items/explicitSurfacePolar.ts
+++ b/client/src/configs/items/explicitSurfacePolar.ts
@@ -12,8 +12,6 @@ import {
   grid2,
   gridWidth,
   opacity,
-  param1,
-  param2,
   range1,
   range2,
   shaded,
@@ -34,8 +32,6 @@ interface ExplicitSurfacePolarProperties {
 
   shaded: string; // eval to boolean;
   expr: string;
-  param1: string;
-  param2: string;
   range1: string;
   range2: string;
   colorExpr: string;
@@ -56,8 +52,6 @@ const defaultValues: ExplicitSurfacePolarProperties = {
   zBias: "0",
   shaded: "true",
   expr: "_f(r, Q)=\\frac{1}{4}r^2*cos(3*Q)",
-  param1: "r",
-  param2: "Q",
   range1: "[0, 3]",
   range2: "[-pi, pi]",
   colorExpr: "_f(X, Y, Z, r, theta)=mod(Z, 1)",
@@ -102,8 +96,6 @@ const config: IMathItemConfig<
     grid2,
     gridWidth,
     opacity,
-    param1,
-    param2,
     range1,
     range2,
     shaded,

--- a/client/src/configs/items/parametricCurve.ts
+++ b/client/src/configs/items/parametricCurve.ts
@@ -15,7 +15,6 @@ import {
   width,
   zBias,
   zIndex,
-  param1,
   range1,
   samples1,
 } from "../shared";
@@ -33,7 +32,6 @@ interface ParametricCurveProperties {
   start: string; // eval to boolean;
   end: string; // eval to boolean;
   expr: string;
-  param1: string;
   range1: string;
   samples1: string;
 }
@@ -50,7 +48,6 @@ const defaultValues: ParametricCurveProperties = {
   start: "false",
   end: "false",
   expr: "_f(t)=[cos(t), sin(t), t]",
-  param1: "t",
   range1: "[-2*pi, 2*pi]",
   samples1: "128",
 };
@@ -86,7 +83,6 @@ const config: IMathItemConfig<
     zIndex,
     start,
     end,
-    param1,
     range1: { ...range1, label: "Range" },
     samples1: { ...samples1, label: "Samples" },
   },

--- a/client/src/configs/items/parametricSurface.ts
+++ b/client/src/configs/items/parametricSurface.ts
@@ -12,8 +12,6 @@ import {
   grid2,
   gridWidth,
   opacity,
-  param1,
-  param2,
   range1,
   range2,
   shaded,
@@ -34,8 +32,6 @@ interface ParametricSurfaceProperties {
 
   shaded: string; // eval to boolean;
   expr: string;
-  param1: string;
-  param2: string;
   range1: string;
   range2: string;
   colorExpr: string;
@@ -56,8 +52,6 @@ const defaultValues: ParametricSurfaceProperties = {
   zBias: "0",
   shaded: "true",
   expr: "_f(u,v)=[1,1,1]",
-  param1: "u",
-  param2: "v",
   range1: "[-pi, pi]",
   range2: "[-3, 3]",
   colorExpr: "_f(X, Y, Z, u, v)=mod(Z, 1)",
@@ -102,8 +96,6 @@ const config: IMathItemConfig<
     grid2,
     gridWidth,
     opacity,
-    param1,
-    param2,
     range1,
     range2,
     shaded,

--- a/client/src/configs/shared.ts
+++ b/client/src/configs/shared.ts
@@ -62,25 +62,6 @@ const opacity: PropertyConfig<"opacity"> = {
   // validate real number
 };
 
-const param1: PropertyConfig<"param1"> = {
-  name: "param1",
-  label: "1st parameter name",
-  widget: WidgetType.Text,
-  // complicated validation... [real, real] or func of V
-};
-const param2: PropertyConfig<"param2"> = {
-  name: "param2",
-  label: "2nd parameter name",
-  widget: WidgetType.Text,
-  // complicated validation... [real, real] or func of V
-};
-const param3: PropertyConfig<"param3"> = {
-  name: "param3",
-  label: "3rd parameter name",
-  widget: WidgetType.Text,
-  // complicated validation... [real, real] or func of V
-};
-
 const range1: PropertyConfig<"range1"> = {
   name: "range1",
   label: "Range (1st parameter)",
@@ -189,9 +170,6 @@ export {
   label,
   labelVisible,
   opacity,
-  param1,
-  param2,
-  param3,
   range1,
   range2,
   range3,

--- a/client/src/features/sceneControls/mathItems/FieldWidget/MathBoolean.spec.tsx
+++ b/client/src/features/sceneControls/mathItems/FieldWidget/MathBoolean.spec.tsx
@@ -32,8 +32,6 @@ const setup = async (initialValue: string) => {
   const visibleControl = within(settings).getByLabelText("Visible");
 
   const getValue = () => mathScope.results.get(id("visible"));
-  const getEvalError = () => mathScope.evalErrors.get(id("visible"));
-  const getParseError = () => mathScope.parseErrors.get(id("visible"));
 
   /**
    * Find and return the Switch button
@@ -78,8 +76,6 @@ const setup = async (initialValue: string) => {
     settings,
     mathScope,
     getValue,
-    getEvalError,
-    getParseError,
     findToggle,
     findReset,
     findUseExpr,

--- a/client/src/features/sceneControls/mathItems/__tests__/implicitSurface.spec.tsx
+++ b/client/src/features/sceneControls/mathItems/__tests__/implicitSurface.spec.tsx
@@ -40,7 +40,7 @@ test("Updating parameter names updates the lhs and rhs appropriately", async () 
   await user.clear(paramInput);
   await user.click(paramInput);
   await user.paste("a1");
-  expect(mathScope.evalErrors.size).toBe(2);
+  expect(mathScope.errors.size).toBe(2);
   const newItem = store.getState().mathItems.items[
     item.id
   ] as MathItem<MIT.ImplicitSurface>;

--- a/client/src/features/sceneControls/mathItems/__tests__/parametricSurface.spec.tsx
+++ b/client/src/features/sceneControls/mathItems/__tests__/parametricSurface.spec.tsx
@@ -56,7 +56,7 @@ test.each([
       setTimeout(resolve);
     });
     // initiall there is an error since the expr RHS contains "abc" which is not a param name or defined variable
-    expect(mathScope.evalErrors.has(id("expr"))).toBe(true);
+    expect(mathScope.errors.has(id("expr"))).toBe(true);
     const inputs = getParamNameInputs();
     await user.clear(inputs[param.index]);
     await user.click(inputs[param.index]);
@@ -113,7 +113,7 @@ test.each([
     ] as MathItem<MIT.ParametricSurface>;
     expect(itemAfterEdit.properties.expr).toBe(expression.expectedFinal);
 
-    const fError = mathScope.parseErrors.get(id("expr"));
+    const fError = mathScope.errors.get(id("expr"));
     assertInstanceOf(fError, ParseAssignmentLHSError);
     expect(fError.details.paramErrors[param.index]).toBeInstanceOf(Error);
   }

--- a/client/src/features/sceneControls/mathItems/__tests__/point.spec.tsx
+++ b/client/src/features/sceneControls/mathItems/__tests__/point.spec.tsx
@@ -40,8 +40,7 @@ test.each([
     const { store } = await renderTestApp(`/${scene.id}`);
 
     const mathScope = store.getState().mathItems.mathScope();
-    expect(mathScope.evalErrors.size).toBe(numEvalErrors);
-    expect(mathScope.parseErrors.size).toBe(numParseErrors);
+    expect(mathScope.errors.size).toBe(numEvalErrors + numParseErrors);
     expect(mathScope.results.get(id("coords"))).toStrictEqual(coords);
   }
 );
@@ -77,8 +76,7 @@ test.each([
     const coordsInput = await screen.findByLabelText("Coordinates");
 
     pasteText(coordsInput, coordsString);
-    expect(mathScope.evalErrors.size).toBe(numEvalErrors);
-    expect(mathScope.parseErrors.size).toBe(numParseErrors);
+    expect(mathScope.errors.size).toBe(numEvalErrors + numParseErrors);
     expect(mathScope.results.get(id("coords"))).toStrictEqual(coords);
   }
 );
@@ -102,8 +100,7 @@ test("Adding items adds to mathScope", async () => {
   const id = nodeId(point);
   getItemByDescription(point.properties.description);
   expect(mathScope.results.get(id("coords"))).toStrictEqual([0, 0, 0]);
-  expect(mathScope.evalErrors.size).toBe(0);
-  expect(mathScope.parseErrors.size).toBe(0);
+  expect(mathScope.errors.size).toBe(0);
 });
 
 test("Deleting items removes them from mathScope", async () => {
@@ -118,14 +115,12 @@ test("Deleting items removes them from mathScope", async () => {
 
   const mathScope = store.getState().mathItems.mathScope();
   expect(mathScope.results.size).toBeGreaterThan(1); // point + folder visibility
-  expect(mathScope.parseErrors.size).toBeGreaterThan(0);
-  expect(mathScope.evalErrors.size).toBeGreaterThan(0);
+  expect(mathScope.errors.size).toBeGreaterThan(0);
 
   const item = getItemByDescription(point.properties.description);
   const remove = within(item).getByLabelText("Remove Item");
   await user.click(remove);
   expect(mathScope.results.size).toBe(1); // folder visibility
-  expect(mathScope.parseErrors.size).toBe(0);
-  expect(mathScope.evalErrors.size).toBe(0);
+  expect(mathScope.errors.size).toBe(0);
   expect(item).not.toBeInTheDocument();
 });

--- a/client/src/features/sceneControls/mathItems/__tests__/variable-slider.spec.tsx
+++ b/client/src/features/sceneControls/mathItems/__tests__/variable-slider.spec.tsx
@@ -101,10 +101,6 @@ const setupTest = async (
   });
 
   const getValueResult = () => mathScope.results.get(valueId);
-  const getValueError = (type: "parse" | "eval") =>
-    type === "parse"
-      ? mathScope.parseErrors.get(valueId)
-      : mathScope.evalErrors.get(valueId);
 
   return {
     mathScope,
@@ -113,7 +109,6 @@ const setupTest = async (
     item,
     valueUpdates,
     getValueResult,
-    getValueError,
     props,
     min,
     max,

--- a/client/src/features/sceneControls/mathItems/__tests__/variable.spec.tsx
+++ b/client/src/features/sceneControls/mathItems/__tests__/variable.spec.tsx
@@ -7,7 +7,7 @@ test("left-hand parse errors are indicated on left-hand side", async () => {
   const { store } = await renderTestApp(`/${scene.id}`);
 
   const mathScope = store.getState().mathItems.mathScope();
-  expect(mathScope.parseErrors.size).toBe(1);
+  expect(mathScope.errors.size).toBe(1);
   const lhs = await screen.findByLabelText("left-hand side", { exact: false });
   const rhs = await screen.findByLabelText("right-hand side", { exact: false });
   expect(lhs).toHaveClass("has-error");
@@ -20,7 +20,7 @@ test("right-hand parse errors are indicated on right-hand side", async () => {
   const { store } = await renderTestApp(`/${scene.id}`);
 
   const mathScope = store.getState().mathItems.mathScope();
-  expect(mathScope.parseErrors.size).toBe(1);
+  expect(mathScope.errors.size).toBe(1);
   const lhs = await screen.findByLabelText("left-hand side", { exact: false });
   const rhs = await screen.findByLabelText("right-hand side", { exact: false });
   expect(lhs).not.toHaveClass("has-error");

--- a/client/src/features/sceneControls/mathItems/mathScope.ts
+++ b/client/src/features/sceneControls/mathItems/mathScope.ts
@@ -33,11 +33,8 @@ const extractErrors = <K extends string, PO extends DefaultParseOptions>(
   const newErrors: EvaluationErrorsSlice<K> = {};
   (Object.keys(ids) as K[]).forEach((name) => {
     const id = ids[name];
-    if (scope.evalErrors.has(id)) {
-      newErrors[name] = scope.evalErrors.get(id);
-    }
-    if (scope.parseErrors.has(id)) {
-      newErrors[name] = scope.parseErrors.get(id);
+    if (scope.errors.has(id)) {
+      newErrors[name] = scope.errors.get(id);
     }
   });
   return newErrors;
@@ -95,11 +92,8 @@ const useMathErrors = <K extends string>(
   const onChange = useCallback<OnChangeListener>(
     (event) => {
       const { mathScope } = event;
-      const { evalErrors, parseErrors } = event.changes;
-      if (
-        names.some((name) => evalErrors.touched.has(ids[name])) ||
-        names.some((name) => parseErrors.touched.has(ids[name]))
-      ) {
+      const { errors } = event.changes;
+      if (names.some((name) => errors.touched.has(ids[name]))) {
         setErrors(extractErrors(mathScope, ids));
       }
     },

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -60,6 +60,10 @@ prepare().then(() => {
   const root = createRoot(container);
 
   const store = getStore();
+  if (import.meta.env.DEV) {
+    // @ts-expect-error Allow accessing store on widnow in dev for debugging
+    window.store = store;
+  }
   const queryClient = new QueryClient();
 
   root.render(

--- a/client/src/util/MathScope/Evaluator.ts
+++ b/client/src/util/MathScope/Evaluator.ts
@@ -2,9 +2,7 @@ import ExpressionGraphManager from "./ExpressionGraphManager";
 import {
   AssignmentNode,
   Diff,
-  Evaluatable,
   EvaluationChange,
-  EvaluationErrors,
   EvaluationResult,
   EvaluationScope,
   MathNode,
@@ -18,8 +16,7 @@ import {
   setDifference,
   setUnion,
 } from "./util";
-
-export class EvaluationError extends Error {}
+import { EvaluationError } from "./errors";
 
 interface EvaluatorAction {
   type: "delete" | "add";
@@ -87,13 +84,11 @@ const getUnmetDependencies = (
  * diff of the changes.
  */
 export default class Evaluator {
-  compiled = new WeakMap<MathNode, Evaluatable>();
-
   results: EvaluationResult = new Map();
 
   scope: EvaluationScope;
 
-  errors: EvaluationErrors = new Map();
+  errors = new Map<string, Error>();
 
   private nodesById: Map<string, MathNode> = new Map();
 

--- a/client/src/util/MathScope/Evaluator.ts
+++ b/client/src/util/MathScope/Evaluator.ts
@@ -105,14 +105,6 @@ export default class Evaluator {
     this.scope = new Map(initialScope);
   }
 
-  private compile(node: MathNode) {
-    const cachedValue = this.compiled.get(node);
-    if (cachedValue) return cachedValue;
-    const compiled = node.compile();
-    this.compiled.set(node, compiled);
-    return compiled;
-  }
-
   private updateAssignmentErrors(
     errors: DiffingMap<string, Error>,
     cycles: AssignmentNode[][]
@@ -223,7 +215,7 @@ export default class Evaluator {
     });
 
     order.forEach((node) => {
-      const { evaluate } = this.compile(node);
+      const { evaluate } = node;
       const exprId = node.id;
       try {
         if (node.type === MathNodeType.FunctionAssignmentNode) {

--- a/client/src/util/MathScope/Evaluator.ts
+++ b/client/src/util/MathScope/Evaluator.ts
@@ -95,8 +95,6 @@ export default class Evaluator {
 
   errors: EvaluationErrors = new Map();
 
-  private validators = new Map<string, (x: unknown) => void>();
-
   private nodesById: Map<string, MathNode> = new Map();
 
   private changeQueue: EvaluatorAction[] = [];
@@ -153,7 +151,6 @@ export default class Evaluator {
       .filter(isNotNil);
     ids.forEach((id) => {
       this.nodesById.delete(id);
-      this.validators.delete(id);
     });
     const action: EvaluatorAction = { type: "delete", nodes };
     this.changeQueue.push(action);
@@ -236,8 +233,6 @@ export default class Evaluator {
           }
         }
         const evaluated = evaluate(this.scope);
-        const validate = this.validators.get(exprId);
-        if (validate) validate(evaluated);
         results.set(exprId, evaluated);
         errors.delete(exprId);
       } catch (rawError) {

--- a/client/src/util/MathScope/Evaluator.ts
+++ b/client/src/util/MathScope/Evaluator.ts
@@ -19,7 +19,7 @@ import {
   setUnion,
 } from "./util";
 
-class EvaluationError extends Error {}
+export class EvaluationError extends Error {}
 
 interface EvaluatorAction {
   type: "delete" | "add";
@@ -235,6 +235,12 @@ export default class Evaluator {
         const evaluated = evaluate(this.scope);
         results.set(exprId, evaluated);
         errors.delete(exprId);
+        if (
+          node.type === MathNodeType.FunctionAssignmentNode ||
+          node.type === MathNodeType.ValueAssignment
+        ) {
+          this.scope.set(node.name, evaluated);
+        }
       } catch (rawError) {
         assertIsError(rawError);
         const unmet = getUnmetDependencies(node, this.scope);

--- a/client/src/util/MathScope/MathScope.spec.ts
+++ b/client/src/util/MathScope/MathScope.spec.ts
@@ -33,9 +33,7 @@ describe("MathScope Setting Expressions", () => {
       ])
     );
 
-    expect(mathScope.evalErrors).toStrictEqual(
-      new Map([["x", expect.any(Error)]])
-    );
+    expect(mathScope.errors).toStrictEqual(new Map([["x", expect.any(Error)]]));
   });
 
   it("Removes expressions", () => {
@@ -53,12 +51,12 @@ describe("MathScope Setting Expressions", () => {
         ["c", 20],
       ])
     );
-    expect(mathScope.evalErrors).toStrictEqual(new Map());
+    expect(mathScope.errors).toStrictEqual(new Map());
 
     mathScope.deleteExpressions(["a"]);
 
     expect(new Set(mathScope.results.keys())).toStrictEqual(new Set(["c"]));
-    expect(new Set(mathScope.evalErrors.keys())).toStrictEqual(new Set(["b"]));
+    expect(new Set(mathScope.errors.keys())).toStrictEqual(new Set(["b"]));
   });
 });
 
@@ -87,13 +85,7 @@ describe('MathScope "change" Events', () => {
           updated: new Set(["b"]),
           touched: new Set(["b", "c"]),
         },
-        evalErrors: {
-          added: new Set(),
-          deleted: new Set(),
-          updated: new Set(),
-          touched: new Set(),
-        },
-        parseErrors: {
+        errors: {
           added: new Set(),
           deleted: new Set(),
           updated: new Set(),
@@ -126,13 +118,7 @@ describe('MathScope "change" Events', () => {
           updated: new Set([]),
           touched: new Set(["b"]),
         },
-        evalErrors: {
-          added: new Set(),
-          deleted: new Set(),
-          updated: new Set(),
-          touched: new Set([]),
-        },
-        parseErrors: {
+        errors: {
           added: new Set(),
           deleted: new Set(),
           updated: new Set(),
@@ -189,8 +175,7 @@ describe('MathScope "change-errors" Events', () => {
       type: "change-errors",
       mathScope,
       changes: {
-        evalErrors: emptyDiff(),
-        parseErrors: {
+        errors: {
           ...emptyDiff(),
           touched: new Set(["a"]),
           added: new Set(["a"]),
@@ -205,8 +190,7 @@ describe('MathScope "change-errors" Events', () => {
       type: "change-errors",
       mathScope,
       changes: {
-        evalErrors: emptyDiff(),
-        parseErrors: {
+        errors: {
           ...emptyDiff(),
           touched: new Set(["a"]),
           updated: new Set(["a"]),
@@ -222,8 +206,7 @@ describe('MathScope "change-errors" Events', () => {
       type: "change-errors",
       mathScope,
       changes: {
-        evalErrors: emptyDiff(),
-        parseErrors: {
+        errors: {
           ...emptyDiff(),
           touched: new Set(["a"]),
           deleted: new Set(["a"]),
@@ -251,13 +234,12 @@ describe('MathScope "change-errors" Events', () => {
       type: "change-errors",
       mathScope,
       changes: {
-        evalErrors: {
+        errors: {
           added: new Set("c"),
           deleted: new Set(),
           updated: new Set(),
           touched: new Set(["c"]),
         },
-        parseErrors: emptyDiff(),
       },
     };
     expect(spy).toHaveBeenCalledTimes(1);
@@ -294,17 +276,11 @@ describe('MathScope "change-errors" Events', () => {
       type: "change-errors",
       mathScope,
       changes: {
-        evalErrors: {
+        errors: {
           added: new Set("b"),
           deleted: new Set(),
           updated: new Set(),
           touched: new Set(["b"]),
-        },
-        parseErrors: {
-          added: new Set(),
-          deleted: new Set(),
-          updated: new Set(),
-          touched: new Set(),
         },
       },
     };

--- a/client/src/util/MathScope/adapter.spec.ts
+++ b/client/src/util/MathScope/adapter.spec.ts
@@ -30,19 +30,17 @@ describe("anonParsed dependencies", () => {
 
 describe("MathNode.evaluate", () => {
   it("includes arity (f.length) on results that are functions", () => {
-    const f = anonParse("f(x, y, z) = x + y + z").compile().evaluate();
-    const g = anonParse("g(w, x, y, z) = x").compile().evaluate();
-    const h = anonParse("h = g")
-      .compile()
-      .evaluate(new Map(Object.entries({ g })));
+    const f = anonParse("f(x, y, z) = x + y + z").evaluate();
+    const g = anonParse("g(w, x, y, z) = x").evaluate();
+    const h = anonParse("h = g").evaluate(new Map(Object.entries({ g })));
     expect(f).toHaveLength(3);
     expect(g).toHaveLength(4);
     expect(h).toHaveLength(4);
   });
 
   it("Evaluates vectors/matrices to arrays", () => {
-    const a = anonParse("[1,2,3, 4]").compile().evaluate();
-    const b = anonParse("[[1,2],[3,4]]").compile().evaluate();
+    const a = anonParse("[1,2,3, 4]").evaluate();
+    const b = anonParse("[[1,2],[3,4]]").evaluate();
     expect(a).toStrictEqual([1, 2, 3, 4]);
     expect(b).toStrictEqual([
       [1, 2],
@@ -51,12 +49,8 @@ describe("MathNode.evaluate", () => {
   });
 
   it("Evaluates functions returning vectors/matrices to funcs returning arrays", () => {
-    const f = anonParse("f() = [1,2,3, 4]")
-      .compile()
-      .evaluate() as CallableFunction;
-    const g = anonParse("g() = [[1,2],[3,4]]")
-      .compile()
-      .evaluate() as CallableFunction;
+    const f = anonParse("f() = [1,2,3, 4]").evaluate() as CallableFunction;
+    const g = anonParse("g() = [[1,2],[3,4]]").evaluate() as CallableFunction;
     expect(f()).toStrictEqual([1, 2, 3, 4]);
     expect(g()).toStrictEqual([
       [1, 2],
@@ -66,8 +60,8 @@ describe("MathNode.evaluate", () => {
 
   it("throws an error for functions that throw errors when evauated", () => {
     const node = anonParse("f(x) = 2^[1,2,3]");
-    expect(() => node.compile().evaluate()).toThrow(EvaluationError);
-    expect(() => node.compile().evaluate()).toThrow(
+    expect(() => node.evaluate()).toThrow(EvaluationError);
+    expect(() => node.evaluate()).toThrow(
       /Unexpected type of argument in function pow/
     );
   });

--- a/client/src/util/MathScope/adapter.spec.ts
+++ b/client/src/util/MathScope/adapter.spec.ts
@@ -1,7 +1,7 @@
 import * as math from "mathjs";
 
 import { anonParse } from "./adapter";
-import { EvaluationError } from "./Evaluator";
+import { EvaluationError } from "./errors";
 
 describe("anonParsed dependencies", () => {
   it("returns a set of symbol dependencies", () => {

--- a/client/src/util/MathScope/adapter.spec.ts
+++ b/client/src/util/MathScope/adapter.spec.ts
@@ -1,6 +1,7 @@
 import * as math from "mathjs";
 
 import { anonParse } from "./adapter";
+import { EvaluationError } from "./Evaluator";
 
 describe("anonParsed dependencies", () => {
   it("returns a set of symbol dependencies", () => {
@@ -29,10 +30,14 @@ describe("anonParsed dependencies", () => {
 
 describe("MathNode.evaluate", () => {
   it("includes arity (f.length) on results that are functions", () => {
-    const f = anonParse("f(x, y) = x + y").compile().evaluate();
-    const g = anonParse("g(x, y, z) = x").compile().evaluate();
-    expect(f).toHaveLength(2);
-    expect(g).toHaveLength(3);
+    const f = anonParse("f(x, y, z) = x + y + z").compile().evaluate();
+    const g = anonParse("g(w, x, y, z) = x").compile().evaluate();
+    const h = anonParse("h = g")
+      .compile()
+      .evaluate(new Map(Object.entries({ g })));
+    expect(f).toHaveLength(3);
+    expect(g).toHaveLength(4);
+    expect(h).toHaveLength(4);
   });
 
   it("Evaluates vectors/matrices to arrays", () => {
@@ -57,5 +62,13 @@ describe("MathNode.evaluate", () => {
       [1, 2],
       [3, 4],
     ]);
+  });
+
+  it("throws an error for functions that throw errors when evauated", () => {
+    const node = anonParse("f(x) = 2^[1,2,3]");
+    expect(() => node.compile().evaluate()).toThrow(EvaluationError);
+    expect(() => node.compile().evaluate()).toThrow(
+      /Unexpected type of argument in function pow/
+    );
   });
 });

--- a/client/src/util/MathScope/adapter.ts
+++ b/client/src/util/MathScope/adapter.ts
@@ -1,4 +1,5 @@
 import * as math from "mathjs";
+import { assertInstanceOf, isNotNil } from "../predicates";
 
 import type {
   AnonMathNode,
@@ -9,6 +10,9 @@ import type {
   Parse,
 } from "./interfaces";
 import { MathNodeType } from "./interfaces";
+import { EvaluationError } from "./Evaluator";
+
+window.math = math;
 
 const getDependencies = (
   node: math.MathNode,
@@ -35,16 +39,55 @@ const defaultParseOptions: Required<ParseOptions> = {
   validate: () => {},
 };
 
+class ArrayEvaluationError extends EvaluationError {
+  itemErrors: Record<number, Error> = {};
+
+  constructor(message: string, itemErrors: Record<number, Error>) {
+    super(message);
+    this.itemErrors = itemErrors;
+  }
+}
+
+const evalArray = (
+  parsed: math.ArrayNode,
+  compileNode: math.EvalFunction,
+  scope?: EvaluationScope
+) => {
+  try {
+    return compileNode.evaluate(scope);
+  } catch (err) {
+    const items = parsed.items
+      .map((item, i) => {
+        try {
+          item.evaluate(scope);
+          return null;
+        } catch (itemErr) {
+          if (!(itemErr instanceof Error)) {
+            throw new Error("Unexpected error type");
+          }
+          return [i, itemErr] as const;
+        }
+      })
+      .filter(isNotNil);
+    const itemErrors = Object.fromEntries(items);
+    const firstError = items[0][1];
+    throw new ArrayEvaluationError(firstError.message, itemErrors);
+  }
+};
+
 const compileNode = (
   mjsNode: math.MathNode,
   options: ParseOptions
 ): Evaluatable => {
-  const { evaluate: rawEvaluate } = mjsNode.compile();
+  const compiled = mjsNode.compile();
   const { validate = defaultParseOptions.validate } = {
     ...options,
   };
   const unvalidatedEvaluate = (scope?: EvaluationScope) => {
-    const rawResult = rawEvaluate(scope);
+    const rawResult =
+      mjsNode instanceof math.ArrayNode
+        ? evalArray(mjsNode, compiled, scope)
+        : compiled.evaluate(scope);
     if (math.isMatrix(rawResult)) {
       return rawResult.toArray();
     }
@@ -53,18 +96,40 @@ const compileNode = (
         const evaluated = rawResult(...args);
         return math.isMatrix(evaluated) ? evaluated.toArray() : evaluated;
       };
-      if (mjsNode.type === "FunctionAssignmentNode") {
-        Object.defineProperty(f, "length", { value: mjsNode.params.length });
-      }
-
+      const numArgs =
+        mjsNode.type === "FunctionAssignmentNode"
+          ? mjsNode.params.length
+          : rawResult.length;
+      Object.defineProperty(f, "length", { value: numArgs });
+      /**
+       * 1. First the node is evalauted... the result is a function F
+       * 2. Subsequently (perhaps) the function F might be evaluated
+       *
+       * The point here is to check that if evaluating F would throw, then we
+       * want to figure that out at step (1) not step (2). Determing a good
+       * sample point seems...infeasible. But in general, if a point is
+       * outside the domain of F, we expect F to return NaN not to throw.
+       */
+      const sample = Array(f.length)
+        .fill(0)
+        .map(() => Math.random());
+      f(...sample);
       return f;
     }
     return rawResult;
   };
   const evaluate = (scope?: EvaluationScope) => {
-    const result = unvalidatedEvaluate(scope);
-    validate(result, mjsNode);
-    return result;
+    try {
+      const result = unvalidatedEvaluate(scope);
+      validate(result, mjsNode);
+      return result;
+    } catch (err) {
+      assertInstanceOf(err, Error);
+      if (err instanceof EvaluationError) {
+        throw err;
+      }
+      throw new EvaluationError(err.message);
+    }
   };
   return { evaluate };
 };

--- a/client/src/util/MathScope/adapter.ts
+++ b/client/src/util/MathScope/adapter.ts
@@ -9,7 +9,7 @@ import type {
   Parse,
 } from "./interfaces";
 import { MathNodeType } from "./interfaces";
-import { EvaluationError } from "./Evaluator";
+import { EvaluationError } from "./errors";
 
 window.math = math;
 

--- a/client/src/util/MathScope/adapter.ts
+++ b/client/src/util/MathScope/adapter.ts
@@ -4,7 +4,6 @@ import { assertInstanceOf, isNotNil } from "../predicates";
 import type {
   AnonMathNode,
   AnonParse,
-  Evaluatable,
   EvaluationScope,
   MathNode,
   Parse,
@@ -78,7 +77,7 @@ const evalArray = (
 const compileNode = (
   mjsNode: math.MathNode,
   options: ParseOptions
-): Evaluatable => {
+): AnonMathNode["evaluate"] => {
   const compiled = mjsNode.compile();
   const { validate = defaultParseOptions.validate } = {
     ...options,
@@ -131,7 +130,7 @@ const compileNode = (
       throw new EvaluationError(err.message);
     }
   };
-  return { evaluate };
+  return evaluate;
 };
 
 const convertNode = (
@@ -139,13 +138,13 @@ const convertNode = (
   options: ParseOptions = {}
 ): AnonMathNode => {
   const dependencies = getDependencies(mjsNode);
-  const compile = () => compileNode(mjsNode, options);
+  const evaluate = compileNode(mjsNode, options);
   if (mjsNode.type === "FunctionAssignmentNode") {
     return {
       type: MathNodeType.FunctionAssignmentNode,
       name: mjsNode.name,
       params: mjsNode.params,
-      compile,
+      evaluate,
       dependencies,
     };
   }
@@ -153,13 +152,13 @@ const convertNode = (
     return {
       type: MathNodeType.ValueAssignment,
       name: mjsNode.name,
-      compile,
+      evaluate,
       dependencies,
     };
   }
   return {
     type: MathNodeType.Value,
-    compile,
+    evaluate,
     dependencies,
   };
 };

--- a/client/src/util/MathScope/errors.ts
+++ b/client/src/util/MathScope/errors.ts
@@ -1,0 +1,13 @@
+export class MathScopeError extends Error {
+  constructor(msg: string | Error) {
+    super(typeof msg === "string" ? msg : msg.message);
+  }
+}
+
+export class ParsingError extends MathScopeError {}
+
+export class EvaluationError extends MathScopeError {}
+
+export interface IBatchedError {
+  errors: Map<string, Error>;
+}

--- a/client/src/util/MathScope/index.ts
+++ b/client/src/util/MathScope/index.ts
@@ -1,5 +1,6 @@
 import * as adapter from "./adapter";
 import {
+  EvaluationError,
   AssignmentError,
   DuplicateAssignmentError,
   UnmetDependencyError,
@@ -11,6 +12,7 @@ export type { IdentifiedExpression, MathNode, OnChangeListener, Parse };
 
 export {
   adapter,
+  EvaluationError,
   AssignmentError,
   DuplicateAssignmentError,
   UnmetDependencyError,

--- a/client/src/util/MathScope/index.ts
+++ b/client/src/util/MathScope/index.ts
@@ -1,6 +1,5 @@
 import * as adapter from "./adapter";
 import {
-  EvaluationError,
   AssignmentError,
   DuplicateAssignmentError,
   UnmetDependencyError,
@@ -12,7 +11,6 @@ export type { IdentifiedExpression, MathNode, OnChangeListener, Parse };
 
 export {
   adapter,
-  EvaluationError,
   AssignmentError,
   DuplicateAssignmentError,
   UnmetDependencyError,

--- a/client/src/util/MathScope/interfaces.ts
+++ b/client/src/util/MathScope/interfaces.ts
@@ -1,7 +1,3 @@
-interface Evaluatable {
-  evaluate: (scope?: Map<string, unknown>) => unknown;
-}
-
 enum MathNodeType {
   FunctionAssignmentNode = "FunctionAssignmentNode",
   ValueAssignment = "ValueAssignment",
@@ -19,7 +15,7 @@ type AssignmentType = typeof assignmentTypes[number];
 interface MathNodeBase<T extends MathNodeType = MathNodeType> {
   id: string;
   type: T;
-  compile: () => Evaluatable;
+  evaluate: (scope?: Map<string, unknown>) => unknown;
   dependencies: Set<string>;
 }
 

--- a/client/src/util/MathScope/interfaces.ts
+++ b/client/src/util/MathScope/interfaces.ts
@@ -52,10 +52,6 @@ type EvaluationScope = Map<string, unknown>;
 
 type EvaluationResult = Map<string, unknown>;
 
-type EvaluationErrors = Map<string, Error>;
-
-type ParseErrors = Map<string, Error>;
-
 interface Diff<T> {
   added: Set<T>;
   updated: Set<T>;
@@ -79,11 +75,8 @@ export type {
   AssignmentNode,
   AssignmentType,
   Diff,
-  Evaluatable,
-  EvaluationErrors,
   EvaluationResult,
   EvaluationScope,
   MathNode,
   Parse,
-  ParseErrors,
 };

--- a/client/src/util/MathScope/interfaces.ts
+++ b/client/src/util/MathScope/interfaces.ts
@@ -29,7 +29,7 @@ interface AssignmentNode<T extends AssignmentType = AssignmentType>
 }
 
 interface FunctionAssignmentNode
-  extends MathNodeBase<MathNodeType.FunctionAssignmentNode> {
+  extends AssignmentNode<MathNodeType.FunctionAssignmentNode> {
   type: MathNodeType.FunctionAssignmentNode;
   params: string[];
 }

--- a/client/src/util/MathScope/util/DiffingMap.ts
+++ b/client/src/util/MathScope/util/DiffingMap.ts
@@ -39,6 +39,10 @@ export default class DiffingMap<T, U> {
     this.areEqual = areEqual;
   }
 
+  get(key: T): U | undefined {
+    return this.map.get(key);
+  }
+
   has(key: T): boolean {
     return this.map.has(key);
   }

--- a/client/src/util/parsing/helpers.ts
+++ b/client/src/util/parsing/helpers.ts
@@ -6,7 +6,10 @@
 const splitAtFirstEquality = (text: string): [string, string] => {
   const pieces = text.split("=");
   if (pieces.length < 2) {
-    // They should have eactly one, but if they have more, that's an issue for the parser
+    /**
+     * The expression could have multiple equalities, e.g., for boolean
+     * expressions like X = a >= 2
+     */
     throw new Error(`Fatal error: Assignments should have an equality sign.`);
   }
   const [lhs, ...others] = pieces;


### PR DESCRIPTION
- This fixes a few issues with parsed function length
- merges MathScope's `parseErrors` and `evalErrors` property into one `errors` property
- gives item-specific arrays for arrays that fail to evaluate