### PR TITLE
Allow array domains

### DIFF
--- a/client/src/configs/items/implicitSurface.ts
+++ b/client/src/configs/items/implicitSurface.ts
@@ -26,7 +26,7 @@ interface ImplicitSurfaceProperties {
   zBias: string;
 
   shaded: string; // eval to boolean;
-  domain: ParseableArray<ParseableObjs["function-assignment"]>;
+  domain: ParseableArray<ParseableObjs["expr"]>;
   lhs: ParseableObjs["function-assignment"];
   rhs: ParseableObjs["function-assignment"];
   samples: string;
@@ -44,22 +44,16 @@ const defaultValues: ImplicitSurfaceProperties = {
     type: "array",
     items: [
       {
-        type: "function-assignment",
-        name: "_f",
-        params: ["y", "z"],
-        rhs: "[-5, 5]",
+        type: "expr",
+        expr: "[-5, 5]",
       },
       {
-        type: "function-assignment",
-        name: "_f",
-        params: ["x", "z"],
-        rhs: "[-5, 5]",
+        type: "expr",
+        expr: "[-5, 5]",
       },
       {
-        type: "function-assignment",
-        name: "_f",
-        params: ["x", "y"],
-        rhs: "[-5, 5]",
+        type: "expr",
+        expr: "[-5, 5]",
       },
     ],
   },

--- a/client/src/configs/items/parametricCurve.ts
+++ b/client/src/configs/items/parametricCurve.ts
@@ -34,7 +34,7 @@ interface ParametricCurveProperties {
   start: string; // eval to boolean;
   end: string; // eval to boolean;
   expr: ParseableObjs["function-assignment"];
-  domain: ParseableArray<ParseableObjs["function-assignment"]>;
+  domain: ParseableArray<ParseableObjs["expr"]>;
   samples1: string;
 }
 
@@ -59,10 +59,8 @@ const defaultValues: ParametricCurveProperties = {
     type: "array",
     items: [
       {
-        type: "function-assignment",
-        name: "_f",
-        params: [],
-        rhs: "[-2*pi, 2*pi]",
+        type: "expr",
+        expr: "[-2*pi, 2*pi]",
       },
     ],
   },

--- a/client/src/configs/items/vectorField.ts
+++ b/client/src/configs/items/vectorField.ts
@@ -35,7 +35,7 @@ interface VectorFieldProperties {
   width: string;
   start: string; // eval to boolean;
   end: string; // eval to boolean;
-  domain: ParseableArray<ParseableObjs["function-assignment"]>;
+  domain: ParseableArray<ParseableObjs["expr"]>;
   expr: ParseableObjs["function-assignment"];
   samples1: string;
   samples2: string;
@@ -58,22 +58,16 @@ const defaultValues: VectorFieldProperties = {
     type: "array",
     items: [
       {
-        type: "function-assignment",
-        name: "_f",
-        params: ["y", "z"],
-        rhs: "[-5, 5]",
+        type: "expr",
+        expr: "[-5, 5]",
       },
       {
-        type: "function-assignment",
-        name: "_f",
-        params: ["x", "z"],
-        rhs: "[-5, 5]",
+        type: "expr",
+        expr: "[-5, 5]",
       },
       {
-        type: "function-assignment",
-        name: "_f",
-        params: ["x", "y"],
-        rhs: "[-5, 5]",
+        type: "expr",
+        expr: "[-5, 5]",
       },
     ],
   },

--- a/client/src/features/sceneControls/mathItems/__tests__/__utils__/index.ts
+++ b/client/src/features/sceneControls/mathItems/__tests__/__utils__/index.ts
@@ -1,4 +1,14 @@
-import { screen, within, user, assertInstanceOf } from "@/test_util";
+import type { MathItemType, MathItem } from "@/configs";
+import {
+  screen,
+  within,
+  user,
+  assertInstanceOf,
+  makeItem,
+  seedDb,
+  renderTestApp,
+} from "@/test_util";
+import invariant from "tiny-invariant";
 
 const addItem = async (itemTypeLabel: string): Promise<void> => {
   const addNewItemButton = screen.getByText("Add New Object");
@@ -25,10 +35,30 @@ const findBtn = async (item: HTMLElement, name: string | RegExp) => {
   return btn;
 };
 
+/**
+ * Renders test app with specified item
+ */
+const setupItemTest = async <T extends MathItemType>(
+  type: T,
+  props: Partial<MathItem<T>["properties"]> = {}
+) => {
+  const item = makeItem(type, props);
+  const scene = seedDb.withSceneFromItems([item]);
+  const { store } = await renderTestApp(`/${scene.id}`);
+
+  const form = await findItemByDescription(item.properties.description);
+  invariant(
+    form instanceof HTMLFormElement,
+    "Expected item form to be an HTMLFormElement"
+  );
+  return { item, form, store };
+};
+
 export {
   addItem,
   clickRemoveItem,
   getItemByDescription,
   findItemByDescription,
   findBtn,
+  setupItemTest,
 };

--- a/client/src/features/sceneControls/mathItems/forms/RangedMathItemForm.tsx
+++ b/client/src/features/sceneControls/mathItems/forms/RangedMathItemForm.tsx
@@ -17,6 +17,7 @@ interface GenericRangedMathItemFormProps<T extends MIT> {
   item: MathItem<T>;
   exprNames: readonly (keyof MathItem<T>["properties"] & string)[];
   children?: React.FC<ExpressionProps>;
+  domainFunctions?: boolean;
 }
 
 type RangedMathItemFormProps =

--- a/client/src/features/sceneControls/mathItems/forms/expressionHelpers.tsx
+++ b/client/src/features/sceneControls/mathItems/forms/expressionHelpers.tsx
@@ -77,7 +77,7 @@ const DomainForm: React.FC<DomainFormProps> = ({
         const subpath =
           paramDomain.type === "function-assignment"
             ? `items/${i}/rhs`
-            : `items/${i}/value`;
+            : `items/${i}/expr`;
         patchProperty(event, subpath);
       };
       return f;
@@ -124,7 +124,7 @@ const DomainForm: React.FC<DomainFormProps> = ({
               <FieldWidget
                 className={styles["param-input"]}
                 widget={WidgetType.MathValue}
-                label={`Range for ${ordinal(i + 1)} parameter`}
+                label={`Domain for ${ordinal(i + 1)} parameter`}
                 name={`${ordinal(i + 1)}-parameter-value`}
                 error={getDomainIndexRhsError(domainError, i)}
                 value={

--- a/client/src/features/sceneControls/mathItems/forms/expressionHelpers.tsx
+++ b/client/src/features/sceneControls/mathItems/forms/expressionHelpers.tsx
@@ -64,7 +64,8 @@ const DomainForm: React.FC<DomainFormProps> = ({
   invariant(
     domain.items.every(
       (x) => x.type === "expr" || x.type === "function-assignment"
-    )
+    ),
+    "Domain must be a list of expressions or function assignments"
   );
 
   const patchProperty = usePatchPropertyOnChange(item);
@@ -75,8 +76,8 @@ const DomainForm: React.FC<DomainFormProps> = ({
         const event = { ...e, name: "domain" };
         const subpath =
           paramDomain.type === "function-assignment"
-            ? `/items/${i}/rhs`
-            : `/items/${i}/value`;
+            ? `items/${i}/rhs`
+            : `items/${i}/value`;
         patchProperty(event, subpath);
       };
       return f;
@@ -198,7 +199,10 @@ const useExpressionsAndParameters = (
       exprNames.map((name) => {
         // @ts-expect-error TODO: Resolve this.
         const expr = item.properties[name];
-        invariant(expr.type === "function-assignment");
+        invariant(
+          expr.type === "function-assignment",
+          "Expected type: function-assignment"
+        );
         return expr;
       }),
     [exprNames, item.properties]
@@ -222,15 +226,14 @@ const useExpressionsAndParameters = (
         name: "domain",
         value: {
           items: domain.items.map((pd, i) => {
-            invariant(
-              typeof pd !== "string" && pd.type === "function-assignment"
-            );
-            return {
-              type: "function-assignment",
-              name: "_f",
-              params: newParameters.filter((p, k) => k !== i),
-              rhs: pd.rhs,
-            };
+            return pd.type === "expr"
+              ? pd
+              : {
+                  type: "function-assignment",
+                  name: "_f",
+                  params: newParameters.filter((p, k) => k !== i),
+                  rhs: pd.rhs,
+                };
           }),
           type: "array",
         },

--- a/client/src/features/sceneControls/mathItems/mathItemsSlice/syncMathScope.ts
+++ b/client/src/features/sceneControls/mathItems/mathItemsSlice/syncMathScope.ts
@@ -41,8 +41,10 @@ const getIdentifiedExpressions = (
         .map((prop) => {
           // @ts-expect-error ... TS does not know config and item are correlated
           const parseable: Parseable = item.properties[prop.name];
-          const parseableObj =
-            typeof parseable === "string" ? { expr: parseable } : parseable;
+          const parseableObj: Parseable =
+            typeof parseable === "string"
+              ? { expr: parseable, type: "expr" }
+              : parseable;
           return {
             id: mathScopeId(item.id, prop.name),
             parseable: {

--- a/client/src/test_util/test_util.ts
+++ b/client/src/test_util/test_util.ts
@@ -13,8 +13,10 @@ const permutations = <T>(tokens: T[], subperms: T[][] = [[]]): T[][] =>
       );
 
 /**
- * Returns a callback that transforms a mathItem into a callback mapping prop
- * names to mathScope node ids.
+ * Helps transform a mathItem's property names into MathScope node ids.
+ *
+ * Returns `propName => <nodeId for prop value>`
+ *
  */
 const nodeId =
   <T extends MathItem>(item: T) =>

--- a/client/src/util/parsing/MathJsParser.ts
+++ b/client/src/util/parsing/MathJsParser.ts
@@ -118,7 +118,7 @@ class MathJsParser implements IMathJsParser {
 
     const expr = `${lhs}=${rhs}`;
 
-    return this.$parse({ expr, validate });
+    return this.$parse({ expr, validate, type: "expr" });
   };
 
   private parseFunctionAssignment = ({
@@ -151,8 +151,10 @@ class MathJsParser implements IMathJsParser {
   private $parse = (
     parseable: Parseable
   ): readonly [AnonMathNode, mjs.MathNode] => {
-    const parseableObj =
-      typeof parseable === "string" ? { expr: parseable } : parseable;
+    const parseableObj: Parseable =
+      typeof parseable === "string"
+        ? { expr: parseable, type: "expr" }
+        : parseable;
     if (parseableObj.type === "assignment") {
       return this.parseAssignment(parseableObj);
     }

--- a/client/src/util/parsing/interfaces.ts
+++ b/client/src/util/parsing/interfaces.ts
@@ -6,7 +6,7 @@ type Validate = (evaluated: unknown, parsed: mjs.MathNode) => void;
 
 type ParseableObjs = {
   expr: {
-    type?: "expr";
+    type: "expr";
     expr: string;
     validate?: Validate;
   };


### PR DESCRIPTION
Allow arrays in `domain` properties. Function-based domains allow for plot ranges like `{x, 0, y}, {y, 0, 10}` (in Mathematica's lingo). Simple arrays restricts user to rectangular plot regions.

We definitely want to allow function-based domains for 2d plot ranges. But they're unnecessary for 1d, and for 3d (vector fields, implicit surfaces) they are complicated and not required for feature-parity with legacy math3d. I may implement function-based ranges for volume domains later, but let's skip it for now.