### PR TITLE
chore: add GitHub PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+<!-- PR title must be a conventional commit: type(scope?): subject — see https://www.conventionalcommits.org -->
+
+### What are the relevant issues?
+
+<!-- Link to the issue here (closes #, fixes #, etc), or write N/A -->
+
+### Description
+
+<!-- Describe your changes in detail. -->
+
+### Screenshots (if appropriate)
+
+<!-- Remove if irrelevant. -->
+
+### How can this be tested?
+
+<!-- Describe how a reviewer can validate your changes. -->
+
+### Additional context
+
+<!-- Any reviewer questions, deployment notes, etc. -->
+
+### Checklist:
+
+- [ ] e.g. Update secret values in Vault before merging
+      --->


### PR DESCRIPTION
## Summary
- Adds a pull request template (`.github/pull_request_template.md`) with sections for relevant issues, description, screenshots, testing instructions, additional context, and a checklist.
- Includes a comment reminding contributors that PR titles must follow conventional commit format, consistent with the existing `pr-title-check` CI workflow.

## Test plan
- [ ] Open a new PR draft and verify the template populates automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)