### PR TITLE
fix(auth): set Site name to Math3d.org so emails aren't "example.com"

### DIFF
--- a/webserver/authentication/migrations/0005_set_site_name.py
+++ b/webserver/authentication/migrations/0005_set_site_name.py
@@ -1,0 +1,47 @@
+"""
+Data migration to set the django.contrib.sites Site name so allauth's
+transactional emails render "Math3d.org" instead of Django's default
+"example.com".
+
+`current_site.name` is what allauth's email templates render (subject + body);
+it is a brand constant, identical across environments, so this carries no
+dependency on the env-powered base URL. We intentionally do NOT manage
+`domain`: it is unused by our headless flows (user-facing URLs come from
+HEADLESS_FRONTEND_URLS / APP_BASE_URL) and is environment-specific, which a
+one-time migration is the wrong place to encode.
+
+We create the row when missing because on a fresh database the default Site is
+created by a post_migrate signal that runs *after* migrations and only creates
+a row when none exists; creating it here ensures that signal leaves our name
+intact. On an existing database we update only the name and leave domain as-is.
+"""
+
+from django.conf import settings
+from django.db import migrations
+
+SITE_NAME = "Math3d.org"
+
+
+def set_site_name(apps, schema_editor):
+    Site = apps.get_model("sites", "Site")
+    site_id = getattr(settings, "SITE_ID", 1)
+    # On a fresh DB no Site row exists yet; create it with Django's default
+    # domain so we never leave it blank (we don't otherwise manage domain).
+    site, created = Site.objects.get_or_create(
+        pk=site_id,
+        defaults={"domain": "example.com", "name": SITE_NAME},
+    )
+    if not created:
+        site.name = SITE_NAME
+        site.save(update_fields=["name"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("authentication", "0004_populate_allauth_emailaddress"),
+        ("sites", "0002_alter_domain_unique"),
+    ]
+
+    operations = [
+        migrations.RunPython(set_site_name, migrations.RunPython.noop),
+    ]

--- a/webserver/authentication/site_test.py
+++ b/webserver/authentication/site_test.py
@@ -1,0 +1,14 @@
+import pytest
+from django.conf import settings
+from django.contrib.sites.models import Site
+
+
+@pytest.mark.django_db
+def test_configured_site_uses_brand_name():
+    """allauth's transactional emails render `current_site.name`, so it must be
+    the brand rather than Django's default "example.com" (regression guard for
+    GH-1136). Asserting against a freshly-migrated test DB also guards the
+    post_migrate default-site signal from clobbering the migration's value.
+    """
+    site = Site.objects.get(pk=settings.SITE_ID)
+    assert site.name == "Math3d.org"


### PR DESCRIPTION
### What are the relevant issues?

Closes #1136.

### Description

allauth's transactional emails render the `django.contrib.sites` Site name
(`current_site.name`) in their subject and body. The Site row was never
configured, so it carried Django's factory default **example.com** — every
signup-activation, email-confirmation, and password-reset email said
"example.com". (The activation/reset *links* were always correct; they come
from `HEADLESS_FRONTEND_URLS`/`APP_BASE_URL`, not the Site row.)

Adds a data migration setting the Site **name** to the brand constant
**`Math3d.org`**.

- **Why a migration, not a one-off:** every database here is built by running
  migrations (CI recreates the DB each run; pytest builds its test DB from
  migrations; new dev clones too). A manual prod edit would leave every fresh
  DB reverting to `example.com`.
- **No env dependency:** `name` is a brand constant, identical across
  environments — no coupling to `APP_BASE_URL`.
- **`domain` deliberately unmanaged:** it's env-specific and unused by our
  headless flows (URLs come from `HEADLESS_FRONTEND_URLS`); a one-time
  migration is the wrong place to encode it.
- **Fresh-DB safe:** Django's default `example.com` Site is created by a
  `post_migrate` signal that only inserts when no Site exists. The migration
  `get_or_create`s the row first, so that signal no-ops and our name survives.

### How can this be tested?

- New `authentication/site_test.py` asserts the configured Site name is
  `Math3d.org`, run against a freshly-migrated test DB (so it also guards the
  post_migrate-clobber path).
- Verified locally: applies cleanly to the existing dev DB
  (`example.com` -> `Math3d.org`); `makemigrations --check` clean; mypy clean.