### PR TITLE
add a test that x! = 5 is a bad assignment

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "lint": "turbo run lint",
     "test": "turbo run test",
+    "start": "yarn workspace app start",
     "build": "yarn workspace app build"
   }
 }

--- a/packages/parser/src/parsers.spec.ts
+++ b/packages/parser/src/parsers.spec.ts
@@ -171,8 +171,16 @@ describe("Parsing assignments and function assignments", () => {
         rhsErr: undefined,
       },
     },
+    {
+      lhs: "x!",
+      rhs: "1",
+      expected: {
+        lhsErr: /Invalid left-hand side/,
+        rhsErr: undefined,
+      },
+    },
   ])(
-    "Associates parse function asiggnment { lhs, rhs } errors with lhs or rhs",
+    "Associates parse asiggnment { lhs, rhs } errors with lhs or rhs",
     ({ lhs, rhs, expected }) => {
       const err = getParseError({ lhs, rhs, type: "assignment" });
       const methods = {


### PR DESCRIPTION
In the olden days this was parsing as `x != 5`, which evaluated to true (but was not valid as an assignment).

Closes https://github.com/ChristopherChudzicki/math3d-next/issues/357