### PR TITLE
refactor: Replace Node EventEmitter with native EventTarget

### DIFF
--- a/packages/app/src/features/sceneControls/mathItems/__tests__/variable-slider.spec.tsx
+++ b/packages/app/src/features/sceneControls/mathItems/__tests__/variable-slider.spec.tsx
@@ -101,7 +101,7 @@ const setupTest = async (overrides: Overrides = {}) => {
   const valueId = mathScopeId(item.id, "value");
   const mathScope = store.getState().scene.mathScope();
   mathScope.addEventListener("change", (e) => {
-    if (e.changes.results.updated.has(mathScopeId(item.id, "value"))) {
+    if (e.detail.changes.results.updated.has(mathScopeId(item.id, "value"))) {
       const v = mathScope.results.get(valueId);
       if (typeof v !== "number") {
         throw new Error(`Value should be a number; received ${value}`);

--- a/packages/app/src/features/sceneControls/mathItems/mathScope.ts
+++ b/packages/app/src/features/sceneControls/mathItems/mathScope.ts
@@ -60,8 +60,8 @@ const useMathResults = <K extends string>(
 
   const onChange = useCallback<OnChangeListener<AppParseable>>(
     (event) => {
-      const { mathScope } = event;
-      const { results } = event.changes;
+      const { mathScope } = event.detail;
+      const { results } = event.detail.changes;
       if (names.some((name) => results.touched.has(ids[name]))) {
         const patch = pickBy(
           extractResults(mathScope, ids),
@@ -123,8 +123,8 @@ const useMathErrors = <K extends string>(
 
   const onChange = useCallback<OnChangeListener<AppParseable>>(
     (event) => {
-      const { mathScope } = event;
-      const { errors } = event.changes;
+      const { mathScope } = event.detail;
+      const { errors } = event.detail.changes;
       if (names.some((name) => errors.touched.has(ids[name]))) {
         setErrors(extractErrors(mathScope, ids));
       }

--- a/packages/mathscope/src/MathScope.spec.ts
+++ b/packages/mathscope/src/MathScope.spec.ts
@@ -102,7 +102,9 @@ describe('MathScope "change" Events', () => {
       },
     };
     expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenCalledWith(event);
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ detail: event }),
+    );
   });
 
   test("Deleting expressions triggers a change", () => {
@@ -135,7 +137,9 @@ describe('MathScope "change" Events', () => {
       },
     };
     expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenCalledWith(event);
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ detail: event }),
+    );
   });
 
   test("Removing event listeners", () => {
@@ -191,7 +195,9 @@ describe('MathScope "change-errors" Events', () => {
       },
     };
     expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenLastCalledWith(event1);
+    expect(spy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ detail: event1 }),
+    );
 
     mathScope.setExpressions([{ id: "a", parseable: "a = 4 + +" }]);
     const event2: ScopeChangeErrorsEvent<Parseable> = {
@@ -207,7 +213,9 @@ describe('MathScope "change-errors" Events', () => {
     };
 
     expect(spy).toHaveBeenCalledTimes(2);
-    expect(spy).toHaveBeenLastCalledWith(event2);
+    expect(spy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ detail: event2 }),
+    );
 
     mathScope.setExpressions([{ id: "a", parseable: "a = 4" }]);
     const event3: ScopeChangeErrorsEvent<Parseable> = {
@@ -223,7 +231,9 @@ describe('MathScope "change-errors" Events', () => {
     };
 
     expect(spy).toHaveBeenCalledTimes(3);
-    expect(spy).toHaveBeenLastCalledWith(event3);
+    expect(spy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ detail: event3 }),
+    );
   });
 
   test("Adding with eval errors does trigger the event", () => {
@@ -251,7 +261,9 @@ describe('MathScope "change-errors" Events', () => {
       },
     };
     expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenCalledWith(event);
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ detail: event }),
+    );
   });
 
   test("Deleting without eval errors does not trigger the event", () => {
@@ -293,7 +305,9 @@ describe('MathScope "change-errors" Events', () => {
       },
     };
     expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenCalledWith(event);
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ detail: event }),
+    );
   });
 
   test("Removing event listeners", () => {


### PR DESCRIPTION
### What are the relevant issues?

N/A

### Description

Replace the Node.js `EventEmitter` (from the `events` polyfill) with the browser-native `EventTarget` API in `MathScope`. This removes the Node polyfill from the browser bundle.

- `EventEmitter` → `EventTarget`
- `emit(type, data)` → `dispatchEvent(new CustomEvent(type, { detail: data }))`
- `addListener` / `removeListener` → `addEventListener` / `removeEventListener`
- Listeners now receive a `CustomEvent` with the payload on `.detail`
- Removed `setMaxListeners(Infinity)` (not needed with `EventTarget`)

### How can this be tested?

- `yarn workspace @math3d/mathscope test` — all 75 tests pass
- `yarn typecheck` — no type errors
- Verify app works correctly in browser (expression evaluation, sliders, error display)

### Additional context

`EventTarget` is available natively in all modern browsers and in Node >= 15, so tests run fine under Vitest as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)