### PR TITLE
tests + fix issues with tests

### DIFF
--- a/client/src/configs/shared.ts
+++ b/client/src/configs/shared.ts
@@ -1,4 +1,4 @@
-import { validators } from "@/util";
+import { validators, domainFuncs } from "@/util/validators";
 import { WidgetType } from "./constants";
 import type { PropertyConfig } from "./interfaces";
 
@@ -69,35 +69,66 @@ const range1: PropertyConfig<"range1", [number, number]> = {
   validate: validators.realVec[2],
 };
 
-type EvaluatedDomain1 = [() => [number, number]];
+type EvaluatedDomain1 = [[number, number]];
 
 const domain1: PropertyConfig<"domain", EvaluatedDomain1> = {
   name: "domain",
   label: "Domain",
   widget: WidgetType.MathValue,
+  validate: validators.arrayOf(validators.realVec[2], 1),
 };
 
-type EvaluatedDomain2 = [
-  (v: number) => [number, number],
-  (u: number) => [number, number]
-];
+/**
+ * A pair of functions describing a simple subset of R2.
+ *
+ * For example:
+ * ```
+ * // For a function f(x, y)
+ * // x \in {0, 5}, y \in {0, x}
+ * {
+ *   value: [(y) => [0, 5], (x) => [0, x]],
+ *   order: [0, 1]
+ * }
+ * ```
+ * Here, the `order` property indicates a valid evaluation order for the variables'
+ * domains. In this case, the `y` domain depends on the value of `x`, so the
+ * evaluation order is "x first, then y".
+ *
+ * If the function were `f(y, x)`, then the evaluation order would be reversed.
+ *
+ */
+type EvaluatedDomain2 = {
+  value: [
+    (param: number) => [number, number],
+    (param: number) => [number, number]
+  ];
+  /**
+   *
+   */
+  order: [number, number];
+};
 
 const domain2: PropertyConfig<"domain", EvaluatedDomain2> = {
   name: "domain",
-  label: "Range",
+  label: "Domain",
   widget: WidgetType.CustomMath,
+  validate: (value, node) => {
+    const funcs = validators.arrayOf(validators.realFunc[1][2], 2)(value);
+    const order = domainFuncs[2](node);
+    return {
+      value: funcs,
+      order,
+    };
+  },
 };
 
-type EvaluatedDomain3 = [
-  (y: number, z: number) => [number, number],
-  (x: number, z: number) => [number, number],
-  (x: number, y: number) => [number, number]
-];
+type EvaluatedDomain3 = [[number, number], [number, number], [number, number]];
 
 const domain3: PropertyConfig<"domain", EvaluatedDomain3> = {
   name: "domain",
-  label: "Range",
+  label: "Domain",
   widget: WidgetType.CustomMath,
+  validate: validators.arrayOf(validators.realVec[2], 3),
 };
 
 const range2: PropertyConfig<"range2", [number, number]> = {

--- a/client/src/features/sceneControls/mathItems/useMathResults.spec.tsx
+++ b/client/src/features/sceneControls/mathItems/useMathResults.spec.tsx
@@ -109,7 +109,7 @@ describe("useMathResults and useMathErrors", () => {
     expect(results.current).toStrictEqual({ a: 3, b: 9 });
   });
 
-  test.only("useMathErrors triggers re-renders when eval errors change", async () => {
+  test("useMathErrors triggers re-renders when eval errors change", async () => {
     const { errors, mathScope } = setup("id1", ["x", "y", "z"]);
 
     await act(() => {

--- a/client/src/features/sceneControls/mathItems/useMathResults.spec.tsx
+++ b/client/src/features/sceneControls/mathItems/useMathResults.spec.tsx
@@ -1,7 +1,7 @@
 import { render } from "@testing-library/react";
 import React, { createContext, useContext, useEffect } from "react";
 import { act } from "react-dom/test-utils";
-import MathScope, { UnmetDependencyError } from "@/util/MathScope";
+import MathScope from "@/util/MathScope";
 import { CyclicAssignmentError } from "@/util/MathScope/Evaluator";
 import { assertNotNil } from "@/util/predicates";
 import { latexParser } from "@/util/parsing";
@@ -109,7 +109,7 @@ describe("useMathResults and useMathErrors", () => {
     expect(results.current).toStrictEqual({ a: 3, b: 9 });
   });
 
-  test("useMathErrors triggers re-renders when eval errors change", async () => {
+  test.only("useMathErrors triggers re-renders when eval errors change", async () => {
     const { errors, mathScope } = setup("id1", ["x", "y", "z"]);
 
     await act(() => {
@@ -117,7 +117,9 @@ describe("useMathResults and useMathErrors", () => {
     });
 
     expect(errors.current).toStrictEqual({
-      x: expect.any(UnmetDependencyError),
+      x: expect.objectContaining({
+        message: "Undefined symbol y",
+      }),
     });
 
     await act(() => {

--- a/client/src/types/util.ts
+++ b/client/src/types/util.ts
@@ -1,11 +1,25 @@
 /**
  * Make properties K in T optional.
  */
-export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 
 /**
  * Extract the resolved type from a promise.
  */
-export type ResolvePromise<T extends Promise<unknown>> = Parameters<
+type ResolvePromise<T extends Promise<unknown>> = Parameters<
   NonNullable<Parameters<T["then"]>[0]>
 >[0];
+
+/**
+ * Create a tuple of generic length. See [Recursive conditional types](https://github.com/microsoft/TypeScript/pull/40002)
+ */
+type TupleOf<T, N extends number> = N extends N
+  ? number extends N
+    ? T[]
+    : _TupleOf<T, N, []>
+  : never;
+type _TupleOf<T, N extends number, R extends unknown[]> = R["length"] extends N
+  ? R
+  : _TupleOf<T, N, [T, ...R]>;
+
+export type { PartialBy, ResolvePromise, TupleOf };

--- a/client/src/util/MathScope/Evaluator.spec.ts
+++ b/client/src/util/MathScope/Evaluator.spec.ts
@@ -3,8 +3,6 @@ import { parse } from "./adapter";
 import Evaluator, {
   CyclicAssignmentError,
   DuplicateAssignmentError,
-  UnmetDependencyError,
-  UnmetDependencyError as UnmetDepErr,
 } from "./Evaluator";
 import { MathNode } from "./interfaces";
 import { assertIsAssignmentNode } from "./util";
@@ -12,6 +10,11 @@ import { assertIsAssignmentNode } from "./util";
 const node = (id: string, parseable: string): MathNode => {
   return { ...parse(parseable), id };
 };
+
+const unmetDepErr = (...unmet: string[]) =>
+  unmet.length === 1
+    ? new Error(`Undefined symbol ${unmet}`)
+    : new Error(`Undefined symbols ${unmet}`);
 
 const asMap = (obj: Record<string, unknown>) => new Map(Object.entries(obj));
 
@@ -49,8 +52,8 @@ describe("Evaluator", () => {
       );
       expect(evaluator.errors).toStrictEqual(
         asMap({
-          "id-c": new UnmetDepErr(["x"]),
-          "id-expr1": new UnmetDepErr(["c", "x"]),
+          "id-c": unmetDepErr("x"),
+          "id-expr1": unmetDepErr("c"),
         })
       );
     });
@@ -63,7 +66,7 @@ describe("Evaluator", () => {
       expect(evaluator.results).toStrictEqual(asMap({}));
       expect(evaluator.errors).toStrictEqual(
         asMap({
-          "id-f": new UnmetDepErr(["a", "b"]),
+          "id-f": unmetDepErr("a", "b"),
         })
       );
       expect(diff.errors).toStrictEqual({
@@ -124,7 +127,7 @@ describe("Evaluator", () => {
         asMap({
           "id-x1": new DuplicateAssignmentError(x1),
           "id-x2": new DuplicateAssignmentError(x2),
-          "id-y": new UnmetDependencyError(["x"]),
+          "id-y": unmetDepErr("x"),
         })
       );
     });
@@ -151,8 +154,8 @@ describe("Evaluator", () => {
       expect(evaluator.results).toStrictEqual(asMap({}));
       expect(evaluator.errors).toStrictEqual(
         asMap({
-          "id-x": new UnmetDependencyError(["z"]),
-          "id-y": new UnmetDependencyError(["x"]),
+          "id-x": unmetDepErr("z"),
+          "id-y": unmetDepErr("x"),
         })
       );
     });
@@ -201,7 +204,7 @@ describe("Evaluator", () => {
       );
       expect(evaluator.errors).toStrictEqual(
         asMap({
-          "id-expr1": new UnmetDepErr(["x"]),
+          "id-expr1": unmetDepErr("x"),
         })
       );
 
@@ -223,7 +226,7 @@ describe("Evaluator", () => {
       );
       expect(evaluator.errors).toStrictEqual(
         asMap({
-          "id-expr2": new UnmetDepErr(["c"]),
+          "id-expr2": unmetDepErr("c"),
         })
       );
 

--- a/client/src/util/MathScope/Evaluator.ts
+++ b/client/src/util/MathScope/Evaluator.ts
@@ -26,7 +26,7 @@ interface EvaluatorAction {
 export class UnmetDependencyError extends EvaluationError {
   constructor(unmetDependencyNames: string[]) {
     const sorted = [...unmetDependencyNames].sort();
-    const message = `Undefined symbol(s): ${sorted}`;
+    const message = `Undefined symbol${sorted.length > 1 ? "s" : ""} ${sorted}`;
     super(message);
   }
 }
@@ -228,11 +228,8 @@ export default class Evaluator {
         ) {
           this.scope.set(node.name, evaluated);
         }
-      } catch (rawError) {
-        assertIsError(rawError);
-        const unmet = getUnmetDependencies(node, this.scope);
-        const error =
-          unmet.length > 0 ? new UnmetDependencyError(unmet) : rawError;
+      } catch (error) {
+        assertIsError(error);
         results.delete(exprId);
         if (isAssignmentNode(node)) {
           this.scope.delete(node.name);

--- a/client/src/util/MathScope/adapter.ts
+++ b/client/src/util/MathScope/adapter.ts
@@ -1,24 +1,8 @@
 import * as math from "mathjs";
+import { getDependencies } from "@/util/mathjs-utils";
 
 import type { AnonMathNode, Parse } from "./interfaces";
 import { MathNodeType, Evaluate } from "./interfaces";
-
-const getDependencies = (
-  node: math.MathNode,
-  omit: Set<string> = new Set([])
-): Set<string> => {
-  if (node instanceof math.AssignmentNode) return getDependencies(node.value);
-  if (node instanceof math.FunctionAssignmentNode) {
-    return getDependencies(node.expr, new Set(node.params));
-  }
-  const dependencies = new Set<string>();
-  node.traverse((n) => {
-    if (n instanceof math.SymbolNode && !omit.has(n.name)) {
-      dependencies.add(n.name);
-    }
-  });
-  return dependencies;
-};
 
 export type ParseableObj = {
   expr: string;

--- a/client/src/util/MathScope/index.ts
+++ b/client/src/util/MathScope/index.ts
@@ -1,9 +1,5 @@
 import * as adapter from "./adapter";
-import {
-  AssignmentError,
-  DuplicateAssignmentError,
-  UnmetDependencyError,
-} from "./Evaluator";
+import { AssignmentError, DuplicateAssignmentError } from "./Evaluator";
 import type {
   MathNode,
   EvaluationScope,
@@ -29,7 +25,6 @@ export {
   EvaluationError,
   AssignmentError,
   DuplicateAssignmentError,
-  UnmetDependencyError,
 };
 
 export default MathScope;

--- a/client/src/util/mathjs-utils/getDependencies.spec.ts
+++ b/client/src/util/mathjs-utils/getDependencies.spec.ts
@@ -1,0 +1,31 @@
+import { parse } from "mathjs";
+import getDependencies from "./getDependencies";
+
+test.each([
+  {
+    expr: "1 + [x, y, z/w]",
+    symbols: ["x", "y", "z", "w"],
+  },
+  {
+    expr: "f(g(x), r_2) + x^2 - a",
+    symbols: ["f", "g", "r_2", "x", "a"],
+  },
+])("getDependencies returns symbols used in give node", ({ expr, symbols }) => {
+  const node = parse(expr);
+  const dependencies = getDependencies(node);
+  expect(dependencies).toEqual(new Set(symbols));
+});
+
+test("getDependencies returns symbols used in right-hand side of AssignmentNode", () => {
+  const node = parse("x = 1 + [y, z]");
+  const dependencies = getDependencies(node);
+  // NOT "x"
+  expect(dependencies).toEqual(new Set(["y", "z"]));
+});
+
+test("getDependencies returns symbols used in right-hand side of FunctionAssignmentNode", () => {
+  const node = parse("f(a) = a^2 + b + c");
+  const dependencies = getDependencies(node);
+  // NOT "a"
+  expect(dependencies).toEqual(new Set(["b", "c"]));
+});

--- a/client/src/util/mathjs-utils/getDependencies.ts
+++ b/client/src/util/mathjs-utils/getDependencies.ts
@@ -1,0 +1,31 @@
+import * as math from "mathjs";
+
+// eslint-disable-next-line no-underscore-dangle
+const _getDependencies = (
+  node: math.MathNode,
+  omit: Set<string> = new Set([])
+): Set<string> => {
+  if (node.type === "AssignmentNode") return _getDependencies(node.value);
+  if (node.type === "FunctionAssignmentNode") {
+    return _getDependencies(node.expr, new Set(node.params));
+  }
+  const dependencies = new Set<string>();
+  node.traverse((n) => {
+    if (n.type === "SymbolNode" && !omit.has(n.name)) {
+      dependencies.add(n.name);
+    }
+  });
+  return dependencies;
+};
+
+/**
+ * Returns the symbols that are used in the given node.
+ *
+ * Notes:
+ *  - for AssignmentNodes and FunctionAssignmentNodes, only symbols used in the
+ *    right-hand side are returned.
+ */
+const getDependencies = (node: math.MathNode): Set<string> =>
+  _getDependencies(node);
+
+export default getDependencies;

--- a/client/src/util/mathjs-utils/index.ts
+++ b/client/src/util/mathjs-utils/index.ts
@@ -1,0 +1,1 @@
+export { default as getDependencies } from "./getDependencies";

--- a/client/src/util/parsing/evaluate.ts
+++ b/client/src/util/parsing/evaluate.ts
@@ -25,7 +25,9 @@ class FunctionEvaluationError extends EvaluationError {
 
   constructor(name: string, error: Error) {
     const namedErrors = FunctionEvaluationError.getErrors(name, error);
-    const message = `Error evaluating ${namedErrors[0].name}: ${namedErrors[0].error.message}.`;
+    const message = name.startsWith("_")
+      ? namedErrors[0].error.message
+      : `Error evaluating ${namedErrors[0].name}: ${namedErrors[0].error.message}.`;
     super(message);
     this.innerError = error;
     this.funcName = name;

--- a/client/src/util/validators/domainFuncs.ts
+++ b/client/src/util/validators/domainFuncs.ts
@@ -1,0 +1,41 @@
+import type * as math from "mathjs";
+import { getDependencies } from "@/util/mathjs-utils";
+
+const domainFuncs2 = (value: math.MathNode): [number, number] => {
+  if (value.type !== "ArrayNode") {
+    throw new Error("Expected an ArrayNode");
+  }
+  if (!value.items.every((n) => n.type === "FunctionAssignmentNode")) {
+    throw new Error("Expected an array of FunctionAssignmentNode");
+  }
+  if (value.items.length !== 2) {
+    throw new Error("Expected an array of 2 FunctionAssignmentNode");
+  }
+  const [f1, f2] = value.items as math.FunctionAssignmentNode[];
+  /**
+   * Not a mistake:
+   *   The expression is a function of 2 variables, f(p1, p2)
+   *   The domain is an array of two single-variable functions, [f1(p2), f2(p1)]
+   *   only one of which should actually depend on its argument
+   */
+  const [p1] = f2.params;
+  const [p2] = f1.params;
+  const [deps1, deps2] = [f1.expr, f2.expr].map(getDependencies);
+
+  if (deps1.has(p2) && deps2.has(p1)) {
+    throw new Error(
+      "Cyclic Dependency: Both domain functions depend on each other."
+    );
+  }
+
+  if (deps1.has(p2)) {
+    return [1, 0];
+  }
+  return [0, 1];
+};
+
+const domainFuncs = {
+  2: domainFuncs2,
+};
+
+export { domainFuncs };

--- a/client/src/util/validators/index.ts
+++ b/client/src/util/validators/index.ts
@@ -1,1 +1,2 @@
 export * from "./validators";
+export * from "./domainFuncs";

--- a/client/src/util/validators/interfaces.ts
+++ b/client/src/util/validators/interfaces.ts
@@ -1,0 +1,3 @@
+type Validator<T> = (value: unknown) => T;
+
+export type { Validator };


### PR DESCRIPTION
Changes include:
- Add validators for domain properties
- Add tests for above
- extract `getDependencies` to `mathjs-util`
- Change how `MathScope` handles unmet dependencies. See below.

Regarding unmet dependencies in MathScope: Previously, MathScope was catching errors during evaluation, checking if there were any unmet dependencies, and throwing a new UnmetDependency error if so.

This proved problematic for finer-control of errors, e.g., when we evaluate an array, it might be possible to associate the error with a particular index. Having MathScope modify the errors thrown during `evaluate` was problematic for this.

See #422.