### PR TITLE
Fix camera position

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -174,21 +178,21 @@
         "filename": "webserver/main/settings.py",
         "hashed_secret": "edac4cad6ab47e16c61a53b75a9db5c4cedc10f9",
         "is_verified": false,
-        "line_number": 40
+        "line_number": 41
       },
       {
         "type": "Secret Keyword",
         "filename": "webserver/main/settings.py",
         "hashed_secret": "99a90fb96e37ff2d10a95c42cb11b81a66755cf0",
         "is_verified": false,
-        "line_number": 130
+        "line_number": 131
       },
       {
         "type": "Secret Keyword",
         "filename": "webserver/main/settings.py",
         "hashed_secret": "dc2449acc3616e7a40a48f6797c6d62763a136a0",
         "is_verified": false,
-        "line_number": 131
+        "line_number": 132
       }
     ],
     "webserver/scenes/models.py": [
@@ -201,5 +205,5 @@
       }
     ]
   },
-  "generated_at": "2025-03-30T20:04:56Z"
+  "generated_at": "2025-04-28T00:27:42Z"
 }

--- a/webserver/main/settings.py
+++ b/webserver/main/settings.py
@@ -27,6 +27,7 @@ env = environ.Env(
     DEFAULT_FROM_EMAIL=(str, ""),
     SERVER_EMAIL=(str, ""),
     APP_BASE_URL=(str, ""),
+    INGESTION_DATABASE_URL=(str, ""),
 )
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -256,3 +257,5 @@ if os.environ.get("IS_HEROKU"):
     import django_heroku  # type: ignore
 
     django_heroku.settings(locals())
+
+INGESTION_DATABASE_URL = env("INGESTION_DATABASE_URL")

--- a/webserver/scenes/legacy_scene_utils/migrate_scene.py
+++ b/webserver/scenes/legacy_scene_utils/migrate_scene.py
@@ -1,3 +1,4 @@
+from typing import Annotated
 from scenes.legacy_scene_utils.translate import ItemMigrator
 from scenes.models import Scene, LegacyScene
 
@@ -19,7 +20,7 @@ def parse_value(value: str, default: float) -> float:
         return default
 
 
-def get_axis_scales(old_items: dict) -> tuple[float, float, float]:
+def get_axis_scales(old_items: dict) -> Annotated[list[float], 3]:
     """
     Get the axis scales from the old items. The axis scales are stored in the
     properties of the axis items.

--- a/webserver/scenes/legacy_scene_utils/migrate_scene.py
+++ b/webserver/scenes/legacy_scene_utils/migrate_scene.py
@@ -1,4 +1,3 @@
-from typing import Annotated
 from scenes.legacy_scene_utils.translate import ItemMigrator
 from scenes.models import Scene, LegacyScene
 
@@ -20,7 +19,7 @@ def parse_value(value: str, default: float) -> float:
         return default
 
 
-def get_axis_scales(old_items: dict) -> Annotated[list[float], 3]:
+def get_axis_scales(old_items: dict) -> tuple[float, float, float]:
     """
     Get the axis scales from the old items. The axis scales are stored in the
     properties of the axis items.
@@ -34,7 +33,7 @@ def get_axis_scales(old_items: dict) -> Annotated[list[float], 3]:
         elif item_id == "axis-z":
             z_scale = parse_value(item.get("properties", {}).get("scale", "1/2"), 0.5)
 
-    return [x_scale, y_scale, z_scale]
+    return x_scale, y_scale, z_scale
 
 
 def migrate_scene(legacy_scene: LegacyScene):

--- a/webserver/scenes/legacy_scene_utils/migrate_scene.py
+++ b/webserver/scenes/legacy_scene_utils/migrate_scene.py
@@ -4,9 +4,40 @@ from scenes.models import Scene, LegacyScene
 from scenes.legacy_scene_utils.default_data import set_defaults
 
 
+def parse_value(value: str, default: float) -> float:
+    """
+    Parse a value from a string to a float. The value can be a fraction or a
+    decimal number.
+    """
+    try:
+        if "/" in value:
+            numerator, denominator = value.split("/")
+            return float(numerator) / float(denominator)
+        return float(value)
+    except ValueError:
+        # If the value cannot be parsed, return the default value
+        return default
+
+
+def get_axis_scales(old_items: dict) -> tuple[float, float, float]:
+    """
+    Get the axis scales from the old items. The axis scales are stored in the
+    properties of the axis items.
+    """
+    x_scale = y_scale = z_scale = 1.0
+    for item_id, item in old_items.items():
+        if item_id == "axis-x":
+            x_scale = parse_value(item.get("properties", {}).get("scale", "1"), 1)
+        elif item_id == "axis-y":
+            y_scale = parse_value(item.get("properties", {}).get("scale", "1"), 1)
+        elif item_id == "axis-z":
+            z_scale = parse_value(item.get("properties", {}).get("scale", "1/2"), 0.5)
+
+    return [x_scale, y_scale, z_scale]
+
+
 def migrate_scene(legacy_scene: LegacyScene):
     set_defaults(legacy_scene)
-    migrator = ItemMigrator()
 
     for item_id, item in legacy_scene.dehydrated["folders"].items():
         item["type"] = "FOLDER"
@@ -32,6 +63,13 @@ def migrate_scene(legacy_scene: LegacyScene):
         **legacy_scene.dehydrated["mathSymbols"],
     }
 
+    axis_scales = get_axis_scales(old_items)
+
+    migrator = ItemMigrator(
+        x_scale=axis_scales[0],
+        y_scale=axis_scales[1],
+        z_scale=axis_scales[2],
+    )
     items = []
     for item_id, item in old_items.items():
         items.append(migrator.translate_item(item, item_id).to_json_data())

--- a/webserver/scenes/legacy_scene_utils/translate.py
+++ b/webserver/scenes/legacy_scene_utils/translate.py
@@ -14,10 +14,19 @@ def stringify(obj: bool):
 
 
 class ItemMigrator:
-    def __init__(self, log: IssueLog | None = None):
+    def __init__(
+        self,
+        log: IssueLog | None = None,
+        x_scale: float = 1.0,
+        y_scale: float = 1.0,
+        z_scale: float = 0.5,
+    ):
         if log is None:
             log = IssueLog()
         self.log = log
+        self.x_scale = x_scale
+        self.y_scale = y_scale
+        self.z_scale = z_scale
 
     def assignment(self, expr: str) -> new.ParseableAssignment:
         lhs, *rhs_pieces = expr.split("=")
@@ -125,8 +134,20 @@ class ItemMigrator:
 
     def translate_camera(self, props) -> new.ItemPropertiesCamera:
         x = old.CameraProperties(**props)
-        position = str(x.relativePosition)
-        target = str(x.relativeLookAt)
+
+        relativePosition = [
+            # Some legacy data has relativePosition as [null, null, null]
+            (x.relativePosition[0] or 0.5) / self.x_scale,
+            (x.relativePosition[1] or -2) / self.y_scale,
+            (x.relativePosition[2] or 0.5) / self.z_scale,
+        ]
+        relativeLookAt = [
+            (x.relativeLookAt[0] or 0) / self.x_scale,
+            (x.relativeLookAt[1] or 0) / self.y_scale,
+            (x.relativeLookAt[2] or 0) / self.z_scale,
+        ]
+        position = str(relativePosition)
+        target = str(relativeLookAt)
         if x.useComputed:
             position = x.computedPosition
             target = x.computedLookAt

--- a/webserver/scenes/legacy_scene_utils/translate_test.py
+++ b/webserver/scenes/legacy_scene_utils/translate_test.py
@@ -94,8 +94,8 @@ def test_boolean_variable():
             },
             {
                 "useRelative": "true",
-                "position": "[0.1, 0.2, 0.3]",
-                "target": "[0, 0, -0.1]",
+                "position": "[0.1, 0.2, 0.6]",
+                "target": "[0.0, 0.0, -0.2]",
             },
         ),
         (

--- a/webserver/scenes/management/commands/pull_scenes.py
+++ b/webserver/scenes/management/commands/pull_scenes.py
@@ -1,0 +1,67 @@
+import psycopg2
+from django.core.management.base import BaseCommand
+from django.conf import settings
+from tqdm import tqdm
+from scenes.models import Scene, LegacyScene
+
+
+class Command(BaseCommand):
+    help = "Pull Scene and LegacyScene data from an external database."
+
+    def handle(self, *args, **kwargs):
+        ingestion_db_url = settings.INGESTION_DATABASE_URL
+
+        # Connect to the external database
+        conn = psycopg2.connect(ingestion_db_url)
+
+        try:
+            with conn.cursor() as cursor:
+                # Fetch total count of scenes
+                cursor.execute("SELECT COUNT(*) FROM scenes_scene;")
+                total_scenes = cursor.fetchone()[0]
+
+                self.stdout.write(f"Total scenes to fetch: {total_scenes}")
+
+            with conn.cursor(name="scene_fetcher") as cursor:
+                cursor.itersize = 500
+                cursor.execute(
+                    "SELECT key, items, item_order, title, archived, times_accessed FROM scenes_scene;"
+                )
+
+                for scene_data in tqdm(
+                    cursor, total=total_scenes, desc="Fetching scenes"
+                ):
+                    scene_dict = {
+                        "key": scene_data[0],
+                        "items": scene_data[1],
+                        "item_order": scene_data[2],
+                        "title": scene_data[3],
+                        "archived": scene_data[4],
+                        "times_accessed": scene_data[5],
+                    }
+                    Scene.objects.update_or_create(
+                        key=scene_dict["key"], defaults=scene_dict
+                    )
+
+            with conn.cursor(name="legacy_scene_fetcher") as cursor:
+                cursor.itersize = 500
+                cursor.execute(
+                    "SELECT key, times_accessed, last_accessed, dehydrated, migration_note FROM scenes_legacyscene;"
+                )
+
+                for legacy_scene_data in tqdm(cursor, desc="Fetching legacy scenes"):
+                    legacy_scene_dict = {
+                        "key": legacy_scene_data[0],
+                        "times_accessed": legacy_scene_data[1],
+                        "last_accessed": legacy_scene_data[2],
+                        "dehydrated": legacy_scene_data[3],
+                        "migration_note": legacy_scene_data[4],
+                    }
+                    LegacyScene.objects.update_or_create(
+                        key=legacy_scene_dict["key"], defaults=legacy_scene_dict
+                    )
+
+        finally:
+            conn.close()
+
+        self.stdout.write(self.style.SUCCESS("Successfully fetched all scenes."))


### PR DESCRIPTION
Closes #943 (mostly)

In math3d-react, relative camera coordinates go from `[-S, +S]` where `S` is the axis scale. In math3d-next, they go from `[-1, +1]`. (Which is how I thought they worked in math3d-react at the time...).

This accounts for that discrepancy, mostly. I saw "mostly" because it's done during the backend migration, which can't really evaluate mathematical expressions like the frontend. The default axis scales are `["1", "1", "1/2"]`, all of which are straightforward to parse on the backend. But a scale like `"1+1"` or `A+B` won't be interpreted correctly on the backend, so the camera position won't be quite right. This (A) isn't too bad, and (B) seems like it should be rare.

