### PR TITLE
add relative camera coordinates

### DIFF
--- a/packages/app/.vscode/settings.json
+++ b/packages/app/.vscode/settings.json
@@ -1,9 +1,0 @@
-{
-  "eslint.enable": true,
-  "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
-  },
-  "eslint.workingDirectories": [
-    "./packages/*"
-  ]
-}

--- a/packages/app/src/api/defaultScene.ts
+++ b/packages/app/src/api/defaultScene.ts
@@ -59,6 +59,7 @@ const defaultScene: Omit<Scene, "id"> = {
         isOrthographic: "false",
         isRotateEnabled: "true",
         position: "\\left[-6, -4, 2\\right]",
+        useRelative: "false",
       },
     },
     {

--- a/packages/app/src/features/scene/Camera.tsx
+++ b/packages/app/src/features/scene/Camera.tsx
@@ -15,6 +15,7 @@ const props = [
   "position",
   "target",
   "updateOnDrag",
+  "useRelative",
 ] as const;
 
 type Coords = [number, number, number];
@@ -67,33 +68,36 @@ const Camera: React.FC<CameraProps> = ({ item, range, onMoveEnd }) => {
     isPanEnabled,
     position,
     updateOnDrag,
+    useRelative,
   } = useMathItemResults(scope, item, props);
 
-  const toThreeJSCoords = useCallback(
+  const fromUiCoords = useCallback(
     (coords: Coords) => {
+      if (useRelative) return coords;
       return project(coords, range, THREEJS_RANGE);
     },
-    [range]
+    [range, useRelative]
   );
-  const toMathboxCoords = useCallback(
+  const toUiCoords = useCallback(
     (coords: Coords) => {
+      if (useRelative) return coords;
       return project(coords, THREEJS_RANGE, range);
     },
-    [range]
+    [range, useRelative]
   );
 
-  const threePos = position ? toThreeJSCoords(position) : undefined;
+  const threePos = position ? fromUiCoords(position) : undefined;
   const onEnd: OnControlsChangeEnd = useCallback(
     (e) => {
       if (!updateOnDrag) return;
       const cameraPosition = e.target.object.position.toArray();
       const target = e.target.target.toArray();
       onMoveEnd?.({
-        position: toMathboxCoords(cameraPosition),
-        target: toMathboxCoords(target),
+        position: toUiCoords(cameraPosition),
+        target: toUiCoords(target),
       });
     },
-    [onMoveEnd, toMathboxCoords, updateOnDrag]
+    [onMoveEnd, toUiCoords, updateOnDrag]
   );
   return (
     <>

--- a/packages/app/src/features/scene/Scene.tsx
+++ b/packages/app/src/features/scene/Scene.tsx
@@ -1,5 +1,5 @@
 import mergeClassNames from "classnames";
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 import * as MB from "mathbox-react";
 import type { MathboxSelection } from "mathbox";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
@@ -7,6 +7,7 @@ import { Vector3 } from "three";
 import { useAppDispatch, useAppSelector } from "@/store/hooks";
 import { isMathGraphic, MathItemType } from "@math3d/mathitem-configs";
 import invariant from "tiny-invariant";
+import { debounce } from "lodash";
 import { actions, select } from "../sceneControls/mathItems/mathItemsSlice";
 import { Graphic, graphicNeedsRange } from "./graphics";
 import useAxesInfo from "./useAxesInfo";
@@ -39,25 +40,25 @@ const SceneContent = () => {
   const [x, y, z, camera] = useAppSelector(select.getItems(REQUIRED_ITEMS));
   invariant(camera.type === MathItemType.Camera);
   const { scale, range } = useAxesInfo(x, y, z);
-  const onCameraChange: OnMoveEnd = useCallback(
-    (event) => {
+
+  const onCameraChange: OnMoveEnd = useMemo(() => {
+    return debounce((event) => {
       dispatch(
         actions.patchProperty({
           id: camera.id,
           path: "/position",
-          value: `[${event.position.map((pos) => pos.toPrecision(3))}]`,
+          value: `[${event.position.map((pos) => pos.toPrecision(6))}]`,
         })
       );
       dispatch(
         actions.patchProperty({
           id: camera.id,
           path: "/target",
-          value: `[${event.target.map((pos) => pos.toPrecision(3))}]`,
+          value: `[${event.target.map((pos) => pos.toPrecision(6))}]`,
         })
       );
-    },
-    [dispatch, camera.id]
-  );
+    }, 200);
+  }, [dispatch, camera.id]);
   return (
     <MB.Cartesian range={range} scale={scale}>
       <Camera item={camera} range={range} onMoveEnd={onCameraChange} />

--- a/packages/app/src/features/scene/Scene.tsx
+++ b/packages/app/src/features/scene/Scene.tsx
@@ -42,7 +42,7 @@ const SceneContent = () => {
   const { scale, range } = useAxesInfo(x, y, z);
 
   const onCameraChange: OnMoveEnd = useMemo(() => {
-    return debounce((event) => {
+    const cb: OnMoveEnd = (event) => {
       dispatch(
         actions.patchProperty({
           id: camera.id,
@@ -57,7 +57,8 @@ const SceneContent = () => {
           value: `[${event.target.map((pos) => pos.toPrecision(6))}]`,
         })
       );
-    }, 200);
+    };
+    return debounce(cb, 200);
   }, [dispatch, camera.id]);
   return (
     <MB.Cartesian range={range} scale={scale}>

--- a/packages/app/src/features/scene/Scene.tsx
+++ b/packages/app/src/features/scene/Scene.tsx
@@ -1,13 +1,13 @@
 import mergeClassNames from "classnames";
-import React, { useCallback, useMemo } from "react";
+import React, { useMemo } from "react";
 import * as MB from "mathbox-react";
 import type { MathboxSelection } from "mathbox";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
 import { Vector3 } from "three";
-import { useAppDispatch, useAppSelector } from "@/store/hooks";
 import { isMathGraphic, MathItemType } from "@math3d/mathitem-configs";
 import invariant from "tiny-invariant";
 import { debounce } from "lodash";
+import { useAppDispatch, useAppSelector } from "@/store/hooks";
 import { actions, select } from "../sceneControls/mathItems/mathItemsSlice";
 import { Graphic, graphicNeedsRange } from "./graphics";
 import useAxesInfo from "./useAxesInfo";

--- a/packages/app/src/features/sceneControls/mathItems/forms/Camera/index.tsx
+++ b/packages/app/src/features/sceneControls/mathItems/forms/Camera/index.tsx
@@ -21,6 +21,7 @@ const propNames = [
   "isPanEnabled",
   "position",
   "target",
+  "useRelative",
   "updateOnDrag",
   "isOrthographic",
 ] as const;

--- a/packages/mathitem-configs/src/items/camera.ts
+++ b/packages/mathitem-configs/src/items/camera.ts
@@ -16,6 +16,7 @@ interface CameraProperties {
   position: string;
   target: string;
   updateOnDrag: string;
+  useRelative: string;
 }
 
 const defaultValues: CameraProperties = {
@@ -27,6 +28,7 @@ const defaultValues: CameraProperties = {
   position: "[-6, -4, 2]",
   target: "[0, 0, 0]",
   updateOnDrag: "true",
+  useRelative: "false",
 };
 
 type EvaluatedProperties = {
@@ -37,6 +39,7 @@ type EvaluatedProperties = {
   updateOnDrag: boolean;
   position: [number, number, number];
   target: [number, number, number];
+  useRelative: boolean;
 };
 
 const make: MathItemGenerator<MathItemType.Camera, CameraProperties> = (
@@ -97,6 +100,12 @@ const config: IMathItemConfig<
       label: "Look At",
       widget: WidgetType.MathValue,
       validate: validators.realVec[3],
+    },
+    useRelative: {
+      name: "useRelative",
+      label: "Use relative coordinates",
+      widget: WidgetType.MathBoolean,
+      validate: validators.boolean,
     },
   },
   settingsProperties: [],

--- a/packages/mathitem-configs/src/schema.jtd.yaml
+++ b/packages/mathitem-configs/src/schema.jtd.yaml
@@ -128,6 +128,8 @@ definitions:
         type: string
       updateOnDrag:
         type: string
+      useRelative:
+        type: string
   itemPropertiesExplicitSurface:
     properties:
       description:


### PR DESCRIPTION
This adds relative camera coordinates. I.e., explicit camera coordinates can now be "scene coordinates" using the scene axes, or they can be scaled to range [-1, 1]. Relative and scene coordinates each have advantages:
- When changing axis ranges, a camera positioned by relative coordinates probably behaves more the way users would expect if the user is only positioning camera via drag
- scene coordinates are convenient if you want an exact camera location

So let's support both.

Prior to this PR, math3d-next was "scene-coordinates only" for cameras. This also would have been problematic for migrating data into math3d-next, since old math3d only has scene coordinates if users are using "computed camera".