### PR TITLE
Range funcs

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -37,6 +37,7 @@
         "react-router-dom": "6.4.2",
         "redaxios": "0.5.1",
         "tarjan-graph": "3.0.0",
+        "tiny-invariant": "^1.3.1",
         "tinycolor2": "1.4.2",
         "toposort": "2.0.2",
         "use-long-press": "2.0.2",
@@ -24178,6 +24179,11 @@
         "globrex": "^0.1.2"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
+      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
+    },
     "node_modules/tinybench": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.3.0.tgz",
@@ -45378,6 +45384,11 @@
         "globalyzer": "0.1.0",
         "globrex": "^0.1.2"
       }
+    },
+    "tiny-invariant": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
+      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
     },
     "tinybench": {
       "version": "2.3.0",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -24,6 +24,7 @@
         "bootstrap": "5.2.2",
         "bootstrap-icons": "1.9.1",
         "classnames": "2.3.2",
+        "fast-json-patch": "^3.1.1",
         "history": "5.3.0",
         "lodash": "4.17.21",
         "mathjs": "11.2.1",
@@ -13675,6 +13676,11 @@
       "resolved": "https://registry.npmjs.org/fast-json-parse/-/fast-json-parse-1.0.3.tgz",
       "integrity": "sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw==",
       "dev": true
+    },
+    "node_modules/fast-json-patch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
+      "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ=="
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -37179,6 +37185,11 @@
       "resolved": "https://registry.npmjs.org/fast-json-parse/-/fast-json-parse-1.0.3.tgz",
       "integrity": "sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw==",
       "dev": true
+    },
+    "fast-json-patch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
+      "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ=="
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",

--- a/client/package.json
+++ b/client/package.json
@@ -55,6 +55,7 @@
     "react-router-dom": "6.4.2",
     "redaxios": "0.5.1",
     "tarjan-graph": "3.0.0",
+    "tiny-invariant": "^1.3.1",
     "tinycolor2": "1.4.2",
     "toposort": "2.0.2",
     "use-long-press": "2.0.2",

--- a/client/package.json
+++ b/client/package.json
@@ -42,6 +42,7 @@
     "bootstrap": "5.2.2",
     "bootstrap-icons": "1.9.1",
     "classnames": "2.3.2",
+    "fast-json-patch": "^3.1.1",
     "history": "5.3.0",
     "lodash": "4.17.21",
     "mathjs": "11.2.1",

--- a/client/src/api/defaultScene.ts
+++ b/client/src/api/defaultScene.ts
@@ -17,13 +17,15 @@ const defaultScene: Omit<Scene, "id"> = {
           type: "array",
           items: [
             {
-              type: "assignment",
-              lhs: "_f(y)",
+              type: "function-assignment",
+              name: "_f",
+              params: ["y"],
               rhs: "[-5, 5]",
             },
             {
-              type: "assignment",
-              lhs: "_f(x)",
+              type: "function-assignment",
+              name: "_f",
+              params: ["x"],
               rhs: "[-5, 5]",
             },
           ],

--- a/client/src/api/defaultScene.ts
+++ b/client/src/api/defaultScene.ts
@@ -13,8 +13,21 @@ const defaultScene: Omit<Scene, "id"> = {
         grid1: "8",
         grid2: "8",
         zBias: "0",
-        range1: "\\left[-2,\\ 2\\right]",
-        range2: "\\left[-2,\\ 2\\right]",
+        domain: {
+          type: "array",
+          items: [
+            {
+              type: "assignment",
+              lhs: "_f(y)",
+              rhs: "[-5, 5]",
+            },
+            {
+              type: "assignment",
+              lhs: "_f(x)",
+              rhs: "[-5, 5]",
+            },
+          ],
+        },
         shaded: "true",
         zIndex: "0",
         opacity: "0.5",

--- a/client/src/api/defaultScene.ts
+++ b/client/src/api/defaultScene.ts
@@ -8,7 +8,12 @@ const defaultScene: Omit<Scene, "id"> = {
       id: "1",
       type: MathItemType.ExplicitSurface,
       properties: {
-        expr: { lhs: "_f(x,y)", rhs: "1 - x^2 - y", type: "assignment" },
+        expr: {
+          name: "_f",
+          params: ["x", "y"],
+          rhs: "1 - x^2 - y",
+          type: "function-assignment",
+        },
         color: "#3498db",
         grid1: "8",
         grid2: "8",

--- a/client/src/configs/interfaces.ts
+++ b/client/src/configs/interfaces.ts
@@ -1,30 +1,35 @@
 import type { MathItemType, WidgetType } from "./constants";
 
-export type Validate = (value: unknown) => void;
+export type Validate<V> = (value: unknown) => V;
 
 export interface MathItemProperties {
   description: string;
 }
 
-export interface PropertyConfig<K> {
+export interface PropertyConfig<K, V = never> {
   readonly name: K;
   readonly widget: WidgetType;
   readonly label: string;
   /**
-   * Used for parsed+evaluated properties, this validator is passed to
-   * MathScope when evaluating the property.
+   * Used for parsed+evaluated properties.
+   *
+   * The default type for `V` is "never", meaning no validation.
+   * Appropriate for un-evaluated properties like `description` or `label`.
    */
-  readonly validate?: Validate;
+  readonly validate?: Validate<V>;
 }
 
 export interface IMathItemConfig<
   T extends MathItemType,
-  P extends MathItemProperties
+  P extends MathItemProperties,
+  E extends Partial<Record<keyof P, unknown>>
 > {
   type: T;
   label: string;
   properties: {
-    [K in keyof P]: K extends string ? PropertyConfig<K> : never;
+    [K in keyof P]: K extends string
+      ? PropertyConfig<K, K extends keyof E ? E[K] : never>
+      : never;
   };
   settingsProperties: (keyof P & string)[];
   /**

--- a/client/src/configs/items/axis.ts
+++ b/client/src/configs/items/axis.ts
@@ -60,7 +60,7 @@ const make: MathItemGenerator<MathItemType.Axis, AxisProperties> = (id) => ({
   properties: { ...defaultValues },
 });
 
-type EvaluatedAxisProperties = {
+type EvaluatedProperties = {
   labelVisible: boolean;
   opacity: number;
   size: number;
@@ -73,7 +73,7 @@ type EvaluatedAxisProperties = {
 const config: IMathItemConfig<
   MathItemType.Axis,
   AxisProperties,
-  EvaluatedAxisProperties
+  EvaluatedProperties
 > = {
   type: MathItemType.Axis,
   label: "Axis",

--- a/client/src/configs/items/axis.ts
+++ b/client/src/configs/items/axis.ts
@@ -60,7 +60,21 @@ const make: MathItemGenerator<MathItemType.Axis, AxisProperties> = (id) => ({
   properties: { ...defaultValues },
 });
 
-const config: IMathItemConfig<MathItemType.Axis, AxisProperties> = {
+type EvaluatedAxisProperties = {
+  labelVisible: boolean;
+  opacity: number;
+  size: number;
+  visible: boolean;
+  width: number;
+  zBias: number;
+  zIndex: number;
+};
+
+const config: IMathItemConfig<
+  MathItemType.Axis,
+  AxisProperties,
+  EvaluatedAxisProperties
+> = {
   type: MathItemType.Axis,
   label: "Axis",
   properties: {

--- a/client/src/configs/items/booleanVariable.ts
+++ b/client/src/configs/items/booleanVariable.ts
@@ -1,3 +1,4 @@
+import { validators } from "@/util/validators";
 import { MathItemType, WidgetType } from "../constants";
 import type {
   IMathItem,
@@ -25,9 +26,14 @@ const make: MathItemGenerator<
   properties: { ...defaultValues },
 });
 
+type EvaluatedProperties = {
+  value: boolean;
+};
+
 const config: IMathItemConfig<
   MathItemType.BooleanVariable,
-  BooleanVariableProperties
+  BooleanVariableProperties,
+  EvaluatedProperties
 > = {
   type: MathItemType.BooleanVariable,
   label: "Toggle Switch",
@@ -37,6 +43,7 @@ const config: IMathItemConfig<
       name: "value",
       label: "Value",
       widget: WidgetType.MathBoolean,
+      validate: validators.boolean,
     },
   },
   settingsProperties: [],

--- a/client/src/configs/items/camera.ts
+++ b/client/src/configs/items/camera.ts
@@ -1,3 +1,4 @@
+import { validators } from "@/util/validators";
 import { MathItemType, WidgetType } from "../constants";
 import type {
   IMathItem,
@@ -30,6 +31,16 @@ const defaultValues: CameraProperties = {
   useComputed: "false",
 };
 
+type EvaluatedProperties = {
+  isOrthographic: boolean;
+  isPanEnabled: boolean;
+  isZoomEnabled: boolean;
+  isRotateEnabled: boolean;
+  useComputed: boolean;
+  computedPosition: [number, number, number];
+  computedLookAt: [number, number, number];
+};
+
 const make: MathItemGenerator<MathItemType.Camera, CameraProperties> = (
   id
 ) => ({
@@ -38,7 +49,11 @@ const make: MathItemGenerator<MathItemType.Camera, CameraProperties> = (
   properties: { ...defaultValues },
 });
 
-const config: IMathItemConfig<MathItemType.Camera, CameraProperties> = {
+const config: IMathItemConfig<
+  MathItemType.Camera,
+  CameraProperties,
+  EvaluatedProperties
+> = {
   type: MathItemType.Camera,
   label: "Camera",
   properties: {
@@ -47,36 +62,43 @@ const config: IMathItemConfig<MathItemType.Camera, CameraProperties> = {
       name: "isOrthographic",
       label: "Orthographic",
       widget: WidgetType.MathBoolean,
+      validate: validators.boolean,
     },
     isPanEnabled: {
       name: "isPanEnabled",
       label: "Pan",
       widget: WidgetType.MathBoolean,
+      validate: validators.boolean,
     },
     isZoomEnabled: {
       name: "isZoomEnabled",
       label: "Zoom",
       widget: WidgetType.MathBoolean,
+      validate: validators.boolean,
     },
     isRotateEnabled: {
       name: "isRotateEnabled",
       label: "Rotate",
       widget: WidgetType.MathBoolean,
+      validate: validators.boolean,
     },
     useComputed: {
       name: "useComputed",
       label: "Use Computed",
       widget: WidgetType.MathBoolean,
+      validate: validators.boolean,
     },
     computedPosition: {
       name: "computedPosition",
       label: "Position",
       widget: WidgetType.MathValue,
+      validate: validators.realVec[3],
     },
     computedLookAt: {
       name: "computedLookAt",
       label: "Look At",
       widget: WidgetType.MathValue,
+      validate: validators.realVec[3],
     },
   },
   settingsProperties: [],

--- a/client/src/configs/items/explicitSurface.ts
+++ b/client/src/configs/items/explicitSurface.ts
@@ -13,15 +13,15 @@ import {
   grid2,
   gridWidth,
   opacity,
-  range1,
-  range2,
   shaded,
   samples1,
   visible,
   samples2,
   zBias,
   zIndex,
+  domain2,
 } from "../shared";
+import type { EvaluatedDomain2 } from "../shared";
 
 interface ExplicitSurfaceProperties {
   description: string;
@@ -32,8 +32,7 @@ interface ExplicitSurfaceProperties {
   zBias: string;
   shaded: string; // eval to boolean;
   expr: ParseableObjs["assignment"];
-  range1: string;
-  range2: string;
+  domain: ParseableObjs["array"];
   colorExpr: string;
   gridOpacity: string;
   gridWidth: string;
@@ -52,8 +51,21 @@ const defaultValues: ExplicitSurfaceProperties = {
   zBias: "0",
   shaded: "true",
   expr: { lhs: "_f(x,y)", rhs: "x^2-y^2", type: "assignment" },
-  range1: "[-2, 2]",
-  range2: "[-2, 2]",
+  domain: {
+    type: "array",
+    items: [
+      {
+        type: "assignment",
+        lhs: "_f(y)",
+        rhs: "[-5, 5]",
+      },
+      {
+        type: "assignment",
+        lhs: "_f(x)",
+        rhs: "[-5, 5]",
+      },
+    ],
+  },
   colorExpr: "_f(X, Y, Z, x, y)=mod(Z, 1)",
   gridOpacity: "0.5",
   gridWidth: "2",
@@ -78,8 +90,7 @@ type EvaluatedProperties = {
   grid2: number;
   gridWidth: number;
   opacity: number;
-  range1: [number, number];
-  range2: [number, number];
+  domain: EvaluatedDomain2;
   shaded: boolean;
   samples1: number;
   samples2: number;
@@ -106,6 +117,7 @@ const config: IMathItemConfig<
       label: "Expression",
       widget: WidgetType.MathValue,
     },
+    domain: domain2,
     color,
     description,
     gridOpacity,
@@ -113,8 +125,6 @@ const config: IMathItemConfig<
     grid2,
     gridWidth,
     opacity,
-    range1,
-    range2,
     shaded,
     samples1,
     samples2,

--- a/client/src/configs/items/explicitSurface.ts
+++ b/client/src/configs/items/explicitSurface.ts
@@ -1,4 +1,4 @@
-import { ParseableObjs } from "@/util/parsing";
+import { ParseableArray, ParseableObjs } from "@/util/parsing";
 import { MathItemType, WidgetType } from "../constants";
 import type {
   IMathItem,
@@ -32,7 +32,7 @@ interface ExplicitSurfaceProperties {
   zBias: string;
   shaded: string; // eval to boolean;
   expr: ParseableObjs["function-assignment"];
-  domain: ParseableObjs["array"];
+  domain: ParseableArray<ParseableObjs["function-assignment"]>;
   colorExpr: string;
   gridOpacity: string;
   gridWidth: string;

--- a/client/src/configs/items/explicitSurface.ts
+++ b/client/src/configs/items/explicitSurface.ts
@@ -31,7 +31,7 @@ interface ExplicitSurfaceProperties {
   zIndex: string;
   zBias: string;
   shaded: string; // eval to boolean;
-  expr: ParseableObjs["assignment"];
+  expr: ParseableObjs["function-assignment"];
   domain: ParseableObjs["array"];
   colorExpr: string;
   gridOpacity: string;
@@ -50,7 +50,12 @@ const defaultValues: ExplicitSurfaceProperties = {
   zIndex: "0",
   zBias: "0",
   shaded: "true",
-  expr: { lhs: "_f(x,y)", rhs: "x^2-y^2", type: "assignment" },
+  expr: {
+    type: "function-assignment",
+    name: "_f",
+    params: ["x", "y"],
+    rhs: "x^2-y^2",
+  },
   domain: {
     type: "array",
     items: [

--- a/client/src/configs/items/explicitSurface.ts
+++ b/client/src/configs/items/explicitSurface.ts
@@ -55,13 +55,15 @@ const defaultValues: ExplicitSurfaceProperties = {
     type: "array",
     items: [
       {
-        type: "assignment",
-        lhs: "_f(y)",
+        type: "function-assignment",
+        name: "_f",
+        params: ["y"],
         rhs: "[-5, 5]",
       },
       {
-        type: "assignment",
-        lhs: "_f(x)",
+        type: "function-assignment",
+        name: "_f",
+        params: ["x"],
         rhs: "[-5, 5]",
       },
     ],

--- a/client/src/configs/items/explicitSurface.ts
+++ b/client/src/configs/items/explicitSurface.ts
@@ -72,9 +72,26 @@ const make: MathItemGenerator<
   properties: { ...defaultValues },
 });
 
+type EvaluatedProperties = {
+  gridOpacity: number;
+  grid1: number;
+  grid2: number;
+  gridWidth: number;
+  opacity: number;
+  range1: [number, number];
+  range2: [number, number];
+  shaded: boolean;
+  samples1: number;
+  samples2: number;
+  visible: boolean;
+  zBias: number;
+  zIndex: number;
+};
+
 const config: IMathItemConfig<
   MathItemType.ExplicitSurface,
-  ExplicitSurfaceProperties
+  ExplicitSurfaceProperties,
+  EvaluatedProperties
 > = {
   type: MathItemType.ExplicitSurface,
   label: "Explicit Surface",

--- a/client/src/configs/items/explicitSurfacePolar.ts
+++ b/client/src/configs/items/explicitSurfacePolar.ts
@@ -31,7 +31,7 @@ interface ExplicitSurfacePolarProperties {
   zIndex: string;
   zBias: string;
   shaded: string; // eval to boolean;
-  expr: ParseableObjs["assignment"];
+  expr: ParseableObjs["function-assignment"];
   domain: ParseableObjs["array"];
   colorExpr: string;
   gridOpacity: string;
@@ -51,9 +51,10 @@ const defaultValues: ExplicitSurfacePolarProperties = {
   zBias: "0",
   shaded: "true",
   expr: {
-    lhs: "_f(r, Q)",
+    type: "function-assignment",
+    name: "_f",
+    params: ["r", "Q"],
     rhs: "\\frac{1}{4}r^2*cos(3*Q)]",
-    type: "assignment",
   },
   domain: {
     type: "array",

--- a/client/src/configs/items/explicitSurfacePolar.ts
+++ b/client/src/configs/items/explicitSurfacePolar.ts
@@ -13,14 +13,14 @@ import {
   grid2,
   gridWidth,
   opacity,
-  range1,
-  range2,
   shaded,
   samples1,
   visible,
   samples2,
   zBias,
   zIndex,
+  domain2,
+  EvaluatedDomain2,
 } from "../shared";
 
 interface ExplicitSurfacePolarProperties {
@@ -30,11 +30,9 @@ interface ExplicitSurfacePolarProperties {
   opacity: string;
   zIndex: string;
   zBias: string;
-
   shaded: string; // eval to boolean;
   expr: ParseableObjs["assignment"];
-  range1: string;
-  range2: string;
+  domain: ParseableObjs["array"];
   colorExpr: string;
   gridOpacity: string;
   gridWidth: string;
@@ -57,8 +55,21 @@ const defaultValues: ExplicitSurfacePolarProperties = {
     rhs: "\\frac{1}{4}r^2*cos(3*Q)]",
     type: "assignment",
   },
-  range1: "[0, 3]",
-  range2: "[-pi, pi]",
+  domain: {
+    type: "array",
+    items: [
+      {
+        type: "assignment",
+        lhs: "_f(Q)",
+        rhs: "[0, 3]",
+      },
+      {
+        type: "assignment",
+        lhs: "_f(r)",
+        rhs: "[-pi, pi]",
+      },
+    ],
+  },
   colorExpr: "_f(X, Y, Z, r, theta)=mod(Z, 1)",
   gridOpacity: "0.5",
   gridWidth: "2",
@@ -83,8 +94,7 @@ type EvaluatedProperties = {
   grid2: number;
   gridWidth: number;
   opacity: number;
-  range1: [number, number];
-  range2: [number, number];
+  domain: EvaluatedDomain2;
   shaded: boolean;
   samples1: number;
   samples2: number;
@@ -118,8 +128,7 @@ const config: IMathItemConfig<
     grid2,
     gridWidth,
     opacity,
-    range1,
-    range2,
+    domain: domain2,
     shaded,
     samples1,
     samples2,

--- a/client/src/configs/items/explicitSurfacePolar.ts
+++ b/client/src/configs/items/explicitSurfacePolar.ts
@@ -77,9 +77,26 @@ const make: MathItemGenerator<
   properties: { ...defaultValues },
 });
 
+type EvaluatedProperties = {
+  gridOpacity: number;
+  grid1: number;
+  grid2: number;
+  gridWidth: number;
+  opacity: number;
+  range1: [number, number];
+  range2: [number, number];
+  shaded: boolean;
+  samples1: number;
+  samples2: number;
+  visible: boolean;
+  zBias: number;
+  zIndex: number;
+};
+
 const config: IMathItemConfig<
   MathItemType.ExplicitSurfacePolar,
-  ExplicitSurfacePolarProperties
+  ExplicitSurfacePolarProperties,
+  EvaluatedProperties
 > = {
   type: MathItemType.ExplicitSurfacePolar,
   label: "Explicit Surface (Polar)",

--- a/client/src/configs/items/explicitSurfacePolar.ts
+++ b/client/src/configs/items/explicitSurfacePolar.ts
@@ -1,4 +1,4 @@
-import { ParseableObjs } from "@/util/parsing";
+import { ParseableArray, ParseableObjs } from "@/util/parsing";
 import { MathItemType, WidgetType } from "../constants";
 import type {
   IMathItem,
@@ -32,7 +32,7 @@ interface ExplicitSurfacePolarProperties {
   zBias: string;
   shaded: string; // eval to boolean;
   expr: ParseableObjs["function-assignment"];
-  domain: ParseableObjs["array"];
+  domain: ParseableArray<ParseableObjs["function-assignment"]>;
   colorExpr: string;
   gridOpacity: string;
   gridWidth: string;

--- a/client/src/configs/items/explicitSurfacePolar.ts
+++ b/client/src/configs/items/explicitSurfacePolar.ts
@@ -59,13 +59,15 @@ const defaultValues: ExplicitSurfacePolarProperties = {
     type: "array",
     items: [
       {
-        type: "assignment",
-        lhs: "_f(Q)",
+        type: "function-assignment",
+        name: "_f",
+        params: ["Q"],
         rhs: "[0, 3]",
       },
       {
-        type: "assignment",
-        lhs: "_f(r)",
+        type: "function-assignment",
+        name: "_f",
+        params: ["r"],
         rhs: "[-pi, pi]",
       },
     ],

--- a/client/src/configs/items/folder.ts
+++ b/client/src/configs/items/folder.ts
@@ -1,3 +1,4 @@
+import { validators } from "@/util/validators";
 import { MathItemType, WidgetType } from "../constants";
 import type {
   IMathItem,
@@ -24,7 +25,15 @@ const make: MathItemGenerator<MathItemType.Folder, FolderProperties> = (
   properties: { ...defaultValues },
 });
 
-const config: IMathItemConfig<MathItemType.Folder, FolderProperties> = {
+type EvaluatedProperties = {
+  isCollapsed: boolean;
+};
+
+const config: IMathItemConfig<
+  MathItemType.Folder,
+  FolderProperties,
+  EvaluatedProperties
+> = {
   type: MathItemType.Folder,
   label: "Folder",
   properties: {
@@ -33,6 +42,7 @@ const config: IMathItemConfig<MathItemType.Folder, FolderProperties> = {
       name: "isCollapsed",
       label: "Collapse Folder",
       widget: WidgetType.MathBoolean,
+      validate: validators.boolean,
     },
   },
   settingsProperties: [],

--- a/client/src/configs/items/grid.ts
+++ b/client/src/configs/items/grid.ts
@@ -47,7 +47,20 @@ const make: MathItemGenerator<MathItemType.Grid, GridProperties> = (id) => ({
   properties: { ...defaultValues },
 });
 
-const config: IMathItemConfig<MathItemType.Grid, GridProperties> = {
+type EvaluatedProperties = {
+  divisions: number;
+  opacity: number;
+  visible: boolean;
+  width: number;
+  zBias: number;
+  zIndex: number;
+};
+
+const config: IMathItemConfig<
+  MathItemType.Grid,
+  GridProperties,
+  EvaluatedProperties
+> = {
   type: MathItemType.Grid,
   label: "Grid",
   properties: {

--- a/client/src/configs/items/implicitSurface.ts
+++ b/client/src/configs/items/implicitSurface.ts
@@ -1,4 +1,4 @@
-import { ParseableObjs } from "@/util/parsing";
+import { ParseableArray, ParseableObjs } from "@/util/parsing";
 import { MathItemType, WidgetType } from "../constants";
 import type {
   IMathItem,
@@ -26,7 +26,7 @@ interface ImplicitSurfaceProperties {
   zBias: string;
 
   shaded: string; // eval to boolean;
-  domain: ParseableObjs["array"];
+  domain: ParseableArray<ParseableObjs["function-assignment"]>;
   lhs: ParseableObjs["function-assignment"];
   rhs: ParseableObjs["function-assignment"];
   samples: string;

--- a/client/src/configs/items/implicitSurface.ts
+++ b/client/src/configs/items/implicitSurface.ts
@@ -1,4 +1,5 @@
 import { ParseableObjs } from "@/util/parsing";
+import { validators } from "@/util/validators";
 import { MathItemType, WidgetType } from "../constants";
 import type {
   IMathItem,
@@ -57,9 +58,21 @@ const make: MathItemGenerator<
   properties: { ...defaultValues },
 });
 
+type EvaluatedProperties = {
+  opacity: number;
+  range1: [number, number];
+  range2: [number, number];
+  range3: [number, number];
+  shaded: boolean;
+  visible: boolean;
+  zBias: number;
+  zIndex: number;
+};
+
 const config: IMathItemConfig<
   MathItemType.ImplicitSurface,
-  ImplicitSurfaceProperties
+  ImplicitSurfaceProperties,
+  EvaluatedProperties
 > = {
   type: MathItemType.ImplicitSurface,
   label: "Implicit Surface",
@@ -79,16 +92,19 @@ const config: IMathItemConfig<
       name: "range1",
       label: "Range X",
       widget: WidgetType.MathValue,
+      validate: validators.realVec[2],
     },
     range2: {
       name: "range2",
       label: "Range X",
       widget: WidgetType.MathValue,
+      validate: validators.realVec[2],
     },
     range3: {
       name: "range3",
       label: "Range X",
       widget: WidgetType.MathValue,
+      validate: validators.realVec[2],
     },
     lhs: {
       name: "lhs",

--- a/client/src/configs/items/implicitSurface.ts
+++ b/client/src/configs/items/implicitSurface.ts
@@ -27,8 +27,8 @@ interface ImplicitSurfaceProperties {
 
   shaded: string; // eval to boolean;
   domain: ParseableObjs["array"];
-  lhs: ParseableObjs["assignment"];
-  rhs: ParseableObjs["assignment"];
+  lhs: ParseableObjs["function-assignment"];
+  rhs: ParseableObjs["function-assignment"];
   samples: string;
 }
 
@@ -63,8 +63,18 @@ const defaultValues: ImplicitSurfaceProperties = {
       },
     ],
   },
-  lhs: { lhs: "_f(x,y,z)", rhs: "x^2+y^2", type: "assignment" },
-  rhs: { lhs: "_f(x,y,z)", rhs: "z^2+1", type: "assignment" },
+  lhs: {
+    type: "function-assignment",
+    name: "_f",
+    params: ["x", "y", "z"],
+    rhs: "x^2+y^2",
+  },
+  rhs: {
+    type: "function-assignment",
+    name: "_f",
+    params: ["x", "y", "z"],
+    rhs: "z^2 + 1",
+  },
   samples: "20",
 };
 

--- a/client/src/configs/items/implicitSurface.ts
+++ b/client/src/configs/items/implicitSurface.ts
@@ -1,5 +1,4 @@
 import { ParseableObjs } from "@/util/parsing";
-import { validators } from "@/util/validators";
 import { MathItemType, WidgetType } from "../constants";
 import type {
   IMathItem,
@@ -9,6 +8,8 @@ import type {
 import {
   color,
   description,
+  domain3,
+  EvaluatedDomain3,
   opacity,
   shaded,
   visible,
@@ -25,9 +26,7 @@ interface ImplicitSurfaceProperties {
   zBias: string;
 
   shaded: string; // eval to boolean;
-  range1: string;
-  range2: string;
-  range3: string;
+  domain: ParseableObjs["array"];
   lhs: ParseableObjs["assignment"];
   rhs: ParseableObjs["assignment"];
   samples: string;
@@ -41,9 +40,26 @@ const defaultValues: ImplicitSurfaceProperties = {
   zIndex: "0",
   zBias: "0",
   shaded: "true",
-  range1: "[-5, 5]",
-  range2: "[-5, 5]",
-  range3: "[-5, 5]",
+  domain: {
+    type: "array",
+    items: [
+      {
+        type: "assignment",
+        lhs: "_f(y, z)",
+        rhs: "[-5, 5]",
+      },
+      {
+        type: "assignment",
+        lhs: "_f(x, z)",
+        rhs: "[-5, 5]",
+      },
+      {
+        type: "assignment",
+        lhs: "_f(x, y)",
+        rhs: "[-5, 5]",
+      },
+    ],
+  },
   lhs: { lhs: "_f(x,y,z)", rhs: "x^2+y^2", type: "assignment" },
   rhs: { lhs: "_f(x,y,z)", rhs: "z^2+1", type: "assignment" },
   samples: "20",
@@ -60,9 +76,7 @@ const make: MathItemGenerator<
 
 type EvaluatedProperties = {
   opacity: number;
-  range1: [number, number];
-  range2: [number, number];
-  range3: [number, number];
+  domain: EvaluatedDomain3;
   shaded: boolean;
   visible: boolean;
   zBias: number;
@@ -88,24 +102,7 @@ const config: IMathItemConfig<
       // scalar value used for x, y, z... why different from other surfaces?
     },
     shaded,
-    range1: {
-      name: "range1",
-      label: "Range X",
-      widget: WidgetType.MathValue,
-      validate: validators.realVec[2],
-    },
-    range2: {
-      name: "range2",
-      label: "Range X",
-      widget: WidgetType.MathValue,
-      validate: validators.realVec[2],
-    },
-    range3: {
-      name: "range3",
-      label: "Range X",
-      widget: WidgetType.MathValue,
-      validate: validators.realVec[2],
-    },
+    domain: domain3,
     lhs: {
       name: "lhs",
       label: "Left-hand side",

--- a/client/src/configs/items/implicitSurface.ts
+++ b/client/src/configs/items/implicitSurface.ts
@@ -44,18 +44,21 @@ const defaultValues: ImplicitSurfaceProperties = {
     type: "array",
     items: [
       {
-        type: "assignment",
-        lhs: "_f(y, z)",
+        type: "function-assignment",
+        name: "_f",
+        params: ["y", "z"],
         rhs: "[-5, 5]",
       },
       {
-        type: "assignment",
-        lhs: "_f(x, z)",
+        type: "function-assignment",
+        name: "_f",
+        params: ["x", "z"],
         rhs: "[-5, 5]",
       },
       {
-        type: "assignment",
-        lhs: "_f(x, y)",
+        type: "function-assignment",
+        name: "_f",
+        params: ["x", "y"],
         rhs: "[-5, 5]",
       },
     ],

--- a/client/src/configs/items/line.ts
+++ b/client/src/configs/items/line.ts
@@ -58,7 +58,24 @@ const make: MathItemGenerator<MathItemType.Line, LineProperties> = (id) => ({
   properties: { ...defaultValues },
 });
 
-const config: IMathItemConfig<MathItemType.Line, LineProperties> = {
+type EvaluatedProperties = {
+  coords: [number, number, number] | [number, number, number][];
+  labelVisible: boolean;
+  opacity: number;
+  visible: boolean;
+  size: number;
+  width: number;
+  zBias: number;
+  zIndex: number;
+  start: boolean;
+  end: boolean;
+};
+
+const config: IMathItemConfig<
+  MathItemType.Line,
+  LineProperties,
+  EvaluatedProperties
+> = {
   type: MathItemType.Line,
   label: "Line",
   properties: {

--- a/client/src/configs/items/parametricCurve.ts
+++ b/client/src/configs/items/parametricCurve.ts
@@ -8,6 +8,7 @@ import type {
 import {
   color,
   description,
+  domain1,
   end,
   opacity,
   size,
@@ -16,8 +17,8 @@ import {
   width,
   zBias,
   zIndex,
-  range1,
   samples1,
+  EvaluatedDomain1,
 } from "../shared";
 
 interface ParametricCurveProperties {
@@ -33,7 +34,7 @@ interface ParametricCurveProperties {
   start: string; // eval to boolean;
   end: string; // eval to boolean;
   expr: ParseableObjs["assignment"];
-  range1: string;
+  domain: ParseableObjs["array"];
   samples1: string;
 }
 
@@ -49,7 +50,16 @@ const defaultValues: ParametricCurveProperties = {
   start: "false",
   end: "false",
   expr: { lhs: "_f(t)", rhs: "[cos(t), sin(t), t]", type: "assignment" },
-  range1: "[-2*pi, 2*pi]",
+  domain: {
+    type: "array",
+    items: [
+      {
+        type: "assignment",
+        lhs: "_f()",
+        rhs: "[-2*pi, 2*pi]",
+      },
+    ],
+  },
   samples1: "128",
 };
 
@@ -71,8 +81,8 @@ type EvaluatedProperties = {
   zIndex: number;
   start: boolean;
   end: boolean;
-  range1: [number, number];
   samples1: number;
+  domain: EvaluatedDomain1;
 };
 
 const config: IMathItemConfig<
@@ -98,7 +108,7 @@ const config: IMathItemConfig<
     zIndex,
     start,
     end,
-    range1: { ...range1, label: "Range" },
+    domain: domain1,
     samples1: { ...samples1, label: "Samples" },
   },
   settingsProperties: [

--- a/client/src/configs/items/parametricCurve.ts
+++ b/client/src/configs/items/parametricCurve.ts
@@ -1,4 +1,4 @@
-import { ParseableObjs } from "@/util/parsing";
+import { ParseableArray, ParseableObjs } from "@/util/parsing";
 import { MathItemType, WidgetType } from "../constants";
 import type {
   IMathItem,
@@ -34,7 +34,7 @@ interface ParametricCurveProperties {
   start: string; // eval to boolean;
   end: string; // eval to boolean;
   expr: ParseableObjs["function-assignment"];
-  domain: ParseableObjs["array"];
+  domain: ParseableArray<ParseableObjs["function-assignment"]>;
   samples1: string;
 }
 

--- a/client/src/configs/items/parametricCurve.ts
+++ b/client/src/configs/items/parametricCurve.ts
@@ -33,7 +33,7 @@ interface ParametricCurveProperties {
   width: string;
   start: string; // eval to boolean;
   end: string; // eval to boolean;
-  expr: ParseableObjs["assignment"];
+  expr: ParseableObjs["function-assignment"];
   domain: ParseableObjs["array"];
   samples1: string;
 }
@@ -49,7 +49,12 @@ const defaultValues: ParametricCurveProperties = {
   width: "4",
   start: "false",
   end: "false",
-  expr: { lhs: "_f(t)", rhs: "[cos(t), sin(t), t]", type: "assignment" },
+  expr: {
+    type: "function-assignment",
+    name: "_f",
+    params: ["t"],
+    rhs: "[cos(t), sin(t), t]",
+  },
   domain: {
     type: "array",
     items: [

--- a/client/src/configs/items/parametricCurve.ts
+++ b/client/src/configs/items/parametricCurve.ts
@@ -54,8 +54,9 @@ const defaultValues: ParametricCurveProperties = {
     type: "array",
     items: [
       {
-        type: "assignment",
-        lhs: "_f()",
+        type: "function-assignment",
+        name: "_f",
+        params: [],
         rhs: "[-2*pi, 2*pi]",
       },
     ],

--- a/client/src/configs/items/parametricCurve.ts
+++ b/client/src/configs/items/parametricCurve.ts
@@ -62,9 +62,23 @@ const make: MathItemGenerator<
   properties: { ...defaultValues },
 });
 
+type EvaluatedProperties = {
+  opacity: number;
+  visible: boolean;
+  size: number;
+  width: number;
+  zBias: number;
+  zIndex: number;
+  start: boolean;
+  end: boolean;
+  range1: [number, number];
+  samples1: number;
+};
+
 const config: IMathItemConfig<
   MathItemType.ParametricCurve,
-  ParametricCurveProperties
+  ParametricCurveProperties,
+  EvaluatedProperties
 > = {
   type: MathItemType.ParametricCurve,
   label: "Parametric Curve",

--- a/client/src/configs/items/parametricSurface.ts
+++ b/client/src/configs/items/parametricSurface.ts
@@ -13,8 +13,7 @@ import {
   grid2,
   gridWidth,
   opacity,
-  range1,
-  range2,
+  domain2,
   shaded,
   samples1,
   visible,
@@ -22,6 +21,7 @@ import {
   zBias,
   zIndex,
 } from "../shared";
+import type { EvaluatedDomain2 } from "../shared";
 
 interface ParametricSurfaceProperties {
   description: string;
@@ -33,8 +33,7 @@ interface ParametricSurfaceProperties {
 
   shaded: string; // eval to boolean;
   expr: ParseableObjs["assignment"];
-  range1: string;
-  range2: string;
+  domain: ParseableObjs["array"];
   colorExpr: string;
   gridOpacity: string;
   gridWidth: string;
@@ -57,8 +56,21 @@ const defaultValues: ParametricSurfaceProperties = {
     rhs: "[u^2-v^2, 2*u*v, u^2+v^2]",
     type: "assignment",
   },
-  range1: "[-pi, pi]",
-  range2: "[-3, 3]",
+  domain: {
+    type: "array",
+    items: [
+      {
+        type: "assignment",
+        lhs: "_f(v)",
+        rhs: "[-pi, pi]",
+      },
+      {
+        type: "assignment",
+        lhs: "_f(u)",
+        rhs: "[-3, 3]",
+      },
+    ],
+  },
   colorExpr: "_f(X, Y, Z, u, v)=mod(Z, 1)",
   gridOpacity: "0.5",
   gridWidth: "2",
@@ -83,8 +95,7 @@ type EvaluatedProperties = {
   grid2: number;
   gridWidth: number;
   opacity: number;
-  range1: [number, number];
-  range2: [number, number];
+  domain: EvaluatedDomain2;
   shaded: boolean;
   samples1: number;
   samples2: number;
@@ -113,13 +124,12 @@ const config: IMathItemConfig<
     },
     color,
     description,
+    domain: domain2,
     gridOpacity,
     grid1,
     grid2,
     gridWidth,
     opacity,
-    range1,
-    range2,
     shaded,
     samples1,
     samples2,

--- a/client/src/configs/items/parametricSurface.ts
+++ b/client/src/configs/items/parametricSurface.ts
@@ -32,7 +32,7 @@ interface ParametricSurfaceProperties {
   zBias: string;
 
   shaded: string; // eval to boolean;
-  expr: ParseableObjs["assignment"];
+  expr: ParseableObjs["function-assignment"];
   domain: ParseableObjs["array"];
   colorExpr: string;
   gridOpacity: string;
@@ -52,9 +52,10 @@ const defaultValues: ParametricSurfaceProperties = {
   zBias: "0",
   shaded: "true",
   expr: {
-    lhs: "_f(u,v)",
+    type: "function-assignment",
+    name: "_f",
+    params: ["u", "v"],
     rhs: "[u^2-v^2, 2*u*v, u^2+v^2]",
-    type: "assignment",
   },
   domain: {
     type: "array",

--- a/client/src/configs/items/parametricSurface.ts
+++ b/client/src/configs/items/parametricSurface.ts
@@ -1,4 +1,4 @@
-import { ParseableObjs } from "@/util/parsing";
+import { ParseableArray, ParseableObjs } from "@/util/parsing";
 import { MathItemType, WidgetType } from "../constants";
 import type {
   IMathItem,
@@ -33,7 +33,7 @@ interface ParametricSurfaceProperties {
 
   shaded: string; // eval to boolean;
   expr: ParseableObjs["function-assignment"];
-  domain: ParseableObjs["array"];
+  domain: ParseableArray<ParseableObjs["function-assignment"]>;
   colorExpr: string;
   gridOpacity: string;
   gridWidth: string;

--- a/client/src/configs/items/parametricSurface.ts
+++ b/client/src/configs/items/parametricSurface.ts
@@ -60,13 +60,15 @@ const defaultValues: ParametricSurfaceProperties = {
     type: "array",
     items: [
       {
-        type: "assignment",
-        lhs: "_f(v)",
+        type: "function-assignment",
+        name: "_f",
+        params: ["v"],
         rhs: "[-pi, pi]",
       },
       {
-        type: "assignment",
-        lhs: "_f(u)",
+        type: "function-assignment",
+        name: "_f",
+        params: ["u"],
         rhs: "[-3, 3]",
       },
     ],

--- a/client/src/configs/items/parametricSurface.ts
+++ b/client/src/configs/items/parametricSurface.ts
@@ -77,9 +77,26 @@ const make: MathItemGenerator<
   properties: { ...defaultValues },
 });
 
+type EvaluatedProperties = {
+  gridOpacity: number;
+  grid1: number;
+  grid2: number;
+  gridWidth: number;
+  opacity: number;
+  range1: [number, number];
+  range2: [number, number];
+  shaded: boolean;
+  samples1: number;
+  samples2: number;
+  visible: boolean;
+  zBias: number;
+  zIndex: number;
+};
+
 const config: IMathItemConfig<
   MathItemType.ParametricSurface,
-  ParametricSurfaceProperties
+  ParametricSurfaceProperties,
+  EvaluatedProperties
 > = {
   type: MathItemType.ParametricSurface,
   label: "Parametric Surface",

--- a/client/src/configs/items/point.ts
+++ b/client/src/configs/items/point.ts
@@ -1,3 +1,4 @@
+import { validators } from "@/util/validators";
 import { MathItemType, WidgetType } from "../constants";
 import type {
   IMathItem,
@@ -40,7 +41,7 @@ export interface EvaluatedProperties {
 
   label: string;
   labelVisible: boolean;
-  coords: string;
+  coords: [number, number, number];
   size: number;
 }
 
@@ -63,7 +64,11 @@ const make: MathItemGenerator<MathItemType.Point, PointProperties> = (id) => ({
   properties: { ...defaultValues },
 });
 
-const config: IMathItemConfig<MathItemType.Point, PointProperties> = {
+const config: IMathItemConfig<
+  MathItemType.Point,
+  PointProperties,
+  EvaluatedProperties
+> = {
   type: MathItemType.Point,
   label: "Point",
   properties: {
@@ -72,10 +77,7 @@ const config: IMathItemConfig<MathItemType.Point, PointProperties> = {
       name: "coords",
       label: "Coordinates",
       widget: WidgetType.MathValue,
-      validate: (v) => {
-        if (!Array.isArray(v)) throw new Error("noooo");
-        if (v.length !== 3) throw new Error("nooooo");
-      },
+      validate: validators.realVec[3],
     },
     description,
     label,

--- a/client/src/configs/items/variable.ts
+++ b/client/src/configs/items/variable.ts
@@ -25,7 +25,15 @@ const make: MathItemGenerator<MathItemType.Variable, VariableProperties> = (
   properties: { ...defaultValues },
 });
 
-const config: IMathItemConfig<MathItemType.Variable, VariableProperties> = {
+type EvaluatedProperties = {
+  value: unknown;
+};
+
+const config: IMathItemConfig<
+  MathItemType.Variable,
+  VariableProperties,
+  EvaluatedProperties
+> = {
   type: MathItemType.Variable,
   label: "Variable or Function",
   properties: {

--- a/client/src/configs/items/variableSlider.ts
+++ b/client/src/configs/items/variableSlider.ts
@@ -40,9 +40,18 @@ const make: MathItemGenerator<
   properties: { ...defaultValues },
 });
 
+type Evaluated = {
+  range: [number, number];
+  duration: number;
+  fps: number;
+  value: number;
+  speedMultiplier: number;
+};
+
 const config: IMathItemConfig<
   MathItemType.VariableSlider,
-  VariableSliderProperties
+  VariableSliderProperties,
+  Evaluated
 > = {
   type: MathItemType.VariableSlider,
   label: "Variable Slider",
@@ -71,6 +80,7 @@ const config: IMathItemConfig<
         if (min >= max) {
           throw new Error("Minimum must be less than maximum.");
         }
+        return [min, max];
       },
     },
     value: {

--- a/client/src/configs/items/variableSlider.ts
+++ b/client/src/configs/items/variableSlider.ts
@@ -46,6 +46,7 @@ type Evaluated = {
   fps: number;
   value: number;
   speedMultiplier: number;
+  isAnimating: boolean;
 };
 
 const config: IMathItemConfig<
@@ -93,6 +94,7 @@ const config: IMathItemConfig<
       name: "isAnimating",
       label: "Animating",
       widget: WidgetType.MathBoolean,
+      validate: validators.boolean,
     },
     speedMultiplier: {
       name: "speedMultiplier",

--- a/client/src/configs/items/vector.ts
+++ b/client/src/configs/items/vector.ts
@@ -1,3 +1,4 @@
+import { validators } from "@/util/validators";
 import { MathItemType, WidgetType } from "../constants";
 import type {
   IMathItem,
@@ -62,7 +63,24 @@ const make: MathItemGenerator<MathItemType.Vector, VectorProperties> = (
   properties: { ...defaultValues },
 });
 
-const config: IMathItemConfig<MathItemType.Vector, VectorProperties> = {
+type EvaluatedProperties = {
+  visible: boolean;
+  size: number;
+  width: number;
+  zBias: number;
+  zIndex: number;
+  start: boolean;
+  end: boolean;
+  labelVisible: boolean;
+  opacity: number;
+  tail: [number, number, number];
+};
+
+const config: IMathItemConfig<
+  MathItemType.Vector,
+  VectorProperties,
+  EvaluatedProperties
+> = {
   type: MathItemType.Vector,
   label: "Vector",
   properties: {
@@ -80,6 +98,7 @@ const config: IMathItemConfig<MathItemType.Vector, VectorProperties> = {
       name: "tail",
       label: "Tail Coordinates",
       widget: WidgetType.MathValue,
+      validate: validators.realVec[3],
     },
     visible,
     size,

--- a/client/src/configs/items/vectorField.ts
+++ b/client/src/configs/items/vectorField.ts
@@ -36,7 +36,7 @@ interface VectorFieldProperties {
   start: string; // eval to boolean;
   end: string; // eval to boolean;
   domain: ParseableObjs["array"];
-  expr: string;
+  expr: ParseableObjs["function-assignment"];
   samples1: string;
   samples2: string;
   samples3: string;
@@ -77,7 +77,12 @@ const defaultValues: VectorFieldProperties = {
       },
     ],
   },
-  expr: "_f(x,y,z)=[y, -x]/sqrt(x^2 + y^2)",
+  expr: {
+    type: "function-assignment",
+    name: "_f",
+    params: ["x", "y", "z"],
+    rhs: "[y, -x]/sqrt(x^2 + y^2)",
+  },
   samples1: "10",
   samples2: "10",
   samples3: "5",

--- a/client/src/configs/items/vectorField.ts
+++ b/client/src/configs/items/vectorField.ts
@@ -1,4 +1,4 @@
-import { ParseableObjs } from "@/util/parsing";
+import { ParseableArray, ParseableObjs } from "@/util/parsing";
 import { MathItemType, WidgetType } from "../constants";
 import type {
   IMathItem,
@@ -35,7 +35,7 @@ interface VectorFieldProperties {
   width: string;
   start: string; // eval to boolean;
   end: string; // eval to boolean;
-  domain: ParseableObjs["array"];
+  domain: ParseableArray<ParseableObjs["function-assignment"]>;
   expr: ParseableObjs["function-assignment"];
   samples1: string;
   samples2: string;

--- a/client/src/configs/items/vectorField.ts
+++ b/client/src/configs/items/vectorField.ts
@@ -58,18 +58,21 @@ const defaultValues: VectorFieldProperties = {
     type: "array",
     items: [
       {
-        type: "assignment",
-        lhs: "_f(y, z)",
+        type: "function-assignment",
+        name: "_f",
+        params: ["y", "z"],
         rhs: "[-5, 5]",
       },
       {
-        type: "assignment",
-        lhs: "_f(x, z)",
+        type: "function-assignment",
+        name: "_f",
+        params: ["x", "z"],
         rhs: "[-5, 5]",
       },
       {
-        type: "assignment",
-        lhs: "_f(x, y)",
+        type: "function-assignment",
+        name: "_f",
+        params: ["x", "y"],
         rhs: "[-5, 5]",
       },
     ],

--- a/client/src/configs/items/vectorField.ts
+++ b/client/src/configs/items/vectorField.ts
@@ -1,3 +1,4 @@
+import { ParseableObjs } from "@/util/parsing";
 import { MathItemType, WidgetType } from "../constants";
 import type {
   IMathItem,
@@ -7,11 +8,10 @@ import type {
 import {
   color,
   description,
+  domain3,
   end,
+  EvaluatedDomain3,
   opacity,
-  range1,
-  range2,
-  range3,
   samples1,
   samples2,
   samples3,
@@ -35,9 +35,7 @@ interface VectorFieldProperties {
   width: string;
   start: string; // eval to boolean;
   end: string; // eval to boolean;
-  range1: string;
-  range2: string;
-  range3: string;
+  domain: ParseableObjs["array"];
   expr: string;
   samples1: string;
   samples2: string;
@@ -56,9 +54,26 @@ const defaultValues: VectorFieldProperties = {
   width: "2",
   start: "false",
   end: "true",
-  range1: "[-5,5]",
-  range2: "[-5,5]",
-  range3: "[-5,5]",
+  domain: {
+    type: "array",
+    items: [
+      {
+        type: "assignment",
+        lhs: "_f(y, z)",
+        rhs: "[-5, 5]",
+      },
+      {
+        type: "assignment",
+        lhs: "_f(x, z)",
+        rhs: "[-5, 5]",
+      },
+      {
+        type: "assignment",
+        lhs: "_f(x, y)",
+        rhs: "[-5, 5]",
+      },
+    ],
+  },
   expr: "_f(x,y,z)=[y, -x]/sqrt(x^2 + y^2)",
   samples1: "10",
   samples2: "10",
@@ -84,9 +99,7 @@ type EvaluatedProperties = {
   width: number;
   start: boolean;
   end: boolean;
-  range1: [number, number];
-  range2: [number, number];
-  range3: [number, number];
+  domain: EvaluatedDomain3;
   samples1: number;
   samples2: number;
   samples3: number;
@@ -111,9 +124,7 @@ const config: IMathItemConfig<
     width,
     start,
     end,
-    range1,
-    range2,
-    range3,
+    domain: domain3,
     samples1,
     samples2,
     samples3,

--- a/client/src/configs/items/vectorField.ts
+++ b/client/src/configs/items/vectorField.ts
@@ -75,53 +75,74 @@ const make: MathItemGenerator<
   properties: { ...defaultValues },
 });
 
-const config: IMathItemConfig<MathItemType.VectorField, VectorFieldProperties> =
-  {
-    type: MathItemType.VectorField,
-    label: "Vector Field",
-    properties: {
-      color,
-      description,
-      opacity,
-      visible,
-      zBias,
-      zIndex,
-      size,
-      width,
-      start,
-      end,
-      range1,
-      range2,
-      range3,
-      samples1,
-      samples2,
-      samples3,
-      scale: {
-        name: "scale",
-        label: "Scale Multiplier",
-        widget: WidgetType.MathValue,
-      },
-      expr: {
-        name: "expr",
-        label: "Expression",
-        widget: WidgetType.MathValue,
-      },
+type EvaluatedProperties = {
+  opacity: number;
+  visible: boolean;
+  zBias: number;
+  zIndex: number;
+  size: number;
+  width: number;
+  start: boolean;
+  end: boolean;
+  range1: [number, number];
+  range2: [number, number];
+  range3: [number, number];
+  samples1: number;
+  samples2: number;
+  samples3: number;
+  scale: number;
+};
+
+const config: IMathItemConfig<
+  MathItemType.VectorField,
+  VectorFieldProperties,
+  EvaluatedProperties
+> = {
+  type: MathItemType.VectorField,
+  label: "Vector Field",
+  properties: {
+    color,
+    description,
+    opacity,
+    visible,
+    zBias,
+    zIndex,
+    size,
+    width,
+    start,
+    end,
+    range1,
+    range2,
+    range3,
+    samples1,
+    samples2,
+    samples3,
+    scale: {
+      name: "scale",
+      label: "Scale Multiplier",
+      widget: WidgetType.MathValue,
     },
-    settingsProperties: [
-      "opacity",
-      "size",
-      "start",
-      "end",
-      "samples1",
-      "samples2",
-      "samples3",
-      "scale",
-      "width",
-      "zBias",
-      "zIndex",
-    ],
-    make,
-  };
+    expr: {
+      name: "expr",
+      label: "Expression",
+      widget: WidgetType.MathValue,
+    },
+  },
+  settingsProperties: [
+    "opacity",
+    "size",
+    "start",
+    "end",
+    "samples1",
+    "samples2",
+    "samples3",
+    "scale",
+    "width",
+    "zBias",
+    "zIndex",
+  ],
+  make,
+};
 
 type VectorField = IMathItem<MathItemType.VectorField, VectorFieldProperties>;
 

--- a/client/src/configs/shared.ts
+++ b/client/src/configs/shared.ts
@@ -1,5 +1,4 @@
 import { validators } from "@/util";
-import { schema } from "@/util/validators";
 import { WidgetType } from "./constants";
 import type { PropertyConfig } from "./interfaces";
 
@@ -19,28 +18,28 @@ const gridOpacity: PropertyConfig<"gridOpacity", number> = {
   name: "gridOpacity",
   label: "Grid Opacity",
   widget: WidgetType.MathValue,
-  validate: schema.positive.validateSync,
+  validate: validators.positive,
 };
 
 const grid1: PropertyConfig<"grid1", number> = {
   name: "grid1",
   label: "Grid (1st parameter)",
   widget: WidgetType.MathValue,
-  validate: schema.positive.validateSync,
+  validate: validators.positive,
 };
 
 const grid2: PropertyConfig<"grid2", number> = {
   name: "grid2",
   label: "Grid (2nd parameter)",
   widget: WidgetType.MathValue,
-  validate: schema.positive.validateSync,
+  validate: validators.positive,
 };
 
 const gridWidth: PropertyConfig<"gridWidth", number> = {
   name: "gridWidth",
   label: "Grid Width",
   widget: WidgetType.MathValue,
-  validate: schema.positive.validateSync,
+  validate: validators.positive,
 };
 
 const label: PropertyConfig<"label"> = {
@@ -53,7 +52,7 @@ const labelVisible: PropertyConfig<"labelVisible", boolean> = {
   name: "labelVisible",
   label: "Label Visible",
   widget: WidgetType.MathBoolean,
-  validate: schema.boolean.validateSync,
+  validate: validators.boolean,
 };
 
 const opacity: PropertyConfig<"opacity", number> = {
@@ -67,97 +66,97 @@ const range1: PropertyConfig<"range1", [number, number]> = {
   name: "range1",
   label: "Range (1st parameter)",
   widget: WidgetType.MathValue,
-  validate: schema.realVectors[2].validateSync,
+  validate: validators.realVec[2],
 };
 
 const range2: PropertyConfig<"range2", [number, number]> = {
   name: "range2",
   label: "Range (2nd parameter)",
   widget: WidgetType.MathValue,
-  validate: schema.realVectors[2].validateSync,
+  validate: validators.realVec[2],
 };
 
 const range3: PropertyConfig<"range3", [number, number]> = {
   name: "range3",
   label: "Range (3rd parameter)",
   widget: WidgetType.MathValue,
-  validate: schema.realVectors[2].validateSync,
+  validate: validators.realVec[2],
 };
 
 const shaded: PropertyConfig<"shaded", boolean> = {
   name: "shaded",
   label: "Shaded",
   widget: WidgetType.MathBoolean,
-  validate: schema.boolean.validateSync,
+  validate: validators.boolean,
 };
 
 const size: PropertyConfig<"size", number> = {
   name: "size",
   label: "Size",
   widget: WidgetType.MathValue,
-  validate: schema.positive.validateSync,
+  validate: validators.positive,
 };
 
 const samples1: PropertyConfig<"samples1", number> = {
   name: "samples1",
   label: "Samples (1st parameter)",
   widget: WidgetType.MathValue,
-  validate: schema.positive.validateSync,
+  validate: validators.positive,
 };
 
 const samples2: PropertyConfig<"samples2", number> = {
   name: "samples2",
   label: "Samples (2nd parameter)",
   widget: WidgetType.MathValue,
-  validate: schema.positive.validateSync,
+  validate: validators.positive,
 };
 
 const samples3: PropertyConfig<"samples3", number> = {
   name: "samples3",
   label: "Samples (3rd parameter)",
   widget: WidgetType.MathValue,
-  validate: schema.positive.validateSync,
+  validate: validators.positive,
 };
 
 const visible: PropertyConfig<"visible", boolean> = {
   name: "visible",
   label: "Visible",
   widget: WidgetType.MathBoolean,
-  validate: schema.boolean.validateSync,
+  validate: validators.boolean,
 };
 
 const width: PropertyConfig<"width", number> = {
   name: "width",
   label: "Width",
   widget: WidgetType.MathValue,
-  validate: schema.positive.validateSync,
+  validate: validators.positive,
 };
 
 const zBias: PropertyConfig<"zBias", number> = {
   name: "zBias",
   label: "Z-Bias",
   widget: WidgetType.MathValue,
-  validate: schema.real.validateSync,
+  validate: validators.real,
 };
 
 const zIndex: PropertyConfig<"zIndex", number> = {
   name: "zIndex",
   label: "Z-Index",
   widget: WidgetType.MathValue,
-  validate: schema.real.validateSync,
+  validate: validators.real,
 };
 
 const start: PropertyConfig<"start", boolean> = {
   name: "start",
   label: "Arrow (start)",
   widget: WidgetType.MathBoolean,
-  validate: schema.boolean.validateSync,
+  validate: validators.boolean,
 };
 const end: PropertyConfig<"end", boolean> = {
   name: "end",
   label: "Arrow (end)",
   widget: WidgetType.MathBoolean,
-  validate: schema.boolean.validateSync,
+  validate: validators.boolean,
 };
 
 export {

--- a/client/src/configs/shared.ts
+++ b/client/src/configs/shared.ts
@@ -1,3 +1,5 @@
+import { validators } from "@/util";
+import { schema } from "@/util/validators";
 import { WidgetType } from "./constants";
 import type { PropertyConfig } from "./interfaces";
 
@@ -13,150 +15,149 @@ const description: PropertyConfig<"description"> = {
   widget: WidgetType.AutosizeText,
 };
 
-const gridOpacity: PropertyConfig<"gridOpacity"> = {
+const gridOpacity: PropertyConfig<"gridOpacity", number> = {
   name: "gridOpacity",
   label: "Grid Opacity",
   widget: WidgetType.MathValue,
-  // validate real number
+  validate: schema.positive.validateSync,
 };
 
-const grid1: PropertyConfig<"grid1"> = {
+const grid1: PropertyConfig<"grid1", number> = {
   name: "grid1",
   label: "Grid (1st parameter)",
   widget: WidgetType.MathValue,
-  // validate real number
+  validate: schema.positive.validateSync,
 };
 
-const grid2: PropertyConfig<"grid2"> = {
+const grid2: PropertyConfig<"grid2", number> = {
   name: "grid2",
   label: "Grid (2nd parameter)",
   widget: WidgetType.MathValue,
-  // validate real number
+  validate: schema.positive.validateSync,
 };
 
-const gridWidth: PropertyConfig<"gridWidth"> = {
+const gridWidth: PropertyConfig<"gridWidth", number> = {
   name: "gridWidth",
   label: "Grid Width",
   widget: WidgetType.MathValue,
-  // validate real number
+  validate: schema.positive.validateSync,
 };
 
 const label: PropertyConfig<"label"> = {
   name: "label",
   label: "Label",
   widget: WidgetType.Text,
-  // validate string
 };
 
-const labelVisible: PropertyConfig<"labelVisible"> = {
+const labelVisible: PropertyConfig<"labelVisible", boolean> = {
   name: "labelVisible",
   label: "Label Visible",
   widget: WidgetType.MathBoolean,
-  // validate boolean
+  validate: schema.boolean.validateSync,
 };
 
-const opacity: PropertyConfig<"opacity"> = {
+const opacity: PropertyConfig<"opacity", number> = {
   name: "opacity",
   label: "Opacity",
   widget: WidgetType.MathValue,
-  // validate real number
+  validate: validators.positive,
 };
 
-const range1: PropertyConfig<"range1"> = {
+const range1: PropertyConfig<"range1", [number, number]> = {
   name: "range1",
   label: "Range (1st parameter)",
   widget: WidgetType.MathValue,
-  // complicated validation... [real, real] or func of V
+  validate: schema.realVectors[2].validateSync,
 };
 
-const range2: PropertyConfig<"range2"> = {
+const range2: PropertyConfig<"range2", [number, number]> = {
   name: "range2",
   label: "Range (2nd parameter)",
   widget: WidgetType.MathValue,
-  // complicated validation... [real, real] or func of U
+  validate: schema.realVectors[2].validateSync,
 };
 
-const range3: PropertyConfig<"range3"> = {
+const range3: PropertyConfig<"range3", [number, number]> = {
   name: "range3",
   label: "Range (3rd parameter)",
   widget: WidgetType.MathValue,
-  // complicated validation... [real, real] or func of U
+  validate: schema.realVectors[2].validateSync,
 };
 
-const shaded: PropertyConfig<"shaded"> = {
+const shaded: PropertyConfig<"shaded", boolean> = {
   name: "shaded",
   label: "Shaded",
   widget: WidgetType.MathBoolean,
-  // validate real number
+  validate: schema.boolean.validateSync,
 };
 
-const size: PropertyConfig<"size"> = {
+const size: PropertyConfig<"size", number> = {
   name: "size",
   label: "Size",
   widget: WidgetType.MathValue,
-  // validate real number
+  validate: schema.positive.validateSync,
 };
 
-const samples1: PropertyConfig<"samples1"> = {
+const samples1: PropertyConfig<"samples1", number> = {
   name: "samples1",
   label: "Samples (1st parameter)",
   widget: WidgetType.MathValue,
-  // validate real number
+  validate: schema.positive.validateSync,
 };
 
-const samples2: PropertyConfig<"samples2"> = {
+const samples2: PropertyConfig<"samples2", number> = {
   name: "samples2",
   label: "Samples (2nd parameter)",
   widget: WidgetType.MathValue,
-  // validate real number
+  validate: schema.positive.validateSync,
 };
 
-const samples3: PropertyConfig<"samples3"> = {
+const samples3: PropertyConfig<"samples3", number> = {
   name: "samples3",
   label: "Samples (3rd parameter)",
   widget: WidgetType.MathValue,
-  // validate real number
+  validate: schema.positive.validateSync,
 };
 
-const visible: PropertyConfig<"visible"> = {
+const visible: PropertyConfig<"visible", boolean> = {
   name: "visible",
   label: "Visible",
   widget: WidgetType.MathBoolean,
-  // validate boolean
+  validate: schema.boolean.validateSync,
 };
 
-const width: PropertyConfig<"width"> = {
+const width: PropertyConfig<"width", number> = {
   name: "width",
   label: "Width",
   widget: WidgetType.MathValue,
-  // validate real number
+  validate: schema.positive.validateSync,
 };
 
-const zBias: PropertyConfig<"zBias"> = {
+const zBias: PropertyConfig<"zBias", number> = {
   name: "zBias",
   label: "Z-Bias",
   widget: WidgetType.MathValue,
-  // validate real number
+  validate: schema.real.validateSync,
 };
 
-const zIndex: PropertyConfig<"zIndex"> = {
+const zIndex: PropertyConfig<"zIndex", number> = {
   name: "zIndex",
   label: "Z-Index",
   widget: WidgetType.MathValue,
-  // validate real number
+  validate: schema.real.validateSync,
 };
 
-const start: PropertyConfig<"start"> = {
+const start: PropertyConfig<"start", boolean> = {
   name: "start",
   label: "Arrow (start)",
   widget: WidgetType.MathBoolean,
-  // validate boolean
+  validate: schema.boolean.validateSync,
 };
-const end: PropertyConfig<"end"> = {
+const end: PropertyConfig<"end", boolean> = {
   name: "end",
   label: "Arrow (end)",
   widget: WidgetType.MathBoolean,
-  // validate boolean
+  validate: schema.boolean.validateSync,
 };
 
 export {

--- a/client/src/configs/shared.ts
+++ b/client/src/configs/shared.ts
@@ -69,6 +69,37 @@ const range1: PropertyConfig<"range1", [number, number]> = {
   validate: validators.realVec[2],
 };
 
+type EvaluatedDomain1 = [() => [number, number]];
+
+const domain1: PropertyConfig<"domain", EvaluatedDomain1> = {
+  name: "domain",
+  label: "Domain",
+  widget: WidgetType.MathValue,
+};
+
+type EvaluatedDomain2 = [
+  (v: number) => [number, number],
+  (u: number) => [number, number]
+];
+
+const domain2: PropertyConfig<"domain", EvaluatedDomain2> = {
+  name: "domain",
+  label: "Range",
+  widget: WidgetType.CustomMath,
+};
+
+type EvaluatedDomain3 = [
+  (y: number, z: number) => [number, number],
+  (x: number, z: number) => [number, number],
+  (x: number, y: number) => [number, number]
+];
+
+const domain3: PropertyConfig<"domain", EvaluatedDomain3> = {
+  name: "domain",
+  label: "Range",
+  widget: WidgetType.CustomMath,
+};
+
 const range2: PropertyConfig<"range2", [number, number]> = {
   name: "range2",
   label: "Range (2nd parameter)",
@@ -183,4 +214,9 @@ export {
   width,
   zBias,
   zIndex,
+  domain1,
+  domain2,
+  domain3,
 };
+
+export type { EvaluatedDomain1, EvaluatedDomain2, EvaluatedDomain3 };

--- a/client/src/features/sceneControls/mathItems/FieldWidget/MathValue.tsx
+++ b/client/src/features/sceneControls/mathItems/FieldWidget/MathValue.tsx
@@ -45,6 +45,7 @@ const MathValue = React.forwardRef<MathfieldElement, IWidgetProps>(
           { [styles["has-error"]]: error },
           className
         )}
+        aria-invalid={error ? "true" : "false"}
         onChange={handleChange}
       >
         {value}

--- a/client/src/features/sceneControls/mathItems/FieldWidget/index.tsx
+++ b/client/src/features/sceneControls/mathItems/FieldWidget/index.tsx
@@ -9,7 +9,12 @@ import MathAssignment from "./MathAssignment";
 import MathBoolean from "./MathBoolean";
 import MathValue from "./MathValue";
 import TextInput from "./TextInput";
-import { IWidgetProps, OnWidgetChange, Parseable } from "./types";
+import {
+  IWidgetProps,
+  OnWidgetChange,
+  Parseable,
+  WidgetChangeEvent,
+} from "./types";
 import ErrorTooltip from "./ErrorTooltip";
 
 type WidgetProps = IWidgetProps & {
@@ -45,6 +50,23 @@ export const useOnWidgetChange = <T extends MIT>(item: MathItem<T>) => {
       dispatch(actions.setProperties(patch));
     },
     [dispatch, item.id, item.type]
+  );
+  return onWidgetChange;
+};
+
+type PatchPropertyOnChange = (
+  e: WidgetChangeEvent<Parseable>,
+  subpath: string
+) => void;
+
+export const usePatchPropertyOnChange = <T extends MIT>(item: MathItem<T>) => {
+  const dispatch = useAppDispatch();
+  const onWidgetChange: PatchPropertyOnChange = useCallback(
+    (e, subpath) => {
+      const path = `/${e.name}/${subpath}`;
+      dispatch(actions.patchProperty({ id: item.id, path, value: e.value }));
+    },
+    [dispatch, item.id]
   );
   return onWidgetChange;
 };

--- a/client/src/features/sceneControls/mathItems/__tests__/__utils__/index.ts
+++ b/client/src/features/sceneControls/mathItems/__tests__/__utils__/index.ts
@@ -11,6 +11,9 @@ const addItem = async (itemTypeLabel: string): Promise<void> => {
 const getItemByDescription = (description: string): HTMLElement =>
   screen.getByLabelText(`Settings for ${description}`);
 
+const findItemByDescription = (description: string): Promise<HTMLElement> =>
+  screen.findByLabelText(`Settings for ${description}`);
+
 const clickRemoveItem = async (itemElement: HTMLElement): Promise<void> => {
   const remove = within(itemElement).getByLabelText("Remove Item");
   await user.click(remove);
@@ -22,4 +25,10 @@ const findBtn = async (item: HTMLElement, name: string | RegExp) => {
   return btn;
 };
 
-export { addItem, clickRemoveItem, getItemByDescription, findBtn };
+export {
+  addItem,
+  clickRemoveItem,
+  getItemByDescription,
+  findItemByDescription,
+  findBtn,
+};

--- a/client/src/features/sceneControls/mathItems/__tests__/implicitSurface.spec.tsx
+++ b/client/src/features/sceneControls/mathItems/__tests__/implicitSurface.spec.tsx
@@ -23,19 +23,31 @@ const getParamNameInputs = (): HTMLTextAreaElement[] => {
 test("Updating parameter names updates the lhs and rhs appropriately", async () => {
   const lhs = {
     initial: {
-      lhs: "_f(x,y,z)",
+      type: "function-assignment" as const,
+      name: "_f",
+      params: ["x", "y", "z"],
       rhs: "x + y + z",
-      type: "assignment" as const,
     },
-    final: { lhs: "_f(a1,y,z)", rhs: "x + y + z", type: "assignment" as const },
+    final: {
+      type: "function-assignment" as const,
+      name: "_f",
+      params: ["a1", "y", "z"],
+      rhs: "x + y + z",
+    },
   };
   const rhs = {
     initial: {
-      lhs: "_f(x,y,z)",
+      type: "function-assignment" as const,
+      name: "_f",
+      params: ["x", "y", "z"],
       rhs: "x * y * z",
-      type: "assignment" as const,
     },
-    final: { lhs: "_f(a1,y,z)", rhs: "x * y * z", type: "assignment" as const },
+    final: {
+      type: "function-assignment" as const,
+      name: "_f",
+      params: ["a1", "y", "z"],
+      rhs: "x * y * z",
+    },
   };
   const item = makeItem(MIT.ImplicitSurface, {
     lhs: lhs.initial,
@@ -60,12 +72,18 @@ test.each([{ name: "lhs" as const }, { name: "rhs" as const }])(
   "Updating parameter names updates the lhs and rhs appropriately",
   async ({ name }) => {
     const initial = {
-      lhs: "_f(x,y,z)",
+      type: "function-assignment" as const,
+      name: "_f",
+      params: ["x", "y", "z"],
       rhs: "x + y + z",
-      type: "assignment" as const,
     };
     const initialDisplay = "x + y + z";
-    const final = { lhs: "_f(x,y,z)", rhs: "x + y + z^2", type: "assignment" };
+    const final = {
+      type: "function-assignment" as const,
+      name: "_f",
+      params: ["x", "y", "z"],
+      rhs: "x + y + z^2",
+    };
     const finalDisplay = "x + y + z^2";
 
     const item = makeItem(MIT.ImplicitSurface, {

--- a/client/src/features/sceneControls/mathItems/__tests__/shows-error-tooltips.spec.tsx
+++ b/client/src/features/sceneControls/mathItems/__tests__/shows-error-tooltips.spec.tsx
@@ -1,12 +1,15 @@
 import { act, waitForElementToBeRemoved } from "@testing-library/react";
 import { MathItemType as MIT } from "@/configs";
-import {
-  makeItem,
-  screen,
-  shortSleep,
-  seedDb,
-  renderTestApp,
-} from "@/test_util";
+import { makeItem, screen, seedDb, renderTestApp } from "@/test_util";
+
+/**
+ *
+ * @deprecated Avoid explicit waits in tests. Use retries instead.
+ */
+const shortSleep = () =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, 15);
+  });
 
 const findTooltip = () => screen.findByRole("tooltip");
 const queryTooltip = () => screen.queryByRole("tooltip");

--- a/client/src/features/sceneControls/mathItems/forms/ExplicitSurface/index.tsx
+++ b/client/src/features/sceneControls/mathItems/forms/ExplicitSurface/index.tsx
@@ -3,16 +3,14 @@ import { MathItemType as MIT } from "@/configs";
 import { MathItemForm } from "../interfaces";
 import RangedMathItemForm from "../RangedMathItemForm";
 
-const rangePropNames = ["range1", "range2"] as const;
 const exprNames = ["expr"] as const;
-const errorNames = [...exprNames, ...rangePropNames] as const;
+const errorNames = [...exprNames] as const;
 
 const ExplicitSurface: MathItemForm<MIT.ExplicitSurface> = ({ item }) => (
   <RangedMathItemForm
     item={item}
     exprNames={exprNames}
     errorNames={errorNames}
-    rangePropNames={rangePropNames}
   />
 );
 

--- a/client/src/features/sceneControls/mathItems/forms/ExplicitSurface/index.tsx
+++ b/client/src/features/sceneControls/mathItems/forms/ExplicitSurface/index.tsx
@@ -4,14 +4,9 @@ import { MathItemForm } from "../interfaces";
 import RangedMathItemForm from "../RangedMathItemForm";
 
 const exprNames = ["expr"] as const;
-const errorNames = [...exprNames] as const;
 
 const ExplicitSurface: MathItemForm<MIT.ExplicitSurface> = ({ item }) => (
-  <RangedMathItemForm
-    item={item}
-    exprNames={exprNames}
-    errorNames={errorNames}
-  />
+  <RangedMathItemForm item={item} exprNames={exprNames} />
 );
 
 export default ExplicitSurface;

--- a/client/src/features/sceneControls/mathItems/forms/ExplicitSurfacePolar/index.tsx
+++ b/client/src/features/sceneControls/mathItems/forms/ExplicitSurfacePolar/index.tsx
@@ -3,9 +3,8 @@ import { MathItemType as MIT } from "@/configs";
 import { MathItemForm } from "../interfaces";
 import RangedMathItemForm from "../RangedMathItemForm";
 
-const rangePropNames = ["range1", "range2"] as const;
 const exprNames = ["expr"] as const;
-const errorNames = [...exprNames, ...rangePropNames] as const;
+const errorNames = [...exprNames] as const;
 
 const ExplicitSurfacePolar: MathItemForm<MIT.ExplicitSurfacePolar> = ({
   item,
@@ -14,7 +13,6 @@ const ExplicitSurfacePolar: MathItemForm<MIT.ExplicitSurfacePolar> = ({
     item={item}
     exprNames={exprNames}
     errorNames={errorNames}
-    rangePropNames={rangePropNames}
   />
 );
 

--- a/client/src/features/sceneControls/mathItems/forms/ExplicitSurfacePolar/index.tsx
+++ b/client/src/features/sceneControls/mathItems/forms/ExplicitSurfacePolar/index.tsx
@@ -4,16 +4,9 @@ import { MathItemForm } from "../interfaces";
 import RangedMathItemForm from "../RangedMathItemForm";
 
 const exprNames = ["expr"] as const;
-const errorNames = [...exprNames] as const;
 
 const ExplicitSurfacePolar: MathItemForm<MIT.ExplicitSurfacePolar> = ({
   item,
-}) => (
-  <RangedMathItemForm
-    item={item}
-    exprNames={exprNames}
-    errorNames={errorNames}
-  />
-);
+}) => <RangedMathItemForm item={item} exprNames={exprNames} />;
 
 export default ExplicitSurfacePolar;

--- a/client/src/features/sceneControls/mathItems/forms/ImplicitSurface/index.tsx
+++ b/client/src/features/sceneControls/mathItems/forms/ImplicitSurface/index.tsx
@@ -11,9 +11,8 @@ import styles from "./ImplicitSurface.module.css";
 import { MathItemForm } from "../interfaces";
 import RangedMathItemForm from "../RangedMathItemForm";
 
-const rangePropNames = ["range1", "range2", "range3"] as const;
 const exprNames = ["lhs", "rhs"] as const;
-const errorNames = [...exprNames, ...rangePropNames] as const;
+const errorNames = [...exprNames] as const;
 
 const config = configs[MIT.ImplicitSurface];
 
@@ -49,12 +48,7 @@ const ImplicitSurfaceExpressions: React.FC<ExpressionProps> = ({
 };
 
 const ImplicitSurface: MathItemForm<MIT.ImplicitSurface> = ({ item }) => (
-  <RangedMathItemForm
-    item={item}
-    exprNames={exprNames}
-    errorNames={errorNames}
-    rangePropNames={rangePropNames}
-  >
+  <RangedMathItemForm item={item} exprNames={exprNames} errorNames={errorNames}>
     {ImplicitSurfaceExpressions}
   </RangedMathItemForm>
 );

--- a/client/src/features/sceneControls/mathItems/forms/ImplicitSurface/index.tsx
+++ b/client/src/features/sceneControls/mathItems/forms/ImplicitSurface/index.tsx
@@ -12,7 +12,6 @@ import { MathItemForm } from "../interfaces";
 import RangedMathItemForm from "../RangedMathItemForm";
 
 const exprNames = ["lhs", "rhs"] as const;
-const errorNames = [...exprNames] as const;
 
 const config = configs[MIT.ImplicitSurface];
 
@@ -48,7 +47,7 @@ const ImplicitSurfaceExpressions: React.FC<ExpressionProps> = ({
 };
 
 const ImplicitSurface: MathItemForm<MIT.ImplicitSurface> = ({ item }) => (
-  <RangedMathItemForm item={item} exprNames={exprNames} errorNames={errorNames}>
+  <RangedMathItemForm item={item} exprNames={exprNames}>
     {ImplicitSurfaceExpressions}
   </RangedMathItemForm>
 );

--- a/client/src/features/sceneControls/mathItems/forms/ParametricCurve/index.tsx
+++ b/client/src/features/sceneControls/mathItems/forms/ParametricCurve/index.tsx
@@ -5,14 +5,9 @@ import { MathItemForm } from "../interfaces";
 import RangedMathItemForm from "../RangedMathItemForm";
 
 const exprNames = ["expr"] as const;
-const errorNames = [...exprNames] as const;
 
 const ParametricSurface: MathItemForm<MIT.ParametricCurve> = ({ item }) => (
-  <RangedMathItemForm
-    item={item}
-    exprNames={exprNames}
-    errorNames={errorNames}
-  />
+  <RangedMathItemForm item={item} exprNames={exprNames} />
 );
 
 export default ParametricSurface;

--- a/client/src/features/sceneControls/mathItems/forms/ParametricCurve/index.tsx
+++ b/client/src/features/sceneControls/mathItems/forms/ParametricCurve/index.tsx
@@ -4,16 +4,14 @@ import React from "react";
 import { MathItemForm } from "../interfaces";
 import RangedMathItemForm from "../RangedMathItemForm";
 
-const rangePropNames = ["range1"] as const;
 const exprNames = ["expr"] as const;
-const errorNames = [...exprNames, ...rangePropNames] as const;
+const errorNames = [...exprNames] as const;
 
 const ParametricSurface: MathItemForm<MIT.ParametricCurve> = ({ item }) => (
   <RangedMathItemForm
     item={item}
     exprNames={exprNames}
     errorNames={errorNames}
-    rangePropNames={rangePropNames}
   />
 );
 

--- a/client/src/features/sceneControls/mathItems/forms/ParametricSurface/index.tsx
+++ b/client/src/features/sceneControls/mathItems/forms/ParametricSurface/index.tsx
@@ -7,11 +7,7 @@ import RangedMathItemForm from "../RangedMathItemForm";
 const exprNames = ["expr"] as const;
 
 const ParametricSurface: MathItemForm<MIT.ParametricSurface> = ({ item }) => (
-  <RangedMathItemForm
-    item={item}
-    exprNames={exprNames}
-    errorNames={exprNames}
-  />
+  <RangedMathItemForm item={item} exprNames={exprNames} />
 );
 
 export default ParametricSurface;

--- a/client/src/features/sceneControls/mathItems/forms/ParametricSurface/index.tsx
+++ b/client/src/features/sceneControls/mathItems/forms/ParametricSurface/index.tsx
@@ -4,16 +4,13 @@ import React from "react";
 import { MathItemForm } from "../interfaces";
 import RangedMathItemForm from "../RangedMathItemForm";
 
-const rangePropNames = ["range1", "range2"] as const;
 const exprNames = ["expr"] as const;
-const errorNames = [...exprNames, ...rangePropNames] as const;
 
 const ParametricSurface: MathItemForm<MIT.ParametricSurface> = ({ item }) => (
   <RangedMathItemForm
     item={item}
     exprNames={exprNames}
-    errorNames={errorNames}
-    rangePropNames={rangePropNames}
+    errorNames={exprNames}
   />
 );
 

--- a/client/src/features/sceneControls/mathItems/forms/RangedMathItemForm.tsx
+++ b/client/src/features/sceneControls/mathItems/forms/RangedMathItemForm.tsx
@@ -16,7 +16,6 @@ import type { ExpressionProps } from "./expressionHelpers";
 interface GenericRangedMathItemFormProps<T extends MIT> {
   item: MathItem<T>;
   exprNames: readonly (keyof MathItem<T>["properties"] & string)[];
-  errorNames: readonly (keyof MathItem<T>["properties"] & string)[];
   children?: React.FC<ExpressionProps>;
 }
 

--- a/client/src/features/sceneControls/mathItems/forms/RangedMathItemForm.tsx
+++ b/client/src/features/sceneControls/mathItems/forms/RangedMathItemForm.tsx
@@ -4,26 +4,19 @@ import {
   MathItemType as MIT,
   WidgetType,
 } from "@/configs";
-import ordinal from "ordinal";
-import React from "react";
+import React, { useMemo } from "react";
 
-import FieldWidget, { useOnWidgetChange } from "../FieldWidget";
+import FieldWidget from "../FieldWidget";
 import { useMathScope } from "../mathItemsSlice";
 import { useMathErrors } from "../mathScope";
 import ItemTemplate from "../templates/ItemTemplate";
-import styles from "./ItemForms.module.css";
-import {
-  ParameterContainer,
-  ParameterForm,
-  useExpressionsAndParameters,
-} from "./expressionHelpers";
+import { DomainForm, useExpressionsAndParameters } from "./expressionHelpers";
 import type { ExpressionProps } from "./expressionHelpers";
 
 interface GenericRangedMathItemFormProps<T extends MIT> {
   item: MathItem<T>;
   exprNames: readonly (keyof MathItem<T>["properties"] & string)[];
   errorNames: readonly (keyof MathItem<T>["properties"] & string)[];
-  rangePropNames: readonly (keyof MathItem<T>["properties"] & string)[];
   children?: React.FC<ExpressionProps>;
 }
 
@@ -38,20 +31,21 @@ type RangedMathItemFormProps =
 const RangedMathItemForm = ({
   item,
   exprNames,
-  rangePropNames,
-  errorNames,
   children,
 }: RangedMathItemFormProps) => {
   const config = configs[item.type];
-  const onWidgetChange = useOnWidgetChange(item);
-  const numParams = rangePropNames.length;
+  const { domain } = item.properties;
+  const numParams = domain.items.length;
   const mathScope = useMathScope();
+  const errorNames = useMemo(() => [...exprNames, "domain"], [exprNames]);
   const errors = useMathErrors(mathScope, item.id, errorNames);
-  const {
-    assignments,
-    handlers,
-    errors: assignmentErrors,
-  } = useExpressionsAndParameters(item, exprNames, numParams, errors);
+  const exprProps = useExpressionsAndParameters(
+    item,
+    exprNames,
+    numParams,
+    errors
+  );
+  const { assignments, handlers, errors: assignmentErrors } = exprProps;
 
   return (
     <ItemTemplate item={item} config={config}>
@@ -68,39 +62,11 @@ const RangedMathItemForm = ({
           onChange={handlers.rhs[0]}
         />
       )}
-      <ParameterContainer>
-        {rangePropNames.map((rangeProp, i) => (
-          <ParameterForm
-            key={rangeProp}
-            nameInput={
-              <FieldWidget
-                className={styles["param-input"]}
-                widget={WidgetType.MathValue}
-                error={assignmentErrors[0].paramErrors?.[i]}
-                label={`Name for ${ordinal(i + 1)} parameter`}
-                name={`${ordinal(i + 1)}-parameter-name`}
-                value={assignments[0].params[i]}
-                onChange={handlers.param[i]}
-              />
-            }
-            rangeInput={
-              <FieldWidget
-                className={styles["param-input"]}
-                widget={WidgetType.MathValue}
-                label={
-                  // @ts-expect-error need to figure out this error
-                  config.properties[rangeProp].label
-                }
-                name={rangeProp}
-                error={errors[rangeProp]}
-                // @ts-expect-error need to figure out this error
-                value={item.properties[rangeProp]}
-                onChange={onWidgetChange}
-              />
-            }
-          />
-        ))}
-      </ParameterContainer>
+      <DomainForm
+        item={item}
+        exprProps={exprProps}
+        domainError={errors.domain}
+      />
     </ItemTemplate>
   );
 };

--- a/client/src/features/sceneControls/mathItems/forms/VectorField/index.tsx
+++ b/client/src/features/sceneControls/mathItems/forms/VectorField/index.tsx
@@ -3,16 +3,14 @@ import { MathItemType as MIT } from "@/configs";
 import { MathItemForm } from "../interfaces";
 import RangedMathItemForm from "../RangedMathItemForm";
 
-const rangePropNames = ["range1", "range2", "range3"] as const;
 const exprNames = ["expr"] as const;
-const errorNames = [...exprNames, ...rangePropNames] as const;
+const errorNames = [...exprNames] as const;
 
 const ParametricSurface: MathItemForm<MIT.VectorField> = ({ item }) => (
   <RangedMathItemForm
     item={item}
     exprNames={exprNames}
     errorNames={errorNames}
-    rangePropNames={rangePropNames}
   />
 );
 

--- a/client/src/features/sceneControls/mathItems/forms/VectorField/index.tsx
+++ b/client/src/features/sceneControls/mathItems/forms/VectorField/index.tsx
@@ -4,14 +4,9 @@ import { MathItemForm } from "../interfaces";
 import RangedMathItemForm from "../RangedMathItemForm";
 
 const exprNames = ["expr"] as const;
-const errorNames = [...exprNames] as const;
 
 const ParametricSurface: MathItemForm<MIT.VectorField> = ({ item }) => (
-  <RangedMathItemForm
-    item={item}
-    exprNames={exprNames}
-    errorNames={errorNames}
-  />
+  <RangedMathItemForm item={item} exprNames={exprNames} />
 );
 
 export default ParametricSurface;

--- a/client/src/features/sceneControls/mathItems/forms/expressionHelpers.tsx
+++ b/client/src/features/sceneControls/mathItems/forms/expressionHelpers.tsx
@@ -1,13 +1,19 @@
-import { MathItem } from "@/configs";
+import { MathItem, WidgetType } from "@/configs";
 import React, { useCallback, useMemo } from "react";
-import { FunctionAssignment, ParseableObjs } from "@/util/parsing";
+import {
+  FunctionAssignment,
+  isBatchError,
+  ParseableObjs,
+} from "@/util/parsing";
 
 import { DetailedAssignmentError } from "@/util/parsing/MathJsParser";
 import { ParameterErrors } from "@/util/parsing/rules";
+import invariant from "tiny-invariant";
+import ordinal from "ordinal";
 import ReadonlyMathField from "../FieldWidget/ReadonlyMathField";
 import { OnWidgetChange, WidgetChangeEvent } from "../FieldWidget/types";
 import styles from "./ItemForms.module.css";
-import { useOnWidgetChange } from "../FieldWidget";
+import FieldWidget, { useOnWidgetChange } from "../FieldWidget";
 
 interface ParameterContainerProps {
   children: React.ReactNode;
@@ -32,6 +38,85 @@ const ParameterForm: React.FC<ParameterFormProps> = (props) => {
       </div>
       <div className="d-flex">{props.rangeInput}</div>
     </>
+  );
+};
+
+interface DomainFormProps {
+  item: MathItem & { properties: { domain: ParseableObjs["array"] } };
+  domainError?: Error;
+  exprProps: ExpressionProps;
+}
+const DomainForm: React.FC<DomainFormProps> = ({
+  item,
+  exprProps,
+  domainError,
+}) => {
+  const { domain } = item.properties;
+  const onWidgetChange = useOnWidgetChange(item);
+  const { assignments, errors: assignmentErrors, handlers } = exprProps;
+  const domainValueHandlers: OnWidgetChange<string>[] = useMemo(
+    () =>
+      domain.items.map((paramDomain, i) => {
+        invariant(
+          typeof paramDomain !== "string" && paramDomain.type === "assignment"
+        );
+        const f: OnWidgetChange<string> = (e) => {
+          onWidgetChange({
+            name: "domain",
+            oldValue: domain,
+            value: {
+              ...domain,
+              items: domain.items.map((item, j) => {
+                return i === j ? { ...paramDomain, rhs: e.value } : item;
+              }),
+            },
+          });
+        };
+        return f;
+      }),
+    [domain, onWidgetChange]
+  );
+  return (
+    <ParameterContainer>
+      {domain.items.map((paramDomain, i) => {
+        invariant(
+          typeof paramDomain !== "string" && paramDomain.type === "assignment"
+        );
+        return (
+          <ParameterForm
+            // it's fine, these are not re-orderable
+            // eslint-disable-next-line react/no-array-index-key
+            key={`param-${i}`}
+            nameInput={
+              <FieldWidget
+                className={styles["param-input"]}
+                widget={WidgetType.MathValue}
+                error={assignmentErrors[0].paramErrors?.[i]}
+                label={`Name for ${ordinal(i + 1)} parameter`}
+                name={`${ordinal(i + 1)}-parameter-name`}
+                value={assignments[0].params[i]}
+                onChange={handlers.param[i]}
+              />
+            }
+            rangeInput={
+              <FieldWidget
+                className={styles["param-input"]}
+                widget={WidgetType.MathValue}
+                label={`Range for ${ordinal(i + 1)} parameter`}
+                name={`${ordinal(i + 1)}-parameter-value`}
+                error={
+                  isBatchError(domainError)
+                    ? domainError.errors[i]
+                    : domainError
+                }
+                value={paramDomain.rhs}
+                onChange={domainValueHandlers[i]}
+              />
+            }
+          />
+        );
+      })}
+    </ParameterContainer>
   );
 };
 
@@ -72,7 +157,7 @@ type ExpressionProps = {
  * This hook provides callbacks and data to assist with this.
  */
 const useExpressionsAndParameters = (
-  item: MathItem,
+  item: MathItem & { properties: { domain: ParseableObjs["array"] } },
   /**
    * The names of the function-parseable math properties. If multiple are
    * provided, they should have the same LHS.
@@ -92,6 +177,7 @@ const useExpressionsAndParameters = (
     () => exprNames.map((name) => item.properties[name]),
     [exprNames, item.properties]
   );
+  const { domain } = item.properties;
 
   const assignments = useMemo(
     () =>
@@ -116,6 +202,27 @@ const useExpressionsAndParameters = (
     [onWidgetChange]
   );
 
+  const updateDomains = useCallback(
+    (newParameters: string[]) => {
+      const event: WidgetChangeEvent<ParseableObjs["array"]> = {
+        name: "domain",
+        value: {
+          items: domain.items.map((pd, i) => {
+            invariant(typeof pd !== "string" && pd.type === "assignment");
+            return {
+              type: "assignment",
+              lhs: `_f(${newParameters.filter((p, k) => k !== i).join(", ")})`,
+              rhs: pd.rhs,
+            };
+          }),
+          type: "array",
+        },
+      };
+      onWidgetChange(event);
+    },
+    [domain.items, onWidgetChange]
+  );
+
   const handlers = useMemo(() => {
     const rhs: OnWidgetChange[] = exprNames.map((name, i) => {
       const handler: OnWidgetChange = (e) => {
@@ -134,12 +241,13 @@ const useExpressionsAndParameters = (
             newParams[handlerIndex] = e.value.replaceAll(/[,=]/g, "");
             const newAssignment = assignment.clone({ params: newParams });
             updateExpr(newAssignment, exprNames[i]);
+            updateDomains(newParams);
           });
         };
         return handler;
       });
     return { rhs, param };
-  }, [assignments, updateExpr, exprNames, numParams]);
+  }, [exprNames, numParams, assignments, updateExpr, updateDomains]);
 
   const errs = useMemo(
     () =>
@@ -161,5 +269,10 @@ const useExpressionsAndParameters = (
   return { assignments, handlers, errors: errs };
 };
 
-export { ParameterContainer, ParameterForm, useExpressionsAndParameters };
+export {
+  DomainForm,
+  ParameterContainer,
+  ParameterForm,
+  useExpressionsAndParameters,
+};
 export type { ExpressionProps };

--- a/client/src/features/sceneControls/mathItems/forms/expressionHelpers.tsx
+++ b/client/src/features/sceneControls/mathItems/forms/expressionHelpers.tsx
@@ -58,7 +58,8 @@ const DomainForm: React.FC<DomainFormProps> = ({
     () =>
       domain.items.map((paramDomain, i) => {
         invariant(
-          typeof paramDomain !== "string" && paramDomain.type === "assignment"
+          typeof paramDomain !== "string" &&
+            paramDomain.type === "function-assignment"
         );
         const f: OnWidgetChange<string> = (e) => {
           onWidgetChange({
@@ -66,8 +67,8 @@ const DomainForm: React.FC<DomainFormProps> = ({
             oldValue: domain,
             value: {
               ...domain,
-              items: domain.items.map((item, j) => {
-                return i === j ? { ...paramDomain, rhs: e.value } : item;
+              items: domain.items.map((_, j) => {
+                return i === j ? { ...paramDomain, rhs: e.value } : paramDomain;
               }),
             },
           });
@@ -80,7 +81,8 @@ const DomainForm: React.FC<DomainFormProps> = ({
     <ParameterContainer>
       {domain.items.map((paramDomain, i) => {
         invariant(
-          typeof paramDomain !== "string" && paramDomain.type === "assignment"
+          typeof paramDomain !== "string" &&
+            paramDomain.type === "function-assignment"
         );
         return (
           <ParameterForm

--- a/client/src/features/sceneControls/mathItems/forms/expressionHelpers.tsx
+++ b/client/src/features/sceneControls/mathItems/forms/expressionHelpers.tsx
@@ -10,7 +10,10 @@ import { ParseableArray } from "@/util/parsing/interfaces";
 import ReadonlyMathField from "../FieldWidget/ReadonlyMathField";
 import { OnWidgetChange, WidgetChangeEvent } from "../FieldWidget/types";
 import styles from "./ItemForms.module.css";
-import FieldWidget, { useOnWidgetChange } from "../FieldWidget";
+import FieldWidget, {
+  useOnWidgetChange,
+  usePatchPropertyOnChange,
+} from "../FieldWidget";
 
 interface ParameterContainerProps {
   children: React.ReactNode;
@@ -55,25 +58,18 @@ const DomainForm: React.FC<DomainFormProps> = ({
   const { domain } = item.properties;
   invariant(domain.items.every((x) => x.type === "function-assignment"));
 
-  const onWidgetChange = useOnWidgetChange(item);
+  const patchProperty = usePatchPropertyOnChange(item);
   const { assignments, errors: assignmentErrors, handlers } = exprProps;
   const domainValueHandlers: OnWidgetChange<string>[] = useMemo(() => {
     return domain.items.map((_item, i) => {
       const f: OnWidgetChange<string> = (e) => {
-        onWidgetChange({
-          name: "domain",
-          oldValue: domain,
-          value: {
-            ...domain,
-            items: domain.items.map((domainItem, j) => {
-              return i === j ? { ...domainItem, rhs: e.value } : domainItem;
-            }),
-          },
-        });
+        const event = { ...e, name: "domain" };
+        const subpath = `/items/${i}/rhs`;
+        patchProperty(event, subpath);
       };
       return f;
     });
-  }, [domain, onWidgetChange]);
+  }, [domain, patchProperty]);
   return (
     <ParameterContainer>
       {domain.items.map((paramDomain, i) => {

--- a/client/src/features/sceneControls/mathItems/mathItemsSlice/syncMathScope.ts
+++ b/client/src/features/sceneControls/mathItems/mathItemsSlice/syncMathScope.ts
@@ -25,7 +25,7 @@ const MATH_WIDGETS = new Set([
 
 const getMathProperties = <T extends MathItemType>(
   config: MathItemConfig<T>
-): PropertyConfig<string>[] =>
+): PropertyConfig<string, unknown>[] =>
   collectionFilter(config.properties, (p) => MATH_WIDGETS.has(p.widget));
 
 const getIdentifiedExpressions = (

--- a/client/src/features/sceneControls/mathItems/mathScope.ts
+++ b/client/src/features/sceneControls/mathItems/mathScope.ts
@@ -119,7 +119,7 @@ const MATH_WIDGETS = new Set([
 
 const getMathProperties = <T extends MathItemType>(
   config: MathItemConfig<T>
-): PropertyConfig<string>[] =>
+): PropertyConfig<string, unknown>[] =>
   collectionFilter(config.properties, (p) => MATH_WIDGETS.has(p.widget));
 
 export { getMathProperties, useMathErrors, useMathResults };

--- a/client/src/test_util/test_util.spec.ts
+++ b/client/src/test_util/test_util.spec.ts
@@ -1,4 +1,4 @@
-import { permutations } from "./test_util";
+import { flatProduct, permutations } from "./test_util";
 
 describe("permutations", () => {
   it("returns all permutations of a list", () => {
@@ -11,5 +11,30 @@ describe("permutations", () => {
       ["c", "a", "b"],
       ["c", "b", "a"],
     ]);
+  });
+});
+
+describe("flatProduct", () => {
+  it("Returns the flattened cartesian product of two arrays objects", () => {
+    const arr1 = [{ a: 1 }, { a: 2 }];
+    const arr2 = [{ b: 10 }, { b: 20 }];
+    const arr3 = [{ c: 100 }, { c: 200 }];
+
+    const result = flatProduct(arr1, arr2, arr3);
+
+    expect(result).toStrictEqual([
+      { a: 1, b: 10, c: 100 },
+      { a: 1, b: 10, c: 200 },
+      { a: 1, b: 20, c: 100 },
+      { a: 1, b: 20, c: 200 },
+      { a: 2, b: 10, c: 100 },
+      { a: 2, b: 10, c: 200 },
+      { a: 2, b: 20, c: 100 },
+      { a: 2, b: 20, c: 200 },
+    ]);
+
+    expect(result[0].a).toBe(1);
+    expect(result[0].b).toBe(10);
+    expect(result[0].c).toBe(100);
   });
 });

--- a/client/src/test_util/test_util.ts
+++ b/client/src/test_util/test_util.ts
@@ -27,6 +27,11 @@ const pasteText = (element: HTMLElement, text: string) => {
   return user.paste(text);
 };
 
+const sleep = (ms: number): Promise<void> =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
 const userWaits = (ms: number, { useFake = false } = {}) =>
   act(() => {
     if (useFake) {

--- a/client/src/test_util/test_util.ts
+++ b/client/src/test_util/test_util.ts
@@ -27,13 +27,6 @@ const pasteText = (element: HTMLElement, text: string) => {
   return user.paste(text);
 };
 
-const sleep = (ms: number) =>
-  new Promise<void>((resolve) => {
-    setTimeout(resolve, ms);
-  });
-
-const shortSleep = () => sleep(15);
-
 const userWaits = (ms: number, { useFake = false } = {}) =>
   act(() => {
     if (useFake) {
@@ -58,6 +51,11 @@ const allowActWarnings = () => {
   vi.spyOn(console, "error").mockImplementation(patchedConsoleError);
 };
 
+const flatProduct1 = <T, U>(arr1: T[], arr2: U[]): (T & U)[] =>
+  arr1.flatMap((obj1) => {
+    return arr2.map((obj2) => ({ ...obj1, ...obj2 }));
+  });
+
 /**
  * Returns the cartesian product of two object arrays, with objects flattened.
  *
@@ -71,10 +69,26 @@ const allowActWarnings = () => {
  *
  * Particularly useful for jest testcases.
  */
-const flatProduct = <T, U>(arr1: T[], arr2: U[]): (T & U)[] =>
-  arr1.flatMap((obj1) => {
-    return arr2.map((obj2) => ({ ...obj1, ...obj2 }));
+function flatProduct<T1, T2>(arr1: T1[], arr2: T2[]): (T1 & T2)[];
+function flatProduct<T1, T2, T3>(
+  arr1: T1[],
+  arr2: T2[],
+  arr3: T3[]
+): (T1 & T2 & T3)[];
+function flatProduct<T1, T2, T3, T4>(
+  arr1: T1[],
+  arr2: T2[],
+  arr3: T3[],
+  arr4: T4[]
+): (T1 & T2 & T3 & T4)[];
+
+function flatProduct(...arrays: unknown[][]): unknown[] {
+  if (arrays.length === 0) return [];
+  if (arrays.length === 1) return arrays[0];
+  return arrays.reduce((acc, arr) => {
+    return flatProduct1(acc, arr);
   });
+}
 
 export {
   assertInstanceOf,
@@ -82,8 +96,6 @@ export {
   permutations,
   flatProduct,
   pasteText,
-  sleep,
   userWaits,
-  shortSleep,
   allowActWarnings,
 };

--- a/client/src/util/parsing/MathJsParser.ts
+++ b/client/src/util/parsing/MathJsParser.ts
@@ -82,7 +82,7 @@ class MathJsParser implements IMathJsParser {
     lhs,
     rhs,
     validate,
-  }: ParseableObjs["assignment"]) => {
+  }: Omit<ParseableObjs["assignment"], "type">) => {
     let lhsError: Error | undefined;
     let rhsError: Error | undefined;
     try {
@@ -112,6 +112,16 @@ class MathJsParser implements IMathJsParser {
     return this.parse({ expr, validate });
   };
 
+  private parseFunctionAssignment = ({
+    name,
+    params,
+    rhs,
+    validate,
+  }: Omit<ParseableObjs["function-assignment"], "type">) => {
+    const lhs = `${name}(${params.join(",")})`;
+    return this.parseAssignment({ lhs, rhs, validate });
+  };
+
   private parseArray = ({ items, validate }: ParseableObjs["array"]) => {
     const parsed = batch(items, (item) => this.parse(item), ArrayParseError);
     return batchNodes(parsed, validate);
@@ -122,6 +132,9 @@ class MathJsParser implements IMathJsParser {
       typeof parseable === "string" ? { expr: parseable } : parseable;
     if (parseableObj.type === "assignment") {
       return this.parseAssignment(parseableObj);
+    }
+    if (parseableObj.type === "function-assignment") {
+      return this.parseFunctionAssignment(parseableObj);
     }
     if (parseableObj.type === "array") {
       return this.parseArray(parseableObj);

--- a/client/src/util/parsing/index.ts
+++ b/client/src/util/parsing/index.ts
@@ -1,4 +1,4 @@
 export * from "./helpers";
 export * from "./parsers";
 export * from "./batch";
-export type { Parseable, ParseableObjs } from "./interfaces";
+export type { Parseable, ParseableObjs, ParseableArray } from "./interfaces";

--- a/client/src/util/parsing/interfaces.ts
+++ b/client/src/util/parsing/interfaces.ts
@@ -16,6 +16,13 @@ type ParseableObjs = {
     rhs: string;
     validate?: Validate;
   };
+  "function-assignment": {
+    type: "function-assignment";
+    name: string;
+    params: string[];
+    rhs: string;
+    validate?: Validate;
+  };
   array: {
     type: "array";
     items: Parseable[];

--- a/client/src/util/parsing/interfaces.ts
+++ b/client/src/util/parsing/interfaces.ts
@@ -32,6 +32,12 @@ type ParseableObjs = {
 
 type ParseableObj = ParseableObjs[keyof ParseableObjs];
 type Parseable = string | ParseableObj;
+type ParseableArray<I extends Parseable = Parseable> = Omit<
+  ParseableObjs["array"],
+  "items"
+> & {
+  items: I[];
+};
 
 enum ParserRuleType {
   MathJs = "mathjs",
@@ -75,6 +81,7 @@ export { ParserRuleType };
 export type {
   Parseable,
   ParseableObjs,
+  ParseableArray,
   IMathJsParser,
   MathJsRule,
   ParserRule,

--- a/client/src/util/parsing/rules/validateParameters.ts
+++ b/client/src/util/parsing/rules/validateParameters.ts
@@ -30,7 +30,7 @@ const validateParameters: TextParserRule = {
     const match = text.match(FUNCTION_ASSIGNMENT_REGEX);
     if (!match?.groups?.params) return text;
     if (match.groups.params.trim() === "") return text;
-    const params = match.groups.params.split(",");
+    const params = match.groups.params.split(",").map((p) => p.trim());
     const invalidEntries = params
       .map((s, i) => {
         const symbol = s;

--- a/client/src/util/validators/index.ts
+++ b/client/src/util/validators/index.ts
@@ -16,11 +16,11 @@ export const real = num;
 
 const positive = real.positive();
 
-export const realVectors = {
-  1: yup.tuple([num]),
-  2: yup.tuple([num, num]),
-  3: yup.tuple([num, num, num]),
-  4: yup.tuple([num, num, num, num]),
+const realVectors = {
+  1: yup.tuple([num]).strict().required(),
+  2: yup.tuple([num, num]).strict().required(),
+  3: yup.tuple([num, num, num]).strict().required(),
+  4: yup.tuple([num, num, num, num]).strict().required(),
 };
 
 type RealFuncs = {
@@ -55,28 +55,29 @@ const numericFunc = <M extends Dim, N extends Dim>(fromDim: M, toDim: N) => {
     `Expected a function from R^${fromDim} -> R^${toDim}. ${detail}`;
   const schema = yup
     .mixed<RealFuncs[M][N]>()
-    .transform((f) => {
-      const zeros = Array(fromDim).fill(0);
-      return f(zeros);
-    })
     .test({
       name: `func-arity-${fromDim}`,
       message: message(`This is not a function from R^${fromDim}.`),
-      test: (_x, ctx) => {
-        return ctx.originalValue.length === fromDim;
+      test: (f) => {
+        return f?.length === fromDim;
       },
     })
     .test({
       name: `func-to-R${toDim}`,
       message: message(`The outputs of this function are not in R^${toDim}`),
-      test: (x) => {
-        return realVectors[toDim].isValidSync(x);
+      test: (f) => {
+        const sample = Array(fromDim)
+          .fill(0)
+          .map(() => Math.random());
+        // @ts-expect-error TS can't tell that sample has correct number of params
+        const out = f?.(...sample);
+        return realVectors[toDim].isValidSync(out);
       },
     });
   return schema;
 };
 
-export const realFuncSchemas = {
+const realFuncSchemas = {
   1: {
     1: numericFunc(1, 1),
     2: numericFunc(1, 2),
@@ -103,8 +104,46 @@ export const realFuncSchemas = {
   },
 };
 
+const realFuncValidators = {
+  1: {
+    1: realFuncSchemas[1][1].validateSync.bind(realFuncSchemas[1][1]),
+    2: realFuncSchemas[1][2].validateSync.bind(realFuncSchemas[1][2]),
+    3: realFuncSchemas[1][3].validateSync.bind(realFuncSchemas[1][3]),
+    4: realFuncSchemas[1][4].validateSync.bind(realFuncSchemas[1][4]),
+  },
+  2: {
+    1: realFuncSchemas[2][1].validateSync.bind(realFuncSchemas[2][1]),
+    2: realFuncSchemas[2][2].validateSync.bind(realFuncSchemas[2][2]),
+    3: realFuncSchemas[2][3].validateSync.bind(realFuncSchemas[2][3]),
+    4: realFuncSchemas[2][4].validateSync.bind(realFuncSchemas[2][4]),
+  },
+  3: {
+    1: realFuncSchemas[3][1].validateSync.bind(realFuncSchemas[3][1]),
+    2: realFuncSchemas[3][2].validateSync.bind(realFuncSchemas[3][2]),
+    3: realFuncSchemas[3][3].validateSync.bind(realFuncSchemas[3][3]),
+    4: realFuncSchemas[3][4].validateSync.bind(realFuncSchemas[3][4]),
+  },
+  4: {
+    1: realFuncSchemas[4][1].validateSync.bind(realFuncSchemas[4][1]),
+    2: realFuncSchemas[4][2].validateSync.bind(realFuncSchemas[4][2]),
+    3: realFuncSchemas[4][3].validateSync.bind(realFuncSchemas[4][3]),
+    4: realFuncSchemas[4][4].validateSync.bind(realFuncSchemas[4][4]),
+  },
+};
+
 export const validators = {
   real: real.validateSync.bind(real),
   positive: positive.validateSync.bind(positive),
   array: array.validateSync.bind(array),
+  realFunc: realFuncValidators,
+};
+
+const boolean = yup.boolean().strict().required();
+
+export const schema = {
+  realVectors,
+  positive,
+  real,
+  array,
+  boolean,
 };

--- a/client/src/util/validators/index.ts
+++ b/client/src/util/validators/index.ts
@@ -131,19 +131,20 @@ const realFuncValidators = {
   },
 };
 
+const realVecValidators = {
+  1: realVectors[1].validateSync.bind(realVectors[1]),
+  2: realVectors[2].validateSync.bind(realVectors[2]),
+  3: realVectors[3].validateSync.bind(realVectors[3]),
+  4: realVectors[4].validateSync.bind(realVectors[4]),
+};
+
+const boolean = yup.boolean().strict().required();
+
 export const validators = {
   real: real.validateSync.bind(real),
   positive: positive.validateSync.bind(positive),
   array: array.validateSync.bind(array),
   realFunc: realFuncValidators,
-};
-
-const boolean = yup.boolean().strict().required();
-
-export const schema = {
-  realVectors,
-  positive,
-  real,
-  array,
-  boolean,
+  realVec: realVecValidators,
+  boolean: boolean.validateSync.bind(boolean),
 };


### PR DESCRIPTION
This PR changes the `range1`, `range2`, etc props to a single `domain` prop which is an array of functions. For example, a parametric surface might have a domain with value
```
domain = [
  f(y) = [0, y],
  f(x) = [0, 10]
]
```

Indicating a plot range of {x, 0, y}, {y, 0, 10}.

One awkward aspect of this approach is that really the domain should be either `[f(y), [y1, y2]]` or `[[x1, x2], f(x)]`, where `f` is some function from R1 -> R2.

Instead, we allow both domain components to be functions. In the case of parametric surfaces, exactly one of the pair `[f(x), f(y)] should depend on its argument. The other should be constant. We'll validate this (in a subsequent PR) with validator fucntions. 