### PR TITLE
fix(auth): treat allauth's success-401 as success on password reset

### DIFF
--- a/packages/api/src/hooks/auth/index.ts
+++ b/packages/api/src/hooks/auth/index.ts
@@ -134,8 +134,20 @@ const useResetPassword = () => {
 
 const useResetPasswordConfirm = () => {
   return useMutation({
-    mutationFn: (data: AllAuthResetPasswordRequest) =>
-      allAuthResetPassword(data),
+    mutationFn: async (data: AllAuthResetPasswordRequest) => {
+      try {
+        return await allAuthResetPassword(data);
+      } catch (err) {
+        // allauth returns 401 after a successful password reset when the user
+        // is not logged in (ACCOUNT_LOGIN_ON_PASSWORD_RESET is False). The
+        // password has been changed — the user just needs to log in. An
+        // invalid/expired key returns 400, so it still surfaces as an error.
+        if (err instanceof AxiosError && err.response?.status === 401) {
+          return err.response;
+        }
+        throw err;
+      }
+    },
   });
 };
 

--- a/packages/app-tests-e2e/src/tests/auth-flows/password-reset.test.ts
+++ b/packages/app-tests-e2e/src/tests/auth-flows/password-reset.test.ts
@@ -1,0 +1,78 @@
+import { test } from "@/fixtures/users";
+import { expect } from "@/utils/expect";
+import AppPage from "@/utils/pages/AppPage";
+import { getInbox } from "@/utils/inbox/emails";
+import { createActiveUser, deleteUser } from "@/utils/api/auth";
+import { makeUserInfo } from "@math3d/mock-api";
+import { faker } from "@faker-js/faker/locale/en";
+import invariant from "tiny-invariant";
+
+test.setTimeout(60_000);
+
+test.describe("Password reset flow", () => {
+  test("Reset password via emailed link, then log in", async ({
+    page,
+    context,
+  }) => {
+    const inbox = getInbox();
+    const app = new AppPage(page);
+    const { auth, cleanup } = await createActiveUser(makeUserInfo());
+    const newPassword = faker.internet.password();
+
+    try {
+      await test.step("Request password reset", async () => {
+        await page.goto("/auth/reset-password");
+        const dialog = page.getByRole("dialog", { name: "Reset Password" });
+        await dialog.getByLabel("Email").fill(auth.email);
+        await dialog.getByRole("button", { name: "Reset Password" }).click();
+        await expect(page.getByRole("alert")).toContainText(
+          /please use the link emailed to/,
+        );
+      });
+
+      const resetLink = await test.step("Retrieve reset link", async () => {
+        const message = await inbox.waitForEmail({
+          subject: /Password reset/,
+          to: auth.email,
+        });
+        invariant(message.html, "Expected email to have HTML content");
+        const messagePage = await context.newPage();
+        await messagePage.setContent(message.html);
+        const href = await messagePage
+          .getByTestId("password-reset-link")
+          .getAttribute("href");
+        invariant(href, "Expected reset link to have href");
+        await messagePage.close();
+        return href;
+      });
+
+      await test.step("Set a new password", async () => {
+        await page.goto(resetLink);
+        const dialog = page.getByRole("dialog", { name: "Change Password" });
+        await dialog
+          .getByLabel("New Password", { exact: true })
+          .fill(newPassword);
+        await dialog.getByLabel("Confirm New Password").fill(newPassword);
+        await dialog.getByRole("button", { name: "Change Password" }).click();
+        await expect(dialog.getByRole("alert")).toContainText(
+          /Password changed/,
+        );
+      });
+
+      await test.step("Log in with the new password", async () => {
+        await page.goto("/");
+        await app
+          .signinPage()
+          .signin({ email: auth.email, password: newPassword });
+        await app.userMenu().opener().click();
+        await expect(app.userMenu().username()).toHaveText(auth.email);
+      });
+    } finally {
+      // The reset changes the password, so delete with whichever credential is
+      // valid: the new password if the reset succeeded, the original (via
+      // cleanup) otherwise. Both no-op if the account is already gone.
+      await deleteUser({ email: auth.email, password: newPassword });
+      await cleanup();
+    }
+  });
+});

--- a/packages/app-tests-e2e/src/utils/api/auth.ts
+++ b/packages/app-tests-e2e/src/utils/api/auth.ts
@@ -47,6 +47,25 @@ const getSessionCookies = async (
   return { sessionid: cookies.sessionid, csrftoken: cookies.csrftoken };
 };
 
+/**
+ * Log in as the given user and self-delete their account. Resolves silently if
+ * login fails (e.g. the account is already gone or the password is no longer
+ * valid). Leaked users are not actively reclaimed; this is harmless in CI,
+ * where the database is recreated fresh each run.
+ */
+const deleteUser = async (user: UserCredentials): Promise<void> => {
+  try {
+    const cookies = await getSessionCookies(user);
+    await axios.post(
+      `/v0/auth/users/me/delete/`,
+      { current_password: user.password },
+      { headers: authHeaders(cookies) },
+    );
+  } catch {
+    // Account already deleted or password no longer valid — ignore.
+  }
+};
+
 type UserInfo = {
   email?: string;
   password?: string;
@@ -134,30 +153,11 @@ const createActiveUser = async (user: UserInfo = {}) => {
     }
   }
 
-  const cleanup = async () => {
-    // Log in as the user and self-delete.
-    // If login fails (e.g., the test changed the password), ignore the error.
-    // Leaked users are not actively reclaimed; this is harmless in CI only
-    // because the database is recreated fresh each run.
-    try {
-      const userCookies = await getSessionCookies({
-        email: request.email,
-        password: request.password,
-      });
-      await axios.post(
-        `/v0/auth/users/me/delete/`,
-        { current_password: request.password },
-        { headers: authHeaders(userCookies) },
-      );
-    } catch {
-      // User may already be deleted or password was changed — ignore
-    }
-  };
-
   const userAuth: UserCredentials = {
     email: request.email,
     password: request.password,
   };
+  const cleanup = () => deleteUser(userAuth);
   const userInfo: Required<UserInfo> = {
     email: request.email,
     password: request.password,
@@ -166,5 +166,5 @@ const createActiveUser = async (user: UserInfo = {}) => {
   return { auth: userAuth, info: userInfo, cleanup };
 };
 
-export { authHeaders, getSessionCookies, users, createActiveUser };
+export { authHeaders, getSessionCookies, deleteUser, users, createActiveUser };
 export type { SessionCookies, UserInfo, UserCredentials };

--- a/packages/mock-api/src/handlers.ts
+++ b/packages/mock-api/src/handlers.ts
@@ -285,7 +285,12 @@ export const handlers = [
   }),
   // allauth reset password with key
   http.post(urls.auth.resetPassword, async () => {
-    return HttpResponse.json({ status: 200 });
+    // Real allauth resets the password but returns 401 because the user is not
+    // logged in yet — it does not auto-authenticate. Mirror that here.
+    return HttpResponse.json(
+      { status: 401, meta: { is_authenticated: false } },
+      { status: 401 },
+    );
   }),
   // allauth change password
   http.post(urls.auth.changePassword, async () => {


### PR DESCRIPTION
### What are the relevant issues?

Fixes the broken password-reset flow on prod (no issue filed; reported directly). Related to the allauth migration (#1129).

### Description

Resetting a password failed: after submitting a new password the UI showed
*"Something went wrong"* (and a retry then showed *"The password reset token was
invalid"*), even though the password had actually been changed.

**Root cause.** django-allauth headless returns **HTTP 401** from
`POST /_allauth/browser/v1/auth/password/reset` on a *successful* reset when the
user is not auto-logged-in (`ACCOUNT_LOGIN_ON_PASSWORD_RESET` defaults to
`False`). The password write happens unconditionally; the 401 only means "you're
now unauthenticated, here's your `login` flow." `useResetPasswordConfirm` treated
any non-2xx as failure. The prod *400 invalid_password_reset* was a downstream
effect of retrying — allauth's reset key is single-use, so the first (mis-reported)
attempt had already consumed it.

Verified against allauth 65.15.0 source: every *failure* on this endpoint is a
distinct status (400 invalid key, 403 CSRF, 409 conflict, 429 rate-limit), so a
401 here is exclusively the success-but-unauthenticated response.

**Fix.** Handle the success-401 exactly as the sibling hooks
`useActivateUser` / `useCreateUser` / `useLogout` already do. Invalid/expired
keys still return 400, so they still surface as errors. The intended
"please log in" UX is preserved (no auto-login-on-reset).

**Why no test caught it.** The mock-api handler for the reset endpoint returned
a fake `200`, diverging from real allauth. Corrected to the realistic `401`
(matching the `verifyEmail` handler beside it). This turns the existing
`ResetPasswordConfirmPage` happy-path spec into a real regression guard —
verified to fail without the fix and pass with it.

### How can this be tested?

- New e2e `password-reset.test.ts`: request reset → fetch email → open link →
  set new password → log in with it (proves the password actually changed).
- Unit: `ResetPasswordConfirmPage.spec.tsx` happy-path now runs through the
  realistic 401 mock (fails without the hook fix).
- All 9 auth-flows e2e and 19 auth unit tests pass; typecheck + lint clean.

### Additional context

Reviewed across three lenses (abstraction, test quality, allauth correctness):
- **Abstraction:** the success-401 handling lives in 4 hooks but encodes 3
  different contracts; a shared helper would be a leaky options-bag and wouldn't
  have prevented this (the bug was an *omission*). Kept inline; the realistic
  mock is the real guard. A global axios interceptor was explicitly rejected
  (401 is a genuine error for other endpoints).
- **allauth:** catching *any* 401 is correct here (401 is reserved for the
  auth-state response); a `flows`-based guard would add fragility, not safety.
- **Test quality:** extracted a shared `deleteUser()` helper for the e2e cleanup
  to avoid drift with `createActiveUser`.

Independent of the `example.com` site-name issue (#1136), which also surfaced in
these reset emails but is a separate fix.