### PR TITLE
chore(deps): track installed versions in manifests (rangeStrategy: bump)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": ["config:base"],
   "labels": ["dependencies"],
+  "rangeStrategy": "bump",
   "packageRules": [
     {
       "matchDepTypes": ["devDependencies"],

--- a/packages/app-tests-e2e/package.json
+++ b/packages/app-tests-e2e/package.json
@@ -23,7 +23,7 @@
     "tiny-invariant": "^1.3.1"
   },
   "dependencies": {
-    "@types/mailparser": "^3.4.4",
-    "mailparser": "^3.7.1"
+    "@types/mailparser": "^3.4.6",
+    "mailparser": "^3.9.12"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5574,7 +5574,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/mailparser@npm:^3.4.4":
+"@types/mailparser@npm:^3.4.6":
   version: 3.4.6
   resolution: "@types/mailparser@npm:3.4.6"
   dependencies:
@@ -7086,12 +7086,12 @@ __metadata:
     "@math3d/eslint-config": "workspace:^"
     "@math3d/mock-api": "workspace:^"
     "@playwright/test": "npm:^1.57.0"
-    "@types/mailparser": "npm:^3.4.4"
+    "@types/mailparser": "npm:^3.4.6"
     axios: "npm:^1.6.7"
     dotenv: "npm:^16.3.1"
     envalid: "npm:^8.0.0"
     eslint: "npm:^8.54.0"
-    mailparser: "npm:^3.7.1"
+    mailparser: "npm:^3.9.12"
     mathlive: "npm:^0.105.0"
     p-retry: "npm:^6.2.0"
     three: "npm:^0.147.0"
@@ -14419,7 +14419,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mailparser@npm:^3.7.1":
+"mailparser@npm:^3.9.12":
   version: 3.9.12
   resolution: "mailparser@npm:3.9.12"
   dependencies:


### PR DESCRIPTION
### What are the relevant issues?

Follow-up to the dependency-update PRs (#1145–#1148). N/A otherwise.

### Description

The dep PRs were lockfile-only for caret-ranged packages because renovate (`config:base`, no `rangeStrategy`) keeps caret ranges at their original floor and only floats the lockfile. For an **app** (no downstream consumers of our ranges; the lockfile is the deployed truth) the manifest should instead track what we actually ship.

- **`.github/renovate.json`**: set `"rangeStrategy": "bump"` so renovate raises each `package.json` floor to the newly-installed version going forward, rather than leaving a stale minimum.
- **`packages/app-tests-e2e`**: bump `mailparser` `^3.7.1` → `^3.9.12` and `@types/mailparser` `^3.4.4` → `^3.4.6` to match what #1148 merged. For mailparser this also makes the security fix **durable** — `^3.7.1` still admitted the vulnerable 3.7.x; `^3.9.12` (≥ the 3.9.3 patch) forecloses it.

The companion PRs #1146 (react) and #1147 (react-router) were updated to bump their floors to installed versions in the same spirit.

### How can this be tested?

`renovate.json` is valid JSON. `yarn install` leaves resolved versions unchanged (only `package.json` floors and lockfile range descriptors move). e2e behavior is unchanged.

### Additional context

Going forward, renovate will keep manifest floors current automatically, so future dep PRs touch `package.json` rather than being lockfile-only.