### PR TITLE
fix(deps): self-host failOnConsole; drop jest-fail-on-console

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -107,7 +107,6 @@
     "gray-matter": "^4.0.3",
     "htmlparser2": "^10.0.0",
     "identity-obj-proxy": "3.0.0",
-    "jest-fail-on-console": "3.3.1",
     "jsdom": "^26.0.0",
     "msw": "^2.0.14",
     "rollup-plugin-visualizer": "5.14.0",

--- a/packages/app/src/setupTests.ts
+++ b/packages/app/src/setupTests.ts
@@ -7,7 +7,7 @@ import { mockAuth } from "@math3d/mock-api";
 // learn more: https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom";
 
-import failOnConsole from "jest-fail-on-console";
+import { failOnConsole } from "@math3d/test-utils";
 
 failOnConsole();
 

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -22,5 +22,8 @@
     "jest-get-type": "^29.4.3",
     "react": "^19.2.0",
     "tiny-invariant": "^1.3.1"
+  },
+  "peerDependencies": {
+    "vitest": "^4.0.18"
   }
 }

--- a/packages/test-utils/src/failOnConsole.spec.ts
+++ b/packages/test-utils/src/failOnConsole.spec.ts
@@ -1,0 +1,37 @@
+/* eslint-disable no-console -- this suite intentionally exercises console */
+import { describe, expect, it } from "vitest";
+import { createConsoleGuard } from "./failOnConsole";
+
+describe("createConsoleGuard", () => {
+  it("flush throws, naming the method, after an unexpected call", () => {
+    const guard = createConsoleGuard("error");
+    guard.install();
+    console.error("boom");
+    guard.restore();
+    expect(() => guard.flush()).toThrow(/console\.error/);
+  });
+
+  it("flush does not throw when the method was not called", () => {
+    const guard = createConsoleGuard("warn");
+    guard.install();
+    guard.restore();
+    expect(() => guard.flush()).not.toThrow();
+  });
+
+  it("includes the formatted message in the failure", () => {
+    const guard = createConsoleGuard("warn");
+    guard.install();
+    console.warn("missing %s", "value");
+    guard.restore();
+    expect(() => guard.flush()).toThrow(/missing value/);
+  });
+
+  it("restore reinstates the original console method", () => {
+    const original = console.error;
+    const guard = createConsoleGuard("error");
+    guard.install();
+    expect(console.error).not.toBe(original);
+    guard.restore();
+    expect(console.error).toBe(original);
+  });
+});

--- a/packages/test-utils/src/failOnConsole.ts
+++ b/packages/test-utils/src/failOnConsole.ts
@@ -1,0 +1,86 @@
+/* eslint-disable no-console -- this module's job is to intercept console */
+import { afterEach, beforeEach } from "vitest";
+import { format } from "node:util";
+
+/**
+ * Console methods that cause a test to fail when called unexpectedly.
+ *
+ * We deliberately mirror only the defaults of jest-fail-on-console /
+ * vitest-fail-on-console (fail on `error` and `warn`); the projects only ever
+ * used the no-options behavior, so the rest of those libraries' config surface
+ * is intentionally not reproduced here.
+ */
+type GuardedMethod = "error" | "warn";
+
+const hint = (method: GuardedMethod): string =>
+  `Expected test not to call console.${method}(). If the call is expected, ` +
+  `mock it explicitly, e.g. ` +
+  `vi.spyOn(console, "${method}").mockImplementation(() => {}), and assert on it.`;
+
+interface ConsoleGuard {
+  /** Replace the console method with the recording guard and reset state. */
+  install: () => void;
+  /** Restore the original console method. */
+  restore: () => void;
+  /** Throw if any unexpected call was recorded since the last install/flush. */
+  flush: () => void;
+}
+
+/**
+ * Builds an installable guard around a single console method. Exposed
+ * (separately from {@link failOnConsole}) so the throwing behavior can be unit
+ * tested without relying on a failing test.
+ */
+export const createConsoleGuard = (method: GuardedMethod): ConsoleGuard => {
+  const original = console[method];
+  let recorded: { message: string; stack: string }[] = [];
+
+  const guard = (...args: unknown[]): void => {
+    const stack = new Error().stack ?? "";
+    recorded.push({
+      message: format(...args),
+      // Drop the leading "Error" line so the stack points at the caller.
+      stack: stack.slice(stack.indexOf("\n") + 1),
+    });
+  };
+
+  return {
+    install: () => {
+      console[method] = guard;
+      recorded = [];
+    },
+    restore: () => {
+      console[method] = original;
+    },
+    flush: () => {
+      if (recorded.length === 0) return;
+      const calls = recorded;
+      recorded = [];
+      const detail = calls
+        .map(({ message, stack }) => `${message}\n${stack}`)
+        .join("\n\n");
+      throw new Error(`${hint(method)}\n\n${detail}`);
+    },
+  };
+};
+
+/**
+ * Fail the current test if it logs to `console.error` or `console.warn`.
+ *
+ * Call once from a test setup file. Tests that legitimately expect such output
+ * should mock the method themselves (e.g.
+ * `vi.spyOn(console, "warn").mockImplementation(() => {})`); that spy shadows
+ * the guard installed here, so those tests pass.
+ */
+const failOnConsole = (): void => {
+  (["error", "warn"] as const).forEach((method) => {
+    const guard = createConsoleGuard(method);
+    beforeEach(guard.install);
+    afterEach(() => {
+      guard.restore();
+      guard.flush();
+    });
+  });
+};
+
+export default failOnConsole;

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -6,4 +6,6 @@ export type { ToNearlyEqualOptions, CustomMatchers };
 
 export { default as getTimedEvents } from "./getTimedEvents";
 
+export { default as failOnConsole } from "./failOnConsole";
+
 /// <reference path="./vitest.d.ts" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -3181,6 +3181,8 @@ __metadata:
     react: "npm:^19.2.0"
     tiny-invariant: "npm:^1.3.1"
     vitest: "npm:^4.0.18"
+  peerDependencies:
+    vitest: ^4.0.18
   languageName: unknown
   linkType: soft
 
@@ -7147,7 +7149,6 @@ __metadata:
     history: "npm:5.3.0"
     htmlparser2: "npm:^10.0.0"
     identity-obj-proxy: "npm:3.0.0"
-    jest-fail-on-console: "npm:3.3.1"
     jsdom: "npm:^26.0.0"
     lodash-es: "npm:4.17.23"
     mathbox: "npm:^2.3.1"
@@ -13691,13 +13692,6 @@ __metadata:
   version: 0.7.1
   resolution: "javascript-natural-sort@npm:0.7.1"
   checksum: 10/7bf6eab67871865d347f09a95aa770f9206c1ab0226bcda6fdd9edec340bf41111a7f82abac30556aa16a21cfa3b2b1ca4a362c8b73dd5ce15220e5d31f49d79
-  languageName: node
-  linkType: hard
-
-"jest-fail-on-console@npm:3.3.1":
-  version: 3.3.1
-  resolution: "jest-fail-on-console@npm:3.3.1"
-  checksum: 10/59d72906c20390dcd79be51c2ff0d65fe66fb68c2a4633339b95c3bd5dce5745adb06ac91b095de03f367cc2b4d6868d44abf97e1fb21d7e7835a9710b0630cd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What are the relevant issues?

Supersedes #1097 (renovate: bump jest-fail-on-console to v3.3.4).

### Description

`jest-fail-on-console@3.3.4` added a hard `require("@jest/globals")` at module load (new in 3.3.4 — 3.3.0–3.3.3 had no dependencies). `@jest/globals` does not exist in this Vitest project, so loading `setupTests.ts` threw `Cannot find module @jest/globals` and the **entire** `frontend-tests` suite (37 files) failed to run. The package is now effectively jest-only.

Rather than swap in another third-party package, **self-host the small slice we actually use.** The project only ever called `failOnConsole()` with no options (fail on `console.error` / `console.warn`), so none of the library’s config surface (`allowMessage`, `silenceMessage`, `skipTest`, group tracking, the other toggles) was in use. This reimplements just that default in the existing `@math3d/test-utils` workspace:

- **`test-utils/src/failOnConsole.ts`** — install a recording guard over `console.error`/`console.warn` in `beforeEach`, throw with the collected messages in `afterEach`, and restore the originals. Tests that intentionally mock console themselves (`vi.spyOn(console, "warn").mockImplementation(() => {})`) shadow the guard and pass — the same mechanism the library used. A factored `createConsoleGuard` is exported for unit testing.
- **`test-utils/src/failOnConsole.spec.ts`** — pins throw / no-throw / message-formatting / restore behavior.
- **`packages/app`** — import `failOnConsole` from `@math3d/test-utils`; drop the `jest-fail-on-console` devDependency. No new external dependency is added.

`vitest` is declared a `peerDependency` of `test-utils` (the consumer supplies the runtime hooks).

### How can this be tested?

- `yarn typecheck` (11/11), `yarn workspace @math3d/test-utils lint` clean.
- `yarn workspace app test` passes (37 files, 178 tests), including the 3 files that mock console themselves.
- Verified the guard still **fails** a suite on an unexpected `console.error` (throwaway test).

### Additional context

Closes out renovate PR #1097 once merged. No third-party `*-fail-on-console` dependency remains — the behavior is now a ~70-line owned utility (incl. its tests).