### PR TITLE
refactor(types): align FE/BE math-item types — Phase A (#1141)

### DIFF
--- a/packages/api/src/v1-sync.check.ts
+++ b/packages/api/src/v1-sync.check.ts
@@ -19,9 +19,11 @@ type GeneratedMathItem = GeneratedV1Scene["items"][number];
 type IsAny<T> = 0 extends 1 & NoInfer<T> ? true : false;
 const _notAny: IsAny<GeneratedMathItem> extends false ? true : never = true;
 
-// The frontend item `type` is a MathItemType enum member; the generated client
-// emits string literals. Widen the source union's discriminant to its literal
-// value so both sides are string literals, preserving per-variant fidelity.
+// `MathItemType` is now a string-literal union (no longer a nominal enum), so the
+// frontend item `type` is already a string literal, matching the generated
+// client's discriminants. `Serialized<>` is therefore an identity transform
+// today; it's retained as the seam where Phase B switches this whole check to a
+// strict `Equal<>`.
 type Serialized<M> = M extends { type: infer T extends MathItemType }
   ? Omit<M, "type"> & { type: `${T}` }
   : never;
@@ -38,8 +40,8 @@ const _itemsBack: GeneratedV1Scene["items"] = {} as SerializedMathItem[];
 
 // itemOrder value-shape. Guard the same any-regression as the items union above
 // (an `any` value would make the shape pin below vacuous), then pin the value
-// type to `string[]`. The generated client now emits
-// `itemOrder: { [key: string]: Array<string> }` via the ItemOrderValue RootModel.
+// type to `string[]`. The generated client emits
+// `itemOrder: { [key: string]: Array<string> }`.
 type GeneratedItemOrderValue = GeneratedV1Scene["itemOrder"][string];
 const _itemOrderNotAny: IsAny<GeneratedItemOrderValue> extends false
   ? true
@@ -48,10 +50,11 @@ const _itemOrderShape: string[] = {} as GeneratedItemOrderValue;
 
 // FE union-completeness: a new MathItemType with no union variant fails CI.
 // (Backstop — a missing variant usually fails configs.ts first, since MathItems
-// is a closed Record<MathItemType, ...>; the unique value here is catching an
-// enum *value* typo that still has a MathItems entry.) NOT Equal<> — under
-// tsc --strict the enum-member union is a distinct identity from the enum type,
-// so Equal<> is false even on a complete union.
+// is a closed Record<MathItemType, ...>; the unique value here is catching a
+// `type` value typo that still has a MathItems entry.) Kept as a `Covers<>`
+// completeness diagnostic for now: with `MathItemType` a literal union,
+// `Equal<MathItem["type"], MathItemType>` would hold, and Phase B replaces this
+// with that strict `Equal<>`.
 type Covers<U extends MathItemType, All extends MathItemType> = [All] extends [
   U,
 ]

--- a/packages/mathitem-configs/src/configs.ts
+++ b/packages/mathitem-configs/src/configs.ts
@@ -125,12 +125,14 @@ const isMathGraphic = (item: MathItem): item is MathGraphic => {
   return (MATH_GRAPHIC_TYPES as readonly MathItemType[]).includes(item.type);
 };
 const isSurface = (item: MathItem): item is MathGraphic => {
-  return [
-    MathItemType.ParametricSurface,
-    MathItemType.ExplicitSurface,
-    MathItemType.ExplicitSurfacePolar,
-    MathItemType.ImplicitSurface,
-  ].includes(item.type);
+  return (
+    [
+      MathItemType.ParametricSurface,
+      MathItemType.ExplicitSurface,
+      MathItemType.ExplicitSurfacePolar,
+      MathItemType.ImplicitSurface,
+    ] as readonly MathItemType[]
+  ).includes(item.type);
 };
 
 export {

--- a/packages/mathitem-configs/src/constants.ts
+++ b/packages/mathitem-configs/src/constants.ts
@@ -1,21 +1,67 @@
-export enum MathItemType {
-  Axis = "AXIS",
-  BooleanVariable = "BOOLEAN_VARIABLE",
-  Camera = "CAMERA",
-  ExplicitSurface = "EXPLICIT_SURFACE",
-  ExplicitSurfacePolar = "EXPLICIT_SURFACE_POLAR",
-  Folder = "FOLDER",
-  Grid = "GRID",
-  ImplicitSurface = "IMPLICIT_SURFACE",
-  Line = "LINE",
-  Point = "POINT",
-  ParametricCurve = "PARAMETRIC_CURVE",
-  ParametricSurface = "PARAMETRIC_SURFACE",
-  Variable = "VARIABLE",
-  VariableSlider = "VARIABLE_SLIDER",
-  Vector = "VECTOR",
-  VectorField = "VECTOR_FIELD",
+// `MathItemType` is a const-object + same-named literal-union type, NOT a TS
+// `enum`. It used to be a string `enum`, but string-enum members are *nominal*:
+// `MathItemType.Point` is a distinct type identity from the string `"POINT"`, so
+// the v1 client-sync check (packages/api/src/v1-sync.check.ts) could not assert
+// strict equality between our discriminants and the generated client's
+// string-literal discriminants. A literal union is structurally `"POINT"`, which
+// unlocks that — and removes a class of nominal-identity friction enums cause.
+//
+// This deliberately mirrors what openapi-generator-cli emits for the same
+// fields, e.g. `PointItemTypeEnum = { Point: "POINT" } as const` + a derived
+// literal-union type — so the frontend source-of-truth and the generated client
+// share one idiom.
+//
+// The `namespace` is the one wrinkle. TS namespaces are legacy syntax (the
+// language discourages them), but here a type-only (non-instantiated, emits no
+// runtime JS) namespace is the cleanest way to keep `MathItemType.Point` usable
+// in *type* positions — e.g. `IMathItem<MathItemType.Point>` — exactly as the
+// enum allowed. Without it, ~48 member-as-type call sites would each need
+// `typeof MathItemType.Point`. The three same-named declarations merge:
+//   - `const`     — value uses (`MathItemType.Point` -> "POINT", computed keys).
+//   - `type`      — the bare union for annotations/constraints.
+//   - `namespace` — member-as-type uses (`MathItemType.Point` as a type).
+// The merge trips three lint rules that don't model declaration merging
+// (import/export's multiple-export, no-redeclare) or intentionally forbid the
+// syntax (no-namespace); disabled for this block only.
+/* eslint-disable import/export, @typescript-eslint/no-redeclare, @typescript-eslint/no-namespace */
+export const MathItemType = {
+  Axis: "AXIS",
+  BooleanVariable: "BOOLEAN_VARIABLE",
+  Camera: "CAMERA",
+  ExplicitSurface: "EXPLICIT_SURFACE",
+  ExplicitSurfacePolar: "EXPLICIT_SURFACE_POLAR",
+  Folder: "FOLDER",
+  Grid: "GRID",
+  ImplicitSurface: "IMPLICIT_SURFACE",
+  Line: "LINE",
+  Point: "POINT",
+  ParametricCurve: "PARAMETRIC_CURVE",
+  ParametricSurface: "PARAMETRIC_SURFACE",
+  Variable: "VARIABLE",
+  VariableSlider: "VARIABLE_SLIDER",
+  Vector: "VECTOR",
+  VectorField: "VECTOR_FIELD",
+} as const;
+export type MathItemType = (typeof MathItemType)[keyof typeof MathItemType];
+export namespace MathItemType {
+  export type Axis = typeof MathItemType.Axis;
+  export type BooleanVariable = typeof MathItemType.BooleanVariable;
+  export type Camera = typeof MathItemType.Camera;
+  export type ExplicitSurface = typeof MathItemType.ExplicitSurface;
+  export type ExplicitSurfacePolar = typeof MathItemType.ExplicitSurfacePolar;
+  export type Folder = typeof MathItemType.Folder;
+  export type Grid = typeof MathItemType.Grid;
+  export type ImplicitSurface = typeof MathItemType.ImplicitSurface;
+  export type Line = typeof MathItemType.Line;
+  export type Point = typeof MathItemType.Point;
+  export type ParametricCurve = typeof MathItemType.ParametricCurve;
+  export type ParametricSurface = typeof MathItemType.ParametricSurface;
+  export type Variable = typeof MathItemType.Variable;
+  export type VariableSlider = typeof MathItemType.VariableSlider;
+  export type Vector = typeof MathItemType.Vector;
+  export type VectorField = typeof MathItemType.VectorField;
 }
+/* eslint-enable import/export, @typescript-eslint/no-redeclare, @typescript-eslint/no-namespace */
 
 export enum WidgetType {
   Color = "color-picker",

--- a/scripts/generate_openapi.sh
+++ b/scripts/generate_openapi.sh
@@ -31,7 +31,7 @@ docker run --rm -v "${PWD}:/local" openapitools/openapi-generator-cli:${GENERATO
 
 # We expect pre-commit to exit with a non-zero status since it is reformatting
 # the generated code.
-git ls-files packages/api/src/generated | xargs pre-commit run --files openapi.yaml ||
+git ls-files packages/api/src/generated | xargs pre-commit run --files ||
 	echo "OpenAPI generation complete."
 
 ##################################################
@@ -51,8 +51,9 @@ docker run --rm -v "${PWD}:/local" openapitools/openapi-generator-cli:${GENERATO
 	--ignore-file-override /local/packages/api/.openapi-generator-ignore \
 	--additional-properties=useSingleRequestParameter=true,paramNaming=original
 
-# Ensure the VERSION file ends with a newline (the generator omits it).
-echo >>packages/api/src/generated-v1/.openapi-generator/VERSION
-
-# Format the generated v1 client with the workspace-pinned prettier (single pin site).
-yarn prettier "packages/api/src/generated-v1/**/*.ts" --write
+# Format the generated v1 client via pre-commit (prettier over .ts + .md docs,
+# end-of-file-fixer on VERSION), mirroring the v0 step above so a single run of
+# this script leaves a clean working tree. pre-commit exits non-zero when it
+# reformats, which is expected.
+git ls-files packages/api/src/generated-v1 | xargs pre-commit run --files ||
+	echo "v1 OpenAPI generation complete."

--- a/webserver/openapi.v1.yaml
+++ b/webserver/openapi.v1.yaml
@@ -19,8 +19,7 @@ components:
           title: Rhs
           type: string
         type:
-          enum:
-          - assignment
+          const: assignment
           title: Type
           type: string
       required:
@@ -455,8 +454,7 @@ components:
           title: Items
           type: array
         type:
-          enum:
-          - array
+          const: array
           title: Type
           type: string
       required:
@@ -471,8 +469,7 @@ components:
           title: Expr
           type: string
         type:
-          enum:
-          - expr
+          const: expr
           title: Type
           type: string
       required:
@@ -521,8 +518,7 @@ components:
           title: Items
           type: array
         type:
-          enum:
-          - array
+          const: array
           title: Type
           type: string
       required:
@@ -545,8 +541,7 @@ components:
           title: Rhs
           type: string
         type:
-          enum:
-          - function-assignment
+          const: function-assignment
           title: Type
           type: string
       required:
@@ -1308,8 +1303,7 @@ components:
           title: Items
           type: array
         type:
-          enum:
-          - array
+          const: array
           title: Type
           type: string
       required:

--- a/webserver/scenes/schemas/math_items.py
+++ b/webserver/scenes/schemas/math_items.py
@@ -17,7 +17,6 @@ from pydantic import (
     Field,
     RootModel,
     TypeAdapter,
-    WithJsonSchema,
 )
 
 
@@ -50,38 +49,26 @@ class _Strict(BaseModel):
 # the optional non-serializable `validate` function field is omitted). ---
 
 
-# Single-value `Literal` fields emit as JSON-schema `{const: X}`, which
-# openapi-generator-cli v7.2.0 (typescript-axios) collapses to a bare `string`
-# in the client — discarding the literal value the FE sync check needs. Emitting
-# them as `{enum: [X], type: string}` via WithJsonSchema makes the generator
-# produce a usable string-literal type instead. WithJsonSchema *replaces* the
-# field schema, so `type: string` is included explicitly. (The 16 item-level
-# `type` discriminants are left as bare `Literal` — the union's
-# `discriminator.mapping` already intersects the literal back in, e.g.
-# `({ type: "AXIS" } & AxisItem)`, so they stay usable without annotation.)
+# Single-value `Literal` fields emit as JSON-schema `{const: X}`.
+# openapi-generator-cli v7.23.0 (typescript-axios) renders that as a usable
+# string-literal const-enum, so the bare `Literal` carries the value through to
+# the client unaided (the v7.2.0 `WithJsonSchema({enum, type})` workaround that
+# papered over the old collapse-to-`string` behavior is no longer needed).
 
 
 class ExprObj(_Strict):
-    type: Annotated[
-        Literal["expr"], WithJsonSchema({"enum": ["expr"], "type": "string"})
-    ]
+    type: Literal["expr"]
     expr: str
 
 
 class AssignmentObj(_Strict):
-    type: Annotated[
-        Literal["assignment"],
-        WithJsonSchema({"enum": ["assignment"], "type": "string"}),
-    ]
+    type: Literal["assignment"]
     lhs: str
     rhs: str
 
 
 class FunctionAssignmentObj(_Strict):
-    type: Annotated[
-        Literal["function-assignment"],
-        WithJsonSchema({"enum": ["function-assignment"], "type": "string"}),
-    ]
+    type: Literal["function-assignment"]
     name: str
     params: list[str]
     rhs: str
@@ -90,23 +77,17 @@ class FunctionAssignmentObj(_Strict):
 # Concrete array types (NOT a Pydantic Generic — a generic emits mangled
 # parametrized $ref names into the OpenAPI/client).
 class FunctionAssignmentArray(_Strict):
-    type: Annotated[
-        Literal["array"], WithJsonSchema({"enum": ["array"], "type": "string"})
-    ]
+    type: Literal["array"]
     items: list[FunctionAssignmentObj]
 
 
 class ExprArray(_Strict):
-    type: Annotated[
-        Literal["array"], WithJsonSchema({"enum": ["array"], "type": "string"})
-    ]
+    type: Literal["array"]
     items: list[ExprObj]
 
 
 class StrArray(_Strict):
-    type: Annotated[
-        Literal["array"], WithJsonSchema({"enum": ["array"], "type": "string"})
-    ]
+    type: Literal["array"]
     items: list[str]
 
 

--- a/webserver/scenes/schemas/scenes.py
+++ b/webserver/scenes/schemas/scenes.py
@@ -52,15 +52,13 @@ class SceneCreateSchema(Schema):
 class ScenePatchSchema(Schema):
     # Partial-update schema (NOT ninja.PatchDict). Presence is detected via
     # `exclude_unset` in the handler, so `items`/`item_order` use non-nullable
-    # defaults rather than `Optional[...] = None`. This is deliberate: an
-    # `Optional[List[MathItem]]` emits `anyOf: [<array-of-$ref>, null]`, and
-    # openapi-generator-cli v7.2.0 (typescript-axios) can't resolve the union
-    # nested inside that `anyOf` and degrades the field to `null` in the client.
-    # A bare `List[MathItem]` default emits the same plain `Array<MathItem>` as
-    # the POST body, so the generated `ScenePatchSchema.items` references the
-    # real `MathItem` union component. Side effect: an explicit `items: null`
-    # (or `itemOrder: null`) in the body now 422s instead of silently
-    # no-op'ing, which is the desired strictness.
+    # defaults rather than `Optional[...] = None`. This is deliberate for
+    # strictness: a non-nullable field rejects an explicit `items: null` (or
+    # `itemOrder: null`) in the body with a 422 instead of silently no-op'ing.
+    # (Historically this also dodged an openapi-generator-cli v7.2.0 bug that
+    # degraded the `anyOf: [<array-of-$ref>, null]` union to `null` in the
+    # client; v7.23.0 resolves that union correctly, so only the strictness
+    # rationale remains.)
     model_config = ConfigDict(populate_by_name=True)
 
     items: List[MathItem] = Field(default_factory=list)


### PR DESCRIPTION
### What are the relevant issues?

Part of #1141 (FE/BE math-item type alignment). This is **Phase A**; Phase B (the validator split + strict `Equal<>` sync-check rewrite) follows as a stacked PR.

### Description

Mechanical/prep work to align the frontend source-of-truth math-item types with the generated v1 OpenAPI client, plus removal of two workarounds the v7.2.0→v7.23.0 generator bump (#1143) made obsolete.

- **`MathItemType` enum → const-object + literal union.** String-enum members are *nominal* (`MathItemType.Point` is a distinct type identity from `"POINT"`), which blocks the v1 sync check from asserting strict `Equal<>` against the generated client's string-literal discriminants. Replaced with a `const` object + same-named literal-union `type` + a type-only `namespace` (declaration merging), so **all 248 member references across 33 files are unchanged** while the union becomes structurally the string literals. This mirrors the const-object idiom the generator itself emits. (A true-enum generator option, `stringEnums`, was considered and rejected — it would reintroduce the nominal mismatch.) One consequence fix: `isSurface`'s array-literal `.includes` narrowing needed the same `as readonly MathItemType[]` cast already used by `isMathGraphic`.
- **Dropped the backend `WithJsonSchema` workaround.** v7.2.0 collapsed single-value `Literal` ({const: X}) to bare `string`; v7.23.0 renders it as a usable const-enum. Verified: removing the wrappers leaves the generated TS client **byte-identical** — only the spec shifts `enum:[X]` → `const:X`.
- **`generate_openapi.sh` one-pass formatting.** The v1 step only prettier'd `.ts`, leaving markdown docs + the VERSION newline dirty until a later commit. It now mirrors the v0 step (pre-commit over the whole generated dir), so one regenerate leaves a clean tree.
- **`ScenePatchSchema` comment.** v7.23.0 resolves the `anyOf:[array,null]` union correctly, so the generator-workaround rationale for the non-null default is gone. Kept the non-null fields (explicit `items: null` → 422 strictness still holds) and rewrote the comment.
- **`v1-sync.check.ts`** — corrected comments the enum removal invalidated. The structural rewrite to strict `Equal<>` is intentionally deferred to Phase B.

### How can this be tested?

CI covers it: frontend `typecheck` / `lint` / `test`, the OpenAPI freshness checks, and backend `pytest` / `mypy`. Locally all green, plus the generated v1 client is byte-identical (no client diff in this PR).

### Additional context

Reviewed by three local agents (type-correctness, cleanliness, backend/generator) before opening; their findings (stale enum comments, a vestigial script arg) are folded in. Phase B will do the validator (`validate?`) split and rewrite the sync check to a strict `Equal<>`.

### Checklist:

- [ ] N/A
