### PR TITLE
fix(header): point Contact menu item at GitHub issues

### DIFF
--- a/packages/app/src/pages/MainPage/components/Header.spec.tsx
+++ b/packages/app/src/pages/MainPage/components/Header.spec.tsx
@@ -59,6 +59,7 @@ test("Contact links to the GitHub issues page in a new tab", async () => {
   const contact = await screen.findByRole("menuitem", { name: "Contact" });
   expect(contact).toHaveAttribute("href", import.meta.env.VITE_ISSUE_URL);
   expect(contact).toHaveAttribute("target", "_blank");
+  expect(contact).toHaveAttribute("rel", "noreferrer");
 });
 
 test("Logout link goes to login page", async () => {

--- a/packages/app/src/pages/MainPage/components/Header.spec.tsx
+++ b/packages/app/src/pages/MainPage/components/Header.spec.tsx
@@ -52,6 +52,15 @@ test("Login link goes to login page", async () => {
   expect(location.current.pathname).toBe(`/auth/login`);
 });
 
+test("Contact links to the GitHub issues page in a new tab", async () => {
+  await renderTestApp("", { isAuthenticated: false });
+  const button = screen.getByRole("button", { name: "Open User Menu" });
+  await user.click(button);
+  const contact = await screen.findByRole("menuitem", { name: "Contact" });
+  expect(contact).toHaveAttribute("href", import.meta.env.VITE_ISSUE_URL);
+  expect(contact).toHaveAttribute("target", "_blank");
+});
+
 test("Logout link goes to login page", async () => {
   const { location } = await renderTestApp("", { isAuthenticated: true });
   const button = screen.getByRole("button", { name: "Open User Menu" });

--- a/packages/app/src/pages/MainPage/components/Header.tsx
+++ b/packages/app/src/pages/MainPage/components/Header.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from "react";
 import { Link } from "react-router";
+import invariant from "tiny-invariant";
 import Header from "@/util/components/Header";
 
 import LightbulbOutlined from "@mui/icons-material/LightbulbOutlined";
@@ -72,6 +73,9 @@ const LoginButtons: React.FC<{
   );
 };
 
+const ISSUE_URL = import.meta.env.VITE_ISSUE_URL;
+invariant(ISSUE_URL, "VITE_ISSUE_URL is not set");
+
 type FilterableItem = SimpleMenuItem & {
   shouldShow: boolean;
 };
@@ -141,7 +145,9 @@ const getItems = ({ user }: { user?: User | null }): FilterableItem[] => {
       label: "Contact",
       key: "contact",
       icon: <HelpOutlineOutlinedIcon fontSize="small" />,
-      href: "contact",
+      href: ISSUE_URL,
+      LinkComponent: "a",
+      target: "_blank",
       shouldShow: true,
     },
     {

--- a/packages/app/src/pages/MainPage/components/Header.tsx
+++ b/packages/app/src/pages/MainPage/components/Header.tsx
@@ -148,6 +148,7 @@ const getItems = ({ user }: { user?: User | null }): FilterableItem[] => {
       href: ISSUE_URL,
       LinkComponent: "a",
       target: "_blank",
+      rel: "noreferrer",
       shouldShow: true,
     },
     {

--- a/packages/app/src/util/components/SimpleMenu/SimpleMenu.tsx
+++ b/packages/app/src/util/components/SimpleMenu/SimpleMenu.tsx
@@ -36,6 +36,7 @@ type SimpleMenuItemLink = {
   href: string;
   LinkComponent?: React.ElementType;
   target?: HTMLAnchorElement["target"];
+  rel?: HTMLAnchorElement["rel"];
 };
 
 type SimpleMenuItem =
@@ -133,6 +134,7 @@ const SimpleMenu: React.FC<SimpleMenuProps> = ({
                   component: item.LinkComponent ?? LinkBehavior,
                   href: item.href,
                   target: item.target,
+                  rel: item.rel,
                 }
               : {};
           const onClick = () => {


### PR DESCRIPTION
### What are the relevant issues?

N/A

### Description

The **Contact** item in the header user menu linked to the relative path
`contact`, which has no matching route. React Router matched it against the
catch-all `/:sceneKey?` route, treated `"contact"` as a scene key, and 404'd.
This has been dead since the user menu was introduced (#612) — it is not a
regression.

It now points at `VITE_ISSUE_URL` (the GitHub issues page) as an external link
that opens in a new tab, reusing the env constant already consumed by
`LegacyDialog` (with the same `invariant` guard). `SimpleMenu` already supports
external links via `LinkComponent: "a"` + `target`, so no component changes were
needed.

### How can this be tested?

1. Open the user menu in the header and click **Contact** → it should open the
   repo's GitHub issues page in a new tab (previously: 404 "scene not found").

The added test in `Header.spec.tsx` asserts the Contact menuitem's `href` equals
`VITE_ISSUE_URL` and that it opens in a new tab (`target="_blank"`).

### Additional context

`VITE_ISSUE_URL` is read from `.env.development`, which now points at
`ChristopherChudzicki/math3d-next/issues` after #1158 merged.