### PR TITLE
ci(e2e): replace shard matrix with single job at workers:2

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,12 +14,6 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     environment: "ci"
-    # TEMPORARY: flakiness check for workers:2 — run the job 3× in parallel,
-    # each repeating every test 3× (9 full-suite passes). Revert before merge.
-    strategy:
-      fail-fast: false
-      matrix:
-        attempt: [1, 2, 3]
     env:
       SKIP_YARN_COREPACK_CHECK: true
       APP_BASE_URL: ${{ vars.APP_BASE_URL }}
@@ -81,15 +75,12 @@ jobs:
       - name: Install Playwright Browsers
         run: yarn workspace app-tests-e2e playwright install --with-deps
       - name: Run Playwright tests
-        # TEMPORARY: --repeat-each=3 and --retries=0 for the flakiness check
-        # (retries:2 would mask 2-worker races). Revert to `yarn test-e2e`
-        # before merge.
-        run: yarn test-e2e --repeat-each=3 --retries=0
+        run: yarn test-e2e
         env:
           CI: True
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report-${{ matrix.attempt }}
+          name: playwright-report
           path: packages/app-tests-e2e/playwright-report/
           retention-days: 30

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,10 +14,12 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     environment: "ci"
+    # TEMPORARY: flakiness check for workers:2 — run the job 3× in parallel,
+    # each repeating every test 3× (9 full-suite passes). Revert before merge.
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        attempt: [1, 2, 3]
     env:
       SKIP_YARN_COREPACK_CHECK: true
       APP_BASE_URL: ${{ vars.APP_BASE_URL }}
@@ -79,12 +81,15 @@ jobs:
       - name: Install Playwright Browsers
         run: yarn workspace app-tests-e2e playwright install --with-deps
       - name: Run Playwright tests
-        run: yarn test-e2e --shard=${{ matrix.shard }}/4
+        # TEMPORARY: --repeat-each=3 and --retries=0 for the flakiness check
+        # (retries:2 would mask 2-worker races). Revert to `yarn test-e2e`
+        # before merge.
+        run: yarn test-e2e --repeat-each=3 --retries=0
         env:
           CI: True
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report-${{ matrix.shard }}
+          name: playwright-report-${{ matrix.attempt }}
           path: packages/app-tests-e2e/playwright-report/
           retention-days: 30

--- a/packages/app-tests-e2e/playwright.config.ts
+++ b/packages/app-tests-e2e/playwright.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   testMatch: "**/?(*.)+(test).ts",
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : "25%",
+  workers: process.env.CI ? 2 : "25%",
   reporter: "html",
   use: {
     baseURL: env.TEST_APP_URL,


### PR DESCRIPTION
### What are the relevant issues?

N/A — CI cleanup enabled by #1129.

### Description

#1129 disabled the webgl-heavy MathBox library by default in E2E tests
(`disable3d` defaults to `true`), so the suite is now ~35s of a ~4min job —
**setup dominates**. The 4-way shard matrix therefore paid that setup cost
(docker build, frontend build, `playwright install`) **4×** for little
wall-clock gain, while fragmenting results into four `playwright-report-N`
artifacts.

This collapses the e2e job to a **single runner with two in-process Playwright
workers** (`workers: 2`) instead of four single-worker machines — one report
artifact, ~¼ the runner minutes. The shipped single-job run lands ~4min.

**Concurrency safety:** the shared backend already tolerated 4-wide concurrency
(the four shards hit it in parallel), so two workers introduce no new collision
surface.

### Flakiness check (done)

Before settling on `workers: 2`, a temporary harness ran the job as a 3-way
matrix with `--repeat-each=3 --retries=0` — **9 full-suite passes across 3
isolated backends, all green, no flakes**. The harness was then reverted; this
PR is now just `workers: 2` + a single `yarn test-e2e` job.

### How can this be tested?

- The e2e job on this PR is the single-job shipped config; it passed (~4min).
- Locally: `yarn test-e2e` (uses `"25%"` workers outside CI).

### Checklist:

- [x] Flakiness check green (3× `--repeat-each=3 --retries=0`)
- [x] Reverted temporary matrix + `--repeat-each`/`--retries` harness
- [x] Shipped single-job config green in CI