### PR TITLE
fix(help): retain focus on Show more/less toggles

### DIFF
--- a/packages/app/src/pages/HelpPage/ReferencePanel.spec.tsx
+++ b/packages/app/src/pages/HelpPage/ReferencePanel.spec.tsx
@@ -4,9 +4,7 @@ import userEvent from "@testing-library/user-event";
 import ReferencePanel from "./ReferencePanel";
 import type { ReferenceEntry } from "./util";
 
-const makeEntry = (
-  overrides: Partial<ReferenceEntry> = {},
-): ReferenceEntry => ({
+const entry: ReferenceEntry = {
   id: "sin",
   name: "sine",
   latex: "\\sin",
@@ -14,26 +12,20 @@ const makeEntry = (
   summaryInnerHtml: "The sine function.",
   detailsHtml: "<p>More about sine.</p>",
   tags: ["trig"],
-  ...overrides,
-});
+};
 
-describe("ReferencePanel show more/less focus", () => {
-  test("focus moves to the Show less button after expanding", async () => {
-    const user = userEvent.setup();
-    render(<ReferencePanel entries={[makeEntry()]} />);
+// "Show more" and "Show less" are deliberately one persistent element whose
+// label toggles, so activating it keeps keyboard focus. This guards against a
+// regression if it's ever split back into two elements swapped in/out of the
+// DOM, which would drop focus to <body> on each click.
+test("the show more/less toggle keeps focus when activated", async () => {
+  const user = userEvent.setup();
+  render(<ReferencePanel entries={[entry]} />);
 
-    await user.click(screen.getByRole("button", { name: "Show more" }));
+  const toggle = screen.getByRole("button", { name: "Show more" });
+  await user.click(toggle);
+  expect(screen.getByRole("button", { name: "Show less" })).toHaveFocus();
 
-    expect(screen.getByRole("button", { name: "Show less" })).toHaveFocus();
-  });
-
-  test("focus moves to the Show more button after collapsing", async () => {
-    const user = userEvent.setup();
-    render(<ReferencePanel entries={[makeEntry()]} />);
-
-    await user.click(screen.getByRole("button", { name: "Show more" }));
-    await user.click(screen.getByRole("button", { name: "Show less" }));
-
-    expect(screen.getByRole("button", { name: "Show more" })).toHaveFocus();
-  });
+  await user.click(screen.getByRole("button", { name: "Show less" }));
+  expect(screen.getByRole("button", { name: "Show more" })).toHaveFocus();
 });

--- a/packages/app/src/pages/HelpPage/ReferencePanel.spec.tsx
+++ b/packages/app/src/pages/HelpPage/ReferencePanel.spec.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ReferencePanel from "./ReferencePanel";
+import type { ReferenceEntry } from "./util";
+
+const makeEntry = (
+  overrides: Partial<ReferenceEntry> = {},
+): ReferenceEntry => ({
+  id: "sin",
+  name: "sine",
+  latex: "\\sin",
+  keyboard: "sin",
+  summaryInnerHtml: "The sine function.",
+  detailsHtml: "<p>More about sine.</p>",
+  tags: ["trig"],
+  ...overrides,
+});
+
+describe("ReferencePanel show more/less focus", () => {
+  test("focus moves to the Show less button after expanding", async () => {
+    const user = userEvent.setup();
+    render(<ReferencePanel entries={[makeEntry()]} />);
+
+    await user.click(screen.getByRole("button", { name: "Show more" }));
+
+    expect(screen.getByRole("button", { name: "Show less" })).toHaveFocus();
+  });
+
+  test("focus moves to the Show more button after collapsing", async () => {
+    const user = userEvent.setup();
+    render(<ReferencePanel entries={[makeEntry()]} />);
+
+    await user.click(screen.getByRole("button", { name: "Show more" }));
+    await user.click(screen.getByRole("button", { name: "Show less" }));
+
+    expect(screen.getByRole("button", { name: "Show more" })).toHaveFocus();
+  });
+});

--- a/packages/app/src/pages/HelpPage/ReferencePanel.tsx
+++ b/packages/app/src/pages/HelpPage/ReferencePanel.tsx
@@ -16,6 +16,25 @@ type ReferencePanelProps = {
 const ReferenceRow = ({ entry }: { entry: ReferenceEntry }) => {
   const hasDetails = !!entry.detailsHtml;
   const [expanded, setExpanded] = useToggle(false);
+  const showMoreRef = React.useRef<HTMLButtonElement>(null);
+  const showLessRef = React.useRef<HTMLButtonElement>(null);
+  const interacted = React.useRef(false);
+
+  // Toggling swaps "Show more" for "Show less" (and vice versa), which are
+  // separate elements in different positions. Without intervention the focused
+  // toggle unmounts and focus falls back to <body>, stranding keyboard users.
+  // Move focus to whichever toggle just appeared, but only after a real click.
+  React.useEffect(() => {
+    if (!interacted.current) return;
+    const target = expanded ? showLessRef.current : showMoreRef.current;
+    target?.focus();
+  }, [expanded]);
+
+  const toggle = () => {
+    interacted.current = true;
+    setExpanded.toggle();
+  };
+
   return (
     <tr className={styles.row}>
       <td dangerouslySetInnerHTML={{ __html: entry.latex }} />
@@ -31,7 +50,8 @@ const ReferenceRow = ({ entry }: { entry: ReferenceEntry }) => {
             {hasDetails && !expanded && (
               // eslint-disable-next-line jsx-a11y/anchor-is-valid
               <Link
-                onClick={setExpanded.on}
+                ref={showMoreRef}
+                onClick={toggle}
                 sx={{ verticalAlign: "baseline", marginLeft: "0.5em" }}
                 component="button"
               >
@@ -45,7 +65,8 @@ const ReferenceRow = ({ entry }: { entry: ReferenceEntry }) => {
             <div dangerouslySetInnerHTML={{ __html: entry.detailsHtml }} />
             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
             <Link
-              onClick={setExpanded.off}
+              ref={showLessRef}
+              onClick={toggle}
               sx={{ verticalAlign: "baseline" }}
               component="button"
             >

--- a/packages/app/src/pages/HelpPage/ReferencePanel.tsx
+++ b/packages/app/src/pages/HelpPage/ReferencePanel.tsx
@@ -16,25 +16,6 @@ type ReferencePanelProps = {
 const ReferenceRow = ({ entry }: { entry: ReferenceEntry }) => {
   const hasDetails = !!entry.detailsHtml;
   const [expanded, setExpanded] = useToggle(false);
-  const showMoreRef = React.useRef<HTMLButtonElement>(null);
-  const showLessRef = React.useRef<HTMLButtonElement>(null);
-  const interacted = React.useRef(false);
-
-  // Toggling swaps "Show more" for "Show less" (and vice versa), which are
-  // separate elements in different positions. Without intervention the focused
-  // toggle unmounts and focus falls back to <body>, stranding keyboard users.
-  // Move focus to whichever toggle just appeared, but only after a real click.
-  React.useEffect(() => {
-    if (!interacted.current) return;
-    const target = expanded ? showLessRef.current : showMoreRef.current;
-    target?.focus();
-  }, [expanded]);
-
-  const toggle = () => {
-    interacted.current = true;
-    setExpanded.toggle();
-  };
-
   return (
     <tr className={styles.row}>
       <td dangerouslySetInnerHTML={{ __html: entry.latex }} />
@@ -47,32 +28,22 @@ const ReferenceRow = ({ entry }: { entry: ReferenceEntry }) => {
             <span
               dangerouslySetInnerHTML={{ __html: entry.summaryInnerHtml }}
             />
-            {hasDetails && !expanded && (
+            {hasDetails && (
+              // A single toggle that stays mounted across expand/collapse, so
+              // it keeps keyboard focus when activated.
               // eslint-disable-next-line jsx-a11y/anchor-is-valid
               <Link
-                ref={showMoreRef}
-                onClick={toggle}
+                onClick={setExpanded.toggle}
                 sx={{ verticalAlign: "baseline", marginLeft: "0.5em" }}
                 component="button"
               >
-                Show more
+                {expanded ? "Show less" : "Show more"}
               </Link>
             )}
           </p>
         </div>
         {expanded && entry.detailsHtml && (
-          <>
-            <div dangerouslySetInnerHTML={{ __html: entry.detailsHtml }} />
-            {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-            <Link
-              ref={showLessRef}
-              onClick={toggle}
-              sx={{ verticalAlign: "baseline" }}
-              component="button"
-            >
-              Show less
-            </Link>
-          </>
+          <div dangerouslySetInnerHTML={{ __html: entry.detailsHtml }} />
         )}
       </td>
     </tr>


### PR DESCRIPTION
### What are the relevant tickets?

N/A

### Description (What does it do?)

On the reference help page (`/app/help/reference`), the **Show more** / **Show less** toggles did not retain keyboard focus when activated. They were two separate elements in different DOM positions, so toggling one unmounted it and mounted the other — focus fell back to `<body>`, stranding keyboard users after every click.

The fix collapses them into a single `Link` whose label switches between "Show more" and "Show less". Because it stays at a fixed position in the tree, React keeps the same DOM node mounted across expand/collapse, so it retains focus naturally with no manual focus management. The expandable details now render below the toggle.

### How can this be tested?

Manual (keyboard): on `/app/help/reference`, Tab to a "Show more" link and press Enter — the toggle should stay focused and its label should flip to "Show less" (and back), rather than focus dropping to the page body.

Automated: new `ReferencePanel.spec.tsx` pins both branches — the toggle stays focused after expanding and after collapsing.

### Additional Context

Minor layout change: "Show less" now sits inline right after the summary (same spot as "Show more") instead of below the expanded details. The details blocks are only a few lines, so this reads fine and keeps the toggle in a stable position.