### PR TITLE
refactor(types): validate-free stored math-item types + strict v1 sync check (#1141)

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -21,6 +21,7 @@
     "@math3d/eslint-config": "workspace:^",
     "@math3d/tsconfig": "workspace:^",
     "eslint": "^8.54.0",
+    "type-fest": "5.7.0",
     "vitest": "^4.0.18"
   }
 }

--- a/packages/api/src/v1-sync.check.ts
+++ b/packages/api/src/v1-sync.check.ts
@@ -1,69 +1,66 @@
 // Compile-time sync check: the generated v1 client and the frontend
-// source-of-truth math-item types must stay mutually assignable. Drift fails
-// `tsc`. This file is never imported or executed. (The shared eslint config
-// ignores `_`-prefixed vars via varsIgnorePattern, so no eslint-disable is
-// needed — verified against packages/eslint-config.)
-import type { MathItem, MathItemType } from "@math3d/mathitem-configs";
+// source-of-truth math-item types must stay in sync. Drift fails `tsc`. This
+// file is never imported or executed. (The shared eslint config ignores
+// `_`-prefixed vars via varsIgnorePattern, so no eslint-disable is needed.)
+//
+// We assert an invariant `Equal` (each member structurally identical, not merely
+// mutually assignable), via type-fest's `IsEqual` over `SimplifyDeep`-normalized
+// types. The normalization is load-bearing:
+//   - The generated client renders its discriminated union as
+//     `({ type: "POINT" } & PointItem) | ...` intersections, whereas the frontend
+//     type is a flat `{ id; type; properties }`. `IsEqual` compares type
+//     *representation*, not assignability, so it reports the unreduced
+//     intersection and the flat object as different even though they describe the
+//     same values.
+//   - `SimplifyDeep` materializes each intersection into a single resolved object
+//     (recursively — the parametric/field members carry the mismatch nested inside
+//     `properties`, so shallow `Simplify` is not enough). After deep normalization
+//     both sides have identical representations and `IsEqual` matches them. This
+//     is deterministic across compiler runs and assertion orderings.
+// `IsEqual` also distinguishes `any` from a concrete type, so if the generator
+// ever collapsed `items`/`itemOrder` to `any` the assertion fails — no separate
+// any-guard needed (unlike mutual assignability, which is any-blind).
+//
+// Phase A (#1144) made the `type` discriminant a string-literal union and Phase B
+// made the item property types validate-free (the parse-time `validate` lives on
+// `ValidatedParseable`, not the stored item), removing the real asymmetries — so
+// no `Serialized<>` widening or `as`-cast crutches are needed.
+//
+// `type-fest` is pinned to an exact version: `SimplifyDeep`/`IsEqual` are deep
+// recursive type machinery, and a bump can change how they reduce the generator's
+// intersection union. After any type-fest bump, re-verify this still goes RED on a
+// real drift (e.g. temporarily add a field to one side) before trusting green.
+import type { IsEqual, SimplifyDeep } from "type-fest";
+import type { MathItem } from "@math3d/mathitem-configs";
 import type { SceneSchema as GeneratedV1Scene } from "./generated-v1";
+
+type Assert<T extends true> = T;
+type DeepEqual<A, B> = IsEqual<SimplifyDeep<A>, SimplifyDeep<B>>;
 
 // The generated item union, derived from the scene's items field so it holds
 // regardless of whether the generator names the union.
 type GeneratedMathItem = GeneratedV1Scene["items"][number];
 
-// GUARD THE any-REGRESSION. If the generator collapses `items` to `any[]`,
-// `GeneratedMathItem` is `any` and EVERY mutual-assignability assertion below
-// silently passes (any is bidirectionally assignable). This makes the check
-// inert. Fail `tsc` here instead, so the compile-time gate is self-sufficient
-// and not solely reliant on schema.spec.ts's runtime oneOf-length assertion.
-// (type-fest's IsAny, inlined to avoid the dependency.)
-type IsAny<T> = 0 extends 1 & NoInfer<T> ? true : false;
-const _notAny: IsAny<GeneratedMathItem> extends false ? true : never = true;
+// Compare the FE and generated item types per-discriminant. Mapping over the
+// union of BOTH sides' `type` discriminants makes this EXHAUSTIVE: a new item
+// type (a new `MathItemType` flows into `MathItem["type"]`) automatically gets an
+// entry here, so one cannot be added without its FE/BE shapes being compared — and
+// a type present on only one side surfaces as a drift (its counterpart extracts to
+// `never`). `DriftingItemTypes` resolves to the discriminant(s) of any item type
+// whose shapes differ, or `never` when all are in sync; when the assertion below
+// fails, hover `DriftingItemTypes` to see exactly which item type(s) drifted.
+type ItemDiscriminant = MathItem["type"] | GeneratedMathItem["type"];
+type DriftingItemTypes = {
+  [T in ItemDiscriminant]: DeepEqual<
+    Extract<MathItem, { type: T }>,
+    Extract<GeneratedMathItem, { type: T }>
+  > extends true
+    ? never
+    : T;
+}[ItemDiscriminant];
+type _itemsInSync = Assert<IsEqual<DriftingItemTypes, never>>;
 
-// `MathItemType` is now a string-literal union (no longer a nominal enum), so the
-// frontend item `type` is already a string literal, matching the generated
-// client's discriminants. `Serialized<>` is therefore an identity transform
-// today; it's retained as the seam where Phase B switches this whole check to a
-// strict `Equal<>`.
-type Serialized<M> = M extends { type: infer T extends MathItemType }
-  ? Omit<M, "type"> & { type: `${T}` }
-  : never;
-type SerializedMathItem = Serialized<MathItem>;
-
-// Item-level mutual assignability (value-consumed; `as`-casts avoid
-// excess-property checks on object literals).
-const _a: GeneratedMathItem = {} as SerializedMathItem;
-const _b: SerializedMathItem = {} as GeneratedMathItem;
-
-// Scene-level assignability (so envelope drift can't escape the item check).
-const _items: SerializedMathItem[] = {} as GeneratedV1Scene["items"];
-const _itemsBack: GeneratedV1Scene["items"] = {} as SerializedMathItem[];
-
-// itemOrder value-shape. Guard the same any-regression as the items union above
-// (an `any` value would make the shape pin below vacuous), then pin the value
-// type to `string[]`. The generated client emits
+// itemOrder value-shape. The generated client emits
 // `itemOrder: { [key: string]: Array<string> }`.
 type GeneratedItemOrderValue = GeneratedV1Scene["itemOrder"][string];
-const _itemOrderNotAny: IsAny<GeneratedItemOrderValue> extends false
-  ? true
-  : never = true;
-const _itemOrderShape: string[] = {} as GeneratedItemOrderValue;
-
-// FE union-completeness: a new MathItemType with no union variant fails CI.
-// (Backstop — a missing variant usually fails configs.ts first, since MathItems
-// is a closed Record<MathItemType, ...>; the unique value here is catching a
-// `type` value typo that still has a MathItems entry.) Kept as a `Covers<>`
-// completeness diagnostic for now: with `MathItemType` a literal union,
-// `Equal<MathItem["type"], MathItemType>` would hold, and Phase B replaces this
-// with that strict `Equal<>`.
-type Covers<U extends MathItemType, All extends MathItemType> = [All] extends [
-  U,
-]
-  ? [U] extends [All]
-    ? true
-    : false
-  : false;
-// Must stay `= true` (value-consumed): when Covers<> is false the annotation is
-// `never` and `= true` fails to compile. Do not change the literal.
-const _complete: Covers<MathItem["type"], MathItemType> extends true
-  ? true
-  : never = true;
+type _itemOrderInSync = Assert<DeepEqual<GeneratedItemOrderValue, string[]>>;

--- a/packages/app/src/features/sceneControls/mathItems/sceneSlice/interfaces.ts
+++ b/packages/app/src/features/sceneControls/mathItems/sceneSlice/interfaces.ts
@@ -1,8 +1,11 @@
 import type { MathItem } from "@math3d/mathitem-configs";
 import type MathScope from "@math3d/mathscope";
-import { Parseable } from "@math3d/parser";
+import { ValidatedParseable } from "@math3d/parser";
 
-type AppParseable = Parseable;
+// The app parses validator-bearing parseables: syncMathScope attaches each math
+// property's config validator to the stored (validate-free) parseable before
+// handing it to MathScope. The stored item shape stays validate-free.
+type AppParseable = ValidatedParseable;
 type AppMathScope = MathScope<AppParseable>;
 
 interface SceneState {

--- a/packages/app/src/features/sceneControls/mathItems/sceneSlice/syncMathScope.ts
+++ b/packages/app/src/features/sceneControls/mathItems/sceneSlice/syncMathScope.ts
@@ -10,7 +10,7 @@ import {
 import { filter as collectionFilter } from "lodash-es";
 import { isNotNil } from "@/util/predicates";
 import type { IdentifiedParseable } from "@math3d/mathscope";
-import type { Parseable } from "@math3d/parser";
+import type { Parseable, ValidatedParseable } from "@math3d/parser";
 import { AppMathScope } from "./interfaces";
 
 const mathScopeId = (itemId: string, propName: string) =>
@@ -30,7 +30,7 @@ const getMathProperties = <T extends MathItemType>(
 
 const getIdentifiedExpressions = (
   items: MathItemPatch[],
-): IdentifiedParseable<Parseable>[] =>
+): IdentifiedParseable<ValidatedParseable>[] =>
   items.flatMap((item) => {
     const config = mathItemConfigs[item.type];
     const mathProperties = getMathProperties(config);

--- a/packages/parser/src/MathJsParser.ts
+++ b/packages/parser/src/MathJsParser.ts
@@ -13,8 +13,8 @@ import { getValidatedEvaluate } from "./evaluate";
 import {
   IMathJsParser,
   MathJsRule,
-  Parseable,
-  ParseableObjs,
+  ValidatedParseable,
+  ValidatedParseableObjs,
   ParserRule,
   ParserRuleType,
   TextParserRule,
@@ -83,7 +83,7 @@ class MathJsParser implements IMathJsParser {
     lhs,
     rhs,
     validate,
-  }: Omit<ParseableObjs["assignment"], "type">): readonly [
+  }: Omit<ValidatedParseableObjs["assignment"], "type">): readonly [
     AnonMathNode,
     mjs.MathNode,
   ] => {
@@ -121,7 +121,7 @@ class MathJsParser implements IMathJsParser {
     params,
     rhs,
     validate,
-  }: Omit<ParseableObjs["function-assignment"], "type">): readonly [
+  }: Omit<ValidatedParseableObjs["function-assignment"], "type">): readonly [
     AnonMathNode,
     mjs.MathNode,
   ] => {
@@ -132,7 +132,10 @@ class MathJsParser implements IMathJsParser {
   private parseArray = ({
     items,
     validate,
-  }: ParseableObjs["array"]): readonly [AnonMathNode, mjs.MathNode] => {
+  }: ValidatedParseableObjs["array"]): readonly [
+    AnonMathNode,
+    mjs.MathNode,
+  ] => {
     const parsed = aggregate(items, (item) => this.$parse(item));
     const nodes = parsed.map((p) => p[0]);
     const mjsNodes = parsed.map((p) => p[1]);
@@ -144,9 +147,9 @@ class MathJsParser implements IMathJsParser {
   };
 
   private $parse = (
-    parseable: Parseable,
+    parseable: ValidatedParseable,
   ): readonly [AnonMathNode, mjs.MathNode] => {
-    const parseableObj: Parseable =
+    const parseableObj: ValidatedParseable =
       typeof parseable === "string"
         ? { expr: parseable, type: "expr" }
         : parseable;
@@ -173,7 +176,8 @@ class MathJsParser implements IMathJsParser {
   private static aggregateNodes = (
     nodes: AnonMathNode[],
     mjsNode: mjs.ArrayNode,
-    validate: NonNullable<ParseableObjs["array"]["validate"]> = (x) => x,
+    validate: NonNullable<ValidatedParseableObjs["array"]["validate"]> = (x) =>
+      x,
   ): AnonMathNode => {
     const evaluate: AnonMathNode["evaluate"] = (scope) => {
       const result = aggregate(nodes, (node) => node.evaluate(scope));

--- a/packages/parser/src/evaluate.ts
+++ b/packages/parser/src/evaluate.ts
@@ -3,7 +3,7 @@ import type * as mjs from "mathjs";
 import type { EvaluationScope, AnonMathNode } from "@math3d/mathscope";
 import { EvaluationError } from "@math3d/mathscope";
 import invariant from "tiny-invariant";
-import type { Validate } from "./interfaces";
+import type { ParseValidate } from "./interfaces";
 
 class FunctionEvaluationError extends EvaluationError {
   innerError: Error;
@@ -55,7 +55,7 @@ const identity = <T>(x: T): T => x;
 
 const getValidatedEvaluate = (
   mjsNode: mjs.MathNode,
-  validate: Validate = identity,
+  validate: ParseValidate = identity,
 ): AnonMathNode["evaluate"] => {
   const compiled = mjsNode.compile();
   const unvalidatedEvaluate = (scope?: EvaluationScope) => {

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -1,5 +1,11 @@
 export * from "./helpers";
 export * from "./parsers";
-export type { Parseable, ParseableObjs, ParseableArray } from "./interfaces";
+export type {
+  Parseable,
+  ParseableObjs,
+  ParseableArray,
+  ValidatedParseable,
+  ValidatedParseableObjs,
+} from "./interfaces";
 export { ParameterErrors } from "./rules";
 export { DetailedAssignmentError } from "./MathJsParser";

--- a/packages/parser/src/interfaces.ts
+++ b/packages/parser/src/interfaces.ts
@@ -2,31 +2,39 @@ import type * as mjs from "mathjs";
 
 import type { Parse } from "@math3d/mathscope";
 
-type Validate = (evaluated: unknown, parsed: mjs.MathNode) => void;
+// A parse-time validator. It runs the evaluated result through a check that
+// throws on invalid input and otherwise returns the (possibly narrowed) value.
+// Sourced from a math-item property config (`Validate<V>` in mathitem-configs,
+// where the return is pinned to the property's EvaluatedProperties type) and
+// attached to a parseable at sync time by syncMathScope — it is NOT part of the
+// serialized item shape. Named `ParseValidate` to distinguish it from the
+// stronger, generic `Validate<V>` in mathitem-configs. Return is `unknown`
+// because the value flows on as the node's evaluated result.
+type ParseValidate = (evaluated: unknown, parsed: mjs.MathNode) => unknown;
+type ArrayValidate = (evaluated: unknown[], node: mjs.ArrayNode) => unknown;
 
+// --- Serializable parseable shapes (the stored/wire form; no validators). ---
+// These mirror the generated v1 client's value models, so the math-item
+// property types that reference them stay structurally equal to the backend.
 type ParseableObjs = {
   expr: {
     type: "expr";
     expr: string;
-    validate?: Validate;
   };
   assignment: {
     type: "assignment";
     lhs: string;
     rhs: string;
-    validate?: Validate;
   };
   "function-assignment": {
     type: "function-assignment";
     name: string;
     params: string[];
     rhs: string;
-    validate?: Validate;
   };
   array: {
     type: "array";
     items: Parseable[];
-    validate?: (evaluated: unknown[], node: mjs.ArrayNode) => void;
   };
 };
 
@@ -38,6 +46,24 @@ type ParseableArray<I extends Parseable = Parseable> = Omit<
 > & {
   items: I[];
 };
+
+// --- Parse-time shapes: the serializable shapes plus the optional validator
+// the parser reads. syncMathScope builds these by attaching a config validator
+// to the stored (validate-free) parseable; the parser consumes them. Array
+// `items` stay validate-free `Parseable` (only the top-level parseable for a
+// property carries a validator), and a validate-free `Parseable` is assignable
+// to `ValidatedParseable` since `validate` is optional. ---
+type ValidatedParseableObjs = {
+  expr: ParseableObjs["expr"] & { validate?: ParseValidate };
+  assignment: ParseableObjs["assignment"] & { validate?: ParseValidate };
+  "function-assignment": ParseableObjs["function-assignment"] & {
+    validate?: ParseValidate;
+  };
+  array: ParseableObjs["array"] & { validate?: ArrayValidate };
+};
+type ValidatedParseableObj =
+  ValidatedParseableObjs[keyof ValidatedParseableObjs];
+type ValidatedParseable = string | ValidatedParseableObj;
 
 enum ParserRuleType {
   MathJs = "mathjs",
@@ -59,7 +85,7 @@ type ParserRule = TextParserRule | MathJsRule;
 
 interface IMathJsParser {
   preprocess: (text: string) => string;
-  parse: Parse<Parseable>;
+  parse: Parse<ValidatedParseable>;
 }
 
 export { ParserRuleType };
@@ -67,9 +93,11 @@ export type {
   Parseable,
   ParseableObjs,
   ParseableArray,
+  ValidatedParseable,
+  ValidatedParseableObjs,
   IMathJsParser,
   MathJsRule,
   ParserRule,
   TextParserRule,
-  Validate,
+  ParseValidate,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3031,6 +3031,7 @@ __metadata:
     axios: "npm:^1.6.7"
     eslint: "npm:^8.54.0"
     tiny-invariant: "npm:^1.3.1"
+    type-fest: "npm:5.7.0"
     vitest: "npm:^4.0.18"
   languageName: unknown
   linkType: soft
@@ -19092,6 +19093,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tagged-tag@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "tagged-tag@npm:1.0.0"
+  checksum: 10/e37653df3e495daa7ea7790cb161b810b00075bba2e4d6c93fb06a709e747e3ae9da11a120d0489833203926511b39e038a2affbd9d279cfb7a2f3fcccd30b5d
+  languageName: node
+  linkType: hard
+
 "tapable@npm:^1.0.0, tapable@npm:^1.1.3":
   version: 1.1.3
   resolution: "tapable@npm:1.1.3"
@@ -19908,6 +19916,15 @@ __metadata:
   dependencies:
     prelude-ls: "npm:~1.1.2"
   checksum: 10/11dec0b50d7c3fd2e630b4b074ba36918ed2b1efbc87dfbd40ba9429d49c58d12dad5c415ece69fcf358fa083f33466fc370f23ab91aa63295c45d38b3a60dda
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:5.7.0":
+  version: 5.7.0
+  resolution: "type-fest@npm:5.7.0"
+  dependencies:
+    tagged-tag: "npm:^1.0.0"
+  checksum: 10/4867626aa489968df98e09ecdefbc45dfbb191ae5fb8924b3bd45da9cd940879b387086226366dce028570983a3fbe80adc53ad105a169bbbd27621c496bd6f0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What are the relevant issues?

Part of #1141 (epic #1120). Phase B, stacked on the merged Phase A (#1144).

### Description

Makes the frontend's stored/serialized math-item property types structurally
identical to the generated v1 API client, and tightens the compile-time FE/BE
sync check.

- **parser:** `ParseableObjs` is now validate-free (the serializable wire
  shape). A new `ValidatedParseable*` layer carries the optional validator the
  parser reads; `syncMathScope` attaches each property's config validator at
  sync time, so stored items never carry `validate`. The parser's weak
  `Validate` is renamed `ParseValidate` to disambiguate from mathitem-configs'
  generic `Validate<V>`, and its return widens `void` → `unknown` (the value
  flows on as the node's evaluated result).
- **api:** `v1-sync.check.ts` now asserts an invariant `Equal`
  (`IsEqual<SimplifyDeep<…>>`, via type-fest) instead of mutual assignability.
  `SimplifyDeep` normalizes the generator's discriminated-union intersection
  rendering; the check is mapped per-discriminant so a newly added item type is
  necessarily covered, and `DriftingItemTypes` names which type drifted on
  failure. Adds `type-fest@5.7.0` (devDependency).

No runtime behavior change: validators are sourced from config and run
identically; they were never part of the stored/serialized object.

### Screenshots (if appropriate)

N/A

### How can this be tested?

- `yarn turbo run typecheck lint test` — green across parser, api, app,
  mathitem-configs (178 tests pass).
- The sync guarantee is compile-time: temporarily add a field to a frontend
  item's properties (or change a type on one side) and `tsc` fails in
  `packages/api/src/v1-sync.check.ts`, naming the drifting item type.

### Additional context

Reviewed locally across four lenses (type-correctness, behavior-preservation,
maintainability, sync-efficacy). The v1 sync check was empirically verified to
catch field add/remove, type changes, optional/required flips, readonly-only
diffs, and `any`-collapse — bidirectionally. No backend changes.
