### PR TITLE
Array parsing

### DIFF
--- a/client/src/features/sceneControls/mathItems/__tests__/variable-slider.spec.tsx
+++ b/client/src/features/sceneControls/mathItems/__tests__/variable-slider.spec.tsx
@@ -273,9 +273,9 @@ describe("Variable Slider", () => {
   );
 
   test.each([
-    { speedMultiplier: "1/2", expectedValues: [2, 4, 6, 8] },
+    { speedMultiplier: "1/2", expectedValues: [0.5, 1, 1.5, 2] },
     { speedMultiplier: "1", expectedValues: [1, 2, 3, 4] },
-    { speedMultiplier: "2", expectedValues: [0.5, 1, 1.5, 2] },
+    { speedMultiplier: "2", expectedValues: [2, 4, 6, 8] },
   ])(
     "Speeding up/down affects duration and increment size, not framerate",
     async ({ speedMultiplier, expectedValues }) => {

--- a/client/src/features/sceneControls/mathItems/__tests__/variable-slider.spec.tsx
+++ b/client/src/features/sceneControls/mathItems/__tests__/variable-slider.spec.tsx
@@ -32,9 +32,14 @@ const btnLabels = {
   decrement: "Step backward",
 };
 
-const setupTest = async (
-  overrides: Partial<MathItem<MIT.VariableSlider>["properties"]> = {}
-) => {
+const range = (min: string, max: string) => ({
+  type: "array" as const,
+  items: [min, max],
+});
+
+type Overrides = Partial<MathItem<MIT.VariableSlider>["properties"]>;
+
+const setupTest = async (overrides: Overrides = {}) => {
   const min = faker.datatype.number({ min: -10, max: -6 });
   const max = faker.datatype.number({ min: 2, max: 10 });
   const fps = faker.datatype.number({ min: 20, max: 40 });
@@ -45,9 +50,8 @@ const setupTest = async (
     precision: 0.1,
   });
   const speed = faker.helpers.arrayElement(["1/4", "1/2", "1", "2", "4"]);
-  const props = {
-    min: String(min),
-    max: String(max),
+  const props: Overrides = {
+    range: { items: [min, max].map(String), type: "array" },
     fps: String(fps),
     value: valueObj(`X=${value}`),
     duration: String(duration),
@@ -183,8 +187,7 @@ describe("Variable Slider", () => {
         // simple check that these are parsed as math
         duration: "0.6 + 0",
         fps: "10 + 0",
-        min: "-10 + 0",
-        max: "11 + 0",
+        range: range("-10 + 0", "11 + 0"),
         value: valueObj("X=6 + 0"),
       },
     },
@@ -201,8 +204,7 @@ describe("Variable Slider", () => {
         speedMultiplier: "1",
         duration: "0.4 + 0",
         fps: "20 + 0",
-        min: "4 + 0",
-        max: "10 + 0",
+        range: range("4 + 0", "10 + 0"),
         value: valueObj("X=5 + 0"),
       },
     },
@@ -278,12 +280,11 @@ describe("Variable Slider", () => {
     "Speeding up/down affects duration and increment size, not framerate",
     async ({ speedMultiplier, expectedValues }) => {
       const timeout = 1 / 5;
-      const props = {
+      const props: Overrides = {
         speedMultiplier,
         duration: "0.5",
         fps: "20",
-        min: "0",
-        max: "10",
+        range: range("0", "10"),
         value: valueObj("X=0"),
       };
       const { el, valueUpdates } = await setupTest(props);
@@ -309,8 +310,7 @@ describe("Variable Slider", () => {
   test("Renaming variable changes name in mathscope", async () => {
     const { el, store } = await setupTest({
       value: valueObj("X=1"),
-      min: "-2",
-      max: "+3",
+      range: { items: ["-2", "+3"], type: "array" },
     });
     const mathsScope = store.getState().mathItems.mathScope();
     expect(mathsScope.evalScope).toEqual(new Map(Object.entries({ X: 1 })));
@@ -352,8 +352,7 @@ describe("Variable Slider", () => {
     async ({ getInput, goodValue, badValue }) => {
       const { el } = await setupTest({
         value: valueObj("X=1"),
-        min: "-10",
-        max: "+10",
+        range: { items: ["-10", "+10"], type: "array" },
       });
       const inputEl = getInput(el);
       act(() => inputEl.focus());
@@ -379,8 +378,7 @@ describe("Variable Slider", () => {
   test("value display shows 2 digits except when set explicitly by user", async () => {
     const { el } = await setupTest({
       value: valueObj("X=0"),
-      min: "0",
-      max: "1",
+      range: { items: ["0", "1"], type: "array" },
       duration: "0.5",
       fps: "6",
       speedMultiplier: "1",

--- a/client/src/features/sceneControls/mathItems/__tests__/variable-slider.spec.tsx
+++ b/client/src/features/sceneControls/mathItems/__tests__/variable-slider.spec.tsx
@@ -410,4 +410,30 @@ describe("Variable Slider", () => {
     expect(el.slider.value).toBeCloseTo(0.4443333, 6);
     expect(el.inputRhs.value).toBe("+0.44");
   });
+
+  test("validates that min < max", async () => {
+    const { el } = await setupTest({
+      value: valueObj("X=1"),
+      range: { items: ["5", "1"], type: "array" },
+    });
+
+    const { inputMin, inputMax } = el;
+    act(() => inputMin.focus());
+    expect(inputMin).toHaveClass("has-error");
+    const tooltipMin = await screen.findByRole("tooltip");
+    expect(tooltipMin).toHaveTextContent("Minimum must be less than maximum.");
+
+    act(() => inputMax.focus());
+    expect(inputMax).toHaveClass("has-error");
+    const tooltipMax = await screen.findByRole("tooltip");
+    expect(tooltipMax).toHaveTextContent("Minimum must be less than maximum.");
+
+    await user.type(inputMax, "5");
+
+    expect(inputMin).not.toHaveClass("has-error");
+    expect(inputMax).not.toHaveClass("has-error");
+
+    expect(el.slider.min).toBe("5");
+    expect(el.slider.max).toBe("15");
+  });
 });

--- a/client/src/features/sceneControls/mathItems/forms/VariableSlider/index.tsx
+++ b/client/src/features/sceneControls/mathItems/forms/VariableSlider/index.tsx
@@ -67,7 +67,7 @@ const getSliderParameters = (
   baseDuration: number,
   speedMultiplier = 1
 ) => {
-  const duration = baseDuration * speedMultiplier;
+  const duration = baseDuration / speedMultiplier;
   const frames = fps * duration;
   const baseFrames = fps * baseDuration;
   const ms = (1 / fps) * 1000;

--- a/client/src/features/sceneControls/mathItems/forms/VariableSlider/index.tsx
+++ b/client/src/features/sceneControls/mathItems/forms/VariableSlider/index.tsx
@@ -3,12 +3,18 @@ import {
   MathItemType as MIT,
   WidgetType,
 } from "@/configs";
-import React, { useRef, useState, useEffect, useCallback } from "react";
+import React, {
+  useRef,
+  useState,
+  useEffect,
+  useCallback,
+  useMemo,
+} from "react";
 
 import Slider, { SliderProps } from "@mui/material/Slider";
 import { useInterval } from "@/util/hooks/useInterval";
 import classNames from "classnames";
-import { ParseableObjs } from "@/util/parsing";
+import { ParseableObjs, isBatchError } from "@/util/parsing";
 import SliderControls, { mustFindSpeed } from "./SliderControls";
 import type { SliderControlsProps } from "./SliderControls";
 import FieldWidget, {
@@ -20,17 +26,16 @@ import { useMathErrors, useMathResults } from "../../mathScope";
 import ItemTemplate from "../../templates/ItemTemplate";
 import { MathItemForm } from "../interfaces";
 import styles from "./slider.module.css";
-import { OnWidgetChange } from "../../FieldWidget/types";
+import { OnWidgetChange, WidgetChangeEvent } from "../../FieldWidget/types";
 
 const config = configs[MIT.VariableSlider];
 const configProps = config.properties;
 
-const errorNames = ["value", "min", "max", "fps"] as const;
+const errorNames = ["value", "range", "fps"] as const;
 const resultNames = [
   "duration",
   "value",
-  "min",
-  "max",
+  "range",
   "fps",
   "isAnimating",
 ] as const;
@@ -148,8 +153,11 @@ const VariableSlider: MathItemForm<MIT.VariableSlider> = ({ item }) => {
 
   useEffect(() => {
     setFps((v) => (typeof results.fps === "number" ? results.fps : v));
-    setMin((v) => (typeof results.min === "number" ? results.min : v));
-    setMax((v) => (typeof results.max === "number" ? results.max : v));
+    const range = results.range as [number, number] | undefined;
+    if (range) {
+      setMin(range[0]);
+      setMax(range[1]);
+    }
     setValue((v) => (typeof results.value === "number" ? results.value : v));
     setDuration((v) =>
       typeof results.duration === "number" ? results.duration : v
@@ -212,6 +220,32 @@ const VariableSlider: MathItemForm<MIT.VariableSlider> = ({ item }) => {
       onValueChange,
     ]
   );
+  const { range } = item.properties;
+  const onSetRange = useMemo(() => {
+    const setMinMax = (e: WidgetChangeEvent<string>, i: number) => {
+      const items = [...range.items];
+      items[i] = e.value;
+      const event: WidgetChangeEvent<ParseableObjs["array"]> = {
+        name: "range",
+        value: { type: "array", items },
+      };
+      onWidgetChange(event);
+    };
+    return {
+      min: (e: WidgetChangeEvent<string>) => setMinMax(e, 0),
+      max: (e: WidgetChangeEvent<string>) => setMinMax(e, 1),
+    };
+  }, [range, onWidgetChange]);
+  const rangeErrors: { min?: Error; max?: Error } = useMemo(() => {
+    if (!errors.range) return {};
+    if (isBatchError(errors.range)) {
+      return {
+        min: errors.range.errors[0],
+        max: errors.range.errors[1],
+      };
+    }
+    return { min: errors.range, max: errors.range };
+  }, [errors.range]);
   return (
     <ItemTemplate item={item} config={config}>
       <div className={styles.controlsRow}>
@@ -238,10 +272,10 @@ const VariableSlider: MathItemForm<MIT.VariableSlider> = ({ item }) => {
         <FieldWidget
           widget={WidgetType.MathValue}
           name="min"
-          error={errors.min}
-          onChange={onWidgetChange}
-          label={configProps.min.label}
-          value={item.properties.min}
+          error={rangeErrors.min}
+          onChange={onSetRange.min}
+          label="Min"
+          value={item.properties.range.items[0] as string}
         />
         <AnimatedSlider
           label={configProps.value.label}
@@ -257,10 +291,10 @@ const VariableSlider: MathItemForm<MIT.VariableSlider> = ({ item }) => {
         <FieldWidget
           widget={WidgetType.MathValue}
           name="max"
-          error={errors.max}
-          onChange={onWidgetChange}
-          label={configProps.max.label}
-          value={item.properties.max}
+          error={rangeErrors.max}
+          onChange={onSetRange.max}
+          label="Max"
+          value={item.properties.range.items[1] as string}
         />
       </div>
     </ItemTemplate>

--- a/client/src/util/MathScope/adapter.ts
+++ b/client/src/util/MathScope/adapter.ts
@@ -59,7 +59,6 @@ const parse: Parse<Parseable> = (parseable) => {
     typeof parseable === "string" ? { expr: parseable } : parseable;
   const mjsNode = math.parse(parseableObj.expr);
   const { evaluate } = mjsNode.compile();
-  // const evaluate = getValidatedEvaluate(mjsNode, parseableObj.validate);
   return convertNode(mjsNode, evaluate);
 };
 

--- a/client/src/util/MathScope/errors.ts
+++ b/client/src/util/MathScope/errors.ts
@@ -4,10 +4,4 @@ export class MathScopeError extends Error {
   }
 }
 
-export class ParsingError extends MathScopeError {}
-
 export class EvaluationError extends MathScopeError {}
-
-export interface IBatchedError {
-  errors: Map<string, Error>;
-}

--- a/client/src/util/parsing/MathJsParser.ts
+++ b/client/src/util/parsing/MathJsParser.ts
@@ -112,9 +112,9 @@ class MathJsParser implements IMathJsParser {
     return this.parse({ expr, validate });
   };
 
-  private parseArray = ({ items }: ParseableObjs["array"]) => {
+  private parseArray = ({ items, validate }: ParseableObjs["array"]) => {
     const parsed = batch(items, (item) => this.parse(item), ArrayParseError);
-    return batchNodes(parsed);
+    return batchNodes(parsed, validate);
   };
 
   parse: IMathJsParser["parse"] = (parseable) => {

--- a/client/src/util/parsing/batch.ts
+++ b/client/src/util/parsing/batch.ts
@@ -1,0 +1,76 @@
+import { AnonMathNode, EvaluationError } from "../MathScope";
+import { MathNodeType } from "../MathScope/interfaces";
+import { assertInstanceOf } from "../predicates";
+import { IBatchError, IBatchErrorCtor } from "./interfaces";
+
+class ArrayParseError extends Error implements IBatchError {
+  itemErrors: IBatchError["itemErrors"];
+
+  constructor(errors: IBatchError["itemErrors"]) {
+    const [e] = Object.values(errors);
+    super(e.message);
+    this.itemErrors = errors;
+  }
+}
+
+class ArrayEvaluationError extends EvaluationError implements IBatchError {
+  itemErrors: Record<number, Error> = {};
+
+  constructor(errors: IBatchError["itemErrors"]) {
+    const [e] = Object.values(errors);
+    super(e.message);
+    this.itemErrors = errors;
+  }
+}
+
+/**
+ * Like Array.map, but does not bail early on errors. All errors are calculated
+ * and grouped in a BatchError.
+ */
+const batch = <T, R, E extends IBatchErrorCtor>(
+  items: T[],
+  cb: (item: T, i: number, arr: T[]) => R,
+  BatchError: E
+): R[] => {
+  const itemErrors: Record<number, Error> = {};
+  const results = items.map((item, i, arr) => {
+    try {
+      return cb(item, i, arr);
+    } catch (err) {
+      assertInstanceOf(err, Error);
+      itemErrors[i] = err;
+      return undefined;
+    }
+  });
+  if (Object.keys(itemErrors).length > 0) {
+    throw new BatchError(itemErrors);
+  }
+  return results as R[];
+};
+
+const batchNodes = (nodes: AnonMathNode[]): AnonMathNode => {
+  const evaluate: AnonMathNode["evaluate"] = (scope) => {
+    return batch(nodes, (node) => node.evaluate(scope), ArrayEvaluationError);
+  };
+  const dependencies = new Set(nodes.flatMap((node) => [...node.dependencies]));
+
+  return {
+    type: MathNodeType.Value,
+    evaluate,
+    dependencies,
+  };
+};
+
+const isBatchError = (error: unknown): error is IBatchError => {
+  if (error instanceof ArrayParseError) return true;
+  if (error instanceof ArrayEvaluationError) return true;
+  return false;
+};
+
+export {
+  batchNodes,
+  batch,
+  ArrayParseError,
+  ArrayEvaluationError,
+  isBatchError,
+};

--- a/client/src/util/parsing/helpers.ts
+++ b/client/src/util/parsing/helpers.ts
@@ -33,6 +33,8 @@ interface FunctionAssignmentProps {
  * and parameter names. In this way, we can parse stirngs that MathJS's parser
  * would reject, and we can give slightly more detailed information about the
  * errors.
+ *
+ * @deprecated
  */
 class FunctionAssignment {
   readonly params: string[];
@@ -76,4 +78,4 @@ class FunctionAssignment {
   }
 }
 
-export { FunctionAssignment, splitAtFirstEquality };
+export { FunctionAssignment };

--- a/client/src/util/parsing/index.ts
+++ b/client/src/util/parsing/index.ts
@@ -1,3 +1,4 @@
 export * from "./helpers";
 export * from "./parsers";
+export * from "./batch";
 export type { Parseable, ParseableObjs } from "./interfaces";

--- a/client/src/util/parsing/interfaces.ts
+++ b/client/src/util/parsing/interfaces.ts
@@ -52,6 +52,10 @@ interface IMathJsParser {
   parse: Parse<Parseable>;
 }
 
+interface ArrayError {
+  itemErrors: Error[];
+}
+
 export { ParserRuleType };
 export type {
   Parseable,

--- a/client/src/util/parsing/interfaces.ts
+++ b/client/src/util/parsing/interfaces.ts
@@ -19,6 +19,7 @@ type ParseableObjs = {
   array: {
     type: "array";
     items: Parseable[];
+    validate?: (evaluated: unknown[]) => void;
   };
 };
 
@@ -60,7 +61,7 @@ interface IBatchErrorCtor {
   new (errors: Record<number, Error>): IBatchError;
 }
 interface IBatchError extends Error {
-  itemErrors: Record<number, Error>;
+  errors: Record<number, Error>;
 }
 
 export { ParserRuleType };

--- a/client/src/util/parsing/interfaces.ts
+++ b/client/src/util/parsing/interfaces.ts
@@ -16,6 +16,10 @@ type ParseableObjs = {
     rhs: string;
     validate?: Validate;
   };
+  array: {
+    type: "array";
+    items: Parseable[];
+  };
 };
 
 type ParseableObj = ParseableObjs[keyof ParseableObjs];
@@ -52,8 +56,11 @@ interface IMathJsParser {
   parse: Parse<Parseable>;
 }
 
-interface ArrayError {
-  itemErrors: Error[];
+interface IBatchErrorCtor {
+  new (errors: Record<number, Error>): IBatchError;
+}
+interface IBatchError extends Error {
+  itemErrors: Record<number, Error>;
 }
 
 export { ParserRuleType };
@@ -67,4 +74,6 @@ export type {
   TextParserRegexRule,
   TextParserRule,
   Validate,
+  IBatchError,
+  IBatchErrorCtor,
 };

--- a/client/src/util/parsing/parsers.spec.ts
+++ b/client/src/util/parsing/parsers.spec.ts
@@ -1,4 +1,3 @@
-import { EvaluationError } from "@/util/MathScope";
 import { assertInstanceOf } from "../predicates";
 import { DetailedAssignmentError } from "./MathJsParser";
 import { latexParser as parser } from "./parsers";

--- a/client/src/util/parsing/parsers.spec.ts
+++ b/client/src/util/parsing/parsers.spec.ts
@@ -204,11 +204,17 @@ describe("returned node's MathNode.evaluate", () => {
     ]);
   });
 
-  it("throws an error for functions that throw errors when evauated", () => {
-    const node = parse("f(x) = 2^[1,2,3]");
-    expect(() => node.evaluate()).toThrow(EvaluationError);
-    expect(() => node.evaluate()).toThrow(
-      /Unexpected type of argument in function pow/
+  it("Functions that throw errors hint at their origin", () => {
+    const nodeF = parse("f(x) = 2^[1,2,3]");
+    const f = nodeF.evaluate() as (x: number) => unknown;
+    expect(() => f(1)).toThrowError(
+      /Error evaluating f: Unexpected type of argument in function pow/
+    );
+
+    const nodeG = parse("g = f");
+    const g = nodeG.evaluate(new Map([["f", f]])) as (x: number) => unknown;
+    expect(() => g(1)).toThrowError(
+      /Error evaluating f: Unexpected type of argument in function pow/
     );
   });
 });

--- a/client/src/util/validators/index.ts
+++ b/client/src/util/validators/index.ts
@@ -1,6 +1,7 @@
 import * as yup from "yup";
 
 const num = yup.number().strict().required();
+const array = yup.array().strict().required();
 
 type Dim = 1 | 2 | 3 | 4;
 
@@ -105,4 +106,5 @@ export const realFuncSchemas = {
 export const validators = {
   real: real.validateSync.bind(real),
   positive: positive.validateSync.bind(positive),
+  array: array.validateSync.bind(array),
 };


### PR DESCRIPTION
This PR switches min/max on Sliders to be a single `range` variable. The goal was to validate that min < max.

I am fairly happy with the current approach to validation:
- parser implementations for MathScope are responsible for implementing their `evaluate` function
- a parser's `evaluate` might call some validation
- if a node's `evaluate` function fails (e.g., because of validation) then an error is added to the MathScope and a corresponding event is emitted.

One consequent of this is that validation isn't aware of anything other than the current node. So if min+max are represented by two separate nodes, we can't make a comparison like "check min < max" during validation.

Solution: represent min+max by a single range property.

One mildly awkward point is that we use separate inputs to control `range[0]` (min) and `range[1]` (max). But we mitigate that with a new ParseableObject (`type: "array"`). And we are already doing something similar for functions (separate inputs for lhs, rhs).