### PR TITLE
refactor(test): make renderTestApp synchronous

### DIFF
--- a/packages/app/src/features/overlays/OverlayHost.spec.tsx
+++ b/packages/app/src/features/overlays/OverlayHost.spec.tsx
@@ -2,12 +2,12 @@ import { test, expect } from "vitest";
 import { renderTestApp, screen } from "@/test_util";
 
 test("no overlay param renders no dialog", async () => {
-  await renderTestApp("/");
+  renderTestApp("/");
   expect(screen.queryByRole("dialog")).toBe(null);
 });
 
 test("unknown overlay value renders nothing and is left in the URL", async () => {
-  const { location } = await renderTestApp("/?overlay=bogus");
+  const { location } = renderTestApp("/?overlay=bogus");
   expect(screen.queryByRole("dialog")).toBe(null);
   expect(location.current.search).toContain("overlay=bogus");
 });
@@ -18,7 +18,7 @@ test("unknown overlay value renders nothing and is left in the URL", async () =>
 test.each(["constructor", "__proto__"])(
   "prototype-chain overlay value %s renders nothing and is left untouched",
   async (value) => {
-    const { location } = await renderTestApp(`/?overlay=${value}`);
+    const { location } = renderTestApp(`/?overlay=${value}`);
     expect(screen.queryByRole("dialog")).toBe(null);
     expect(location.current.search).toContain(`overlay=${value}`);
     // The root errorElement (branded ErrorPage) must not have been triggered.

--- a/packages/app/src/features/overlays/OverlayHost.spec.tsx
+++ b/packages/app/src/features/overlays/OverlayHost.spec.tsx
@@ -1,12 +1,12 @@
 import { test, expect } from "vitest";
 import { renderTestApp, screen } from "@/test_util";
 
-test("no overlay param renders no dialog", async () => {
+test("no overlay param renders no dialog", () => {
   renderTestApp("/");
   expect(screen.queryByRole("dialog")).toBe(null);
 });
 
-test("unknown overlay value renders nothing and is left in the URL", async () => {
+test("unknown overlay value renders nothing and is left in the URL", () => {
   const { location } = renderTestApp("/?overlay=bogus");
   expect(screen.queryByRole("dialog")).toBe(null);
   expect(location.current.search).toContain("overlay=bogus");
@@ -17,7 +17,7 @@ test("unknown overlay value renders nothing and is left in the URL", async () =>
 // app to the branded ErrorPage. They must be treated like any other unknown value.
 test.each(["constructor", "__proto__"])(
   "prototype-chain overlay value %s renders nothing and is left untouched",
-  async (value) => {
+  (value) => {
     const { location } = renderTestApp(`/?overlay=${value}`);
     expect(screen.queryByRole("dialog")).toBe(null);
     expect(location.current.search).toContain(`overlay=${value}`);

--- a/packages/app/src/features/sceneControls/mathItems/FieldWidget/MathBoolean.spec.tsx
+++ b/packages/app/src/features/sceneControls/mathItems/FieldWidget/MathBoolean.spec.tsx
@@ -20,12 +20,12 @@ const setup = async (initialValue: string) => {
   const point = makeItem(MIT.Point, { labelVisible: initialValue });
   const id = nodeId(point);
   const scene = seedDb.withSceneFromItems([point]);
-  const { store } = await renderTestApp(`/${scene.key}`);
+  const { store } = renderTestApp(`/${scene.key}`);
 
-  const mathScope = store.getState().scene.mathScope();
   await user.click(await screen.findByLabelText("More Settings"), {
     pointerEventsCheck: 0,
   });
+  const mathScope = store.getState().scene.mathScope();
   const settingsTitle = await screen.findByText("Settings", { exact: false });
   // eslint-disable-next-line testing-library/no-node-access
   const settings = settingsTitle.closest("section");

--- a/packages/app/src/features/sceneControls/mathItems/ShareButton.spec.tsx
+++ b/packages/app/src/features/sceneControls/mathItems/ShareButton.spec.tsx
@@ -19,17 +19,17 @@ describe("Share Button", () => {
   test("Clicking Share button sends correct POST request", async () => {
     const item = makeItem(MIT.Point);
     const scene = seedDb.withSceneFromItems([item]);
-    await renderTestApp(`/${scene.key}`);
-    const shareButton = screen.getByRole("button", { name: "Share" });
+    renderTestApp(`/${scene.key}`);
+    const shareButton = await screen.findByRole("button", { name: "Share" });
     await user.click(shareButton);
   });
 
   test("Clicking Share button shows dialog with shareable URL", async () => {
     const item = makeItem(MIT.Point);
     const scene = seedDb.withSceneFromItems([item]);
-    await renderTestApp(`/${scene.key}`);
+    renderTestApp(`/${scene.key}`);
 
-    const shareButton = screen.getByRole("button", { name: "Share" });
+    const shareButton = await screen.findByRole("button", { name: "Share" });
     await user.click(shareButton);
 
     const input =
@@ -47,9 +47,9 @@ describe("Share Button", () => {
   });
 
   test("Clicking Copy button copies the URL", async () => {
-    await renderTestApp();
+    renderTestApp();
 
-    const shareButton = screen.getByRole("button", { name: "Share" });
+    const shareButton = await screen.findByRole("button", { name: "Share" });
     await user.click(shareButton);
 
     const input =

--- a/packages/app/src/features/sceneControls/mathItems/__tests__/__utils__/index.ts
+++ b/packages/app/src/features/sceneControls/mathItems/__tests__/__utils__/index.ts
@@ -49,7 +49,7 @@ const setupItemTest = async <T extends MathItemType>(
 ) => {
   const item = makeItem(type, props);
   const scene = seedDb.withSceneFromItems([item]);
-  const { store } = await renderTestApp(`/${scene.key}`);
+  const { store } = renderTestApp(`/${scene.key}`);
 
   const form = await findItemByDescription(item.properties.description);
   invariant(

--- a/packages/app/src/features/sceneControls/mathItems/__tests__/booleanVariable.spec.tsx
+++ b/packages/app/src/features/sceneControls/mathItems/__tests__/booleanVariable.spec.tsx
@@ -1,20 +1,20 @@
 import { MathItemType as MIT } from "@math3d/mathitem-configs";
 import { nodeId, renderTestApp, screen, user, within } from "@/test_util";
 import { seedDb, makeItem } from "@math3d/mock-api";
-import { getItemByDescription } from "./__utils__";
+import { findItemByDescription } from "./__utils__";
 
 test("left-hand parse errors are indicated on left-hand side", async () => {
   const variable = makeItem(MIT.BooleanVariable, {
     value: { lhs: "a+", rhs: "123", type: "assignment" },
   });
   const scene = seedDb.withSceneFromItems([variable]);
-  const { store } = await renderTestApp(`/${scene.key}`);
+  const { store } = renderTestApp(`/${scene.key}`);
 
-  const mathScope = store.getState().scene.mathScope();
-  expect(mathScope.errors.size).toBe(1);
   const lhs = await screen.findByLabelText("Switch name", {
     exact: false,
   });
+  const mathScope = store.getState().scene.mathScope();
+  expect(mathScope.errors.size).toBe(1);
   expect(lhs).toHaveClass("has-error");
 });
 
@@ -25,9 +25,9 @@ test("Clicking switch on Boolean variable toggles value", async () => {
   });
   const scene = seedDb.withSceneFromItems([variable]);
   const id = nodeId(variable);
-  const { store } = await renderTestApp(`/${scene.key}`);
+  const { store } = renderTestApp(`/${scene.key}`);
+  const form = await findItemByDescription("Test Switch");
   const mathScope = store.getState().scene.mathScope();
-  const form = getItemByDescription("Test Switch");
   const checkboxEl = await within(form).findByRole("checkbox", {
     name: "Value",
   });

--- a/packages/app/src/features/sceneControls/mathItems/__tests__/collapsing.spec.tsx
+++ b/packages/app/src/features/sceneControls/mathItems/__tests__/collapsing.spec.tsx
@@ -1,6 +1,10 @@
 import { renderTestApp, screen, user, within } from "@/test_util";
 import * as _ from "lodash-es";
-import { addItem, getItemByDescription } from "./__utils__";
+import {
+  addItem,
+  findItemByDescription,
+  getItemByDescription,
+} from "./__utils__";
 
 /**
  * Detect whether an element or one of its ancestors is hidden based on its
@@ -35,8 +39,9 @@ test.each([
 ])(
   "When isCollapsed is initially $isCollapsed, items are $adjective",
   async ({ route, expectHidden }) => {
-    await renderTestApp(route);
+    renderTestApp(route);
 
+    await findItemByDescription("P2a");
     const els = screen.getAllByLabelText("Description");
     expect(els[4]).toBeVisible();
 
@@ -46,8 +51,8 @@ test.each([
 );
 
 test("Collapsing and expanding folders", async () => {
-  await renderTestApp("/test_folders");
-  await user.click(getExpandCollapse(getItemByDescription("F2")));
+  renderTestApp("/test_folders");
+  await user.click(getExpandCollapse(await findItemByDescription("F2")));
 
   const els = screen.getAllByLabelText("Description");
   expect(els[4]).toBeVisible();
@@ -70,9 +75,9 @@ test("Collapsing and expanding folders", async () => {
 });
 
 test("Inserting into a collapsed folder expands the folder", async () => {
-  await renderTestApp("/test_folders");
+  renderTestApp("/test_folders");
 
-  const folder = getItemByDescription("F2");
+  const folder = await findItemByDescription("F2");
   const toggle = getExpandCollapse(folder);
   await user.click(toggle);
 

--- a/packages/app/src/features/sceneControls/mathItems/__tests__/colorpicker.spec.tsx
+++ b/packages/app/src/features/sceneControls/mathItems/__tests__/colorpicker.spec.tsx
@@ -16,7 +16,7 @@ const setup = async <R extends MIT>(
   const item = makeItem(type, itemProps);
   const id = nodeId(item);
   const scene = seedDb.withSceneFromItems([item]);
-  const { store } = await renderTestApp(`/${scene.key}`);
+  const { store } = renderTestApp(`/${scene.key}`);
 
   const mathScope = store.getState().scene.mathScope();
   const findButton = () =>
@@ -45,8 +45,9 @@ const setup = async <R extends MIT>(
 
 test("short clicks on indicator toggle visibility", async () => {
   const { findButton, getItem, user } = await setup(MIT.Point);
+  const button = await findButton();
   expect(getItem().properties.visible).toBe(true);
-  await user.click(await findButton());
+  await user.click(button);
   expect(getItem().properties.visible).toBe(false);
   await user.click(await findButton());
   expect(getItem().properties.visible).toBe(true);
@@ -55,10 +56,11 @@ test("short clicks on indicator toggle visibility", async () => {
 test("long press opens color picker dialog", async () => {
   const { findButton, getItem, getAllSwatches, user } = await setup(MIT.Point);
   const timedEvents = getTimedEvents(user);
+  const button = await findButton();
   expect(getItem().properties.visible).toBe(true);
   expect(screen.queryByRole("dialog")).toBe(null);
   await timedEvents.pointerPrimary({
-    target: await findButton(),
+    target: button,
     duration: 500,
   });
   expect(screen.getByRole("dialog")).toBeDefined();
@@ -72,9 +74,10 @@ test("clicking a swatch sets item to that color", async () => {
   const { findButton, getItem, getAllSwatches, user } = await setup(MIT.Point);
   const timedEvents = getTimedEvents(user);
 
+  const button = await findButton();
   expect(getItem().properties.color).toBe("#3090ff");
   await timedEvents.pointerPrimary({
-    target: await findButton(),
+    target: button,
     duration: 500,
   });
   const swatches = await getAllSwatches();
@@ -83,7 +86,7 @@ test("clicking a swatch sets item to that color", async () => {
 });
 
 test("Setting colorExpr for surfaces", async () => {
-  const { getButton, getItem, user } = await setup(MIT.ExplicitSurface, {
+  const { findButton, getItem, user } = await setup(MIT.ExplicitSurface, {
     colorExpr: {
       type: "function-assignment",
       name: "_f",
@@ -116,7 +119,7 @@ test("Setting colorExpr for surfaces", async () => {
   });
   const timedEvents = getTimedEvents(user);
   await timedEvents.pointerPrimary({
-    target: await getButton(),
+    target: await findButton(),
     duration: 500,
   });
 

--- a/packages/app/src/features/sceneControls/mathItems/__tests__/colorpicker.spec.tsx
+++ b/packages/app/src/features/sceneControls/mathItems/__tests__/colorpicker.spec.tsx
@@ -21,7 +21,6 @@ const setup = async <R extends MIT>(
   const mathScope = store.getState().scene.mathScope();
   const findButton = () =>
     screen.findByRole("button", { name: "Show Graphic" });
-  const getButton = () => screen.getByRole("button", { name: "Show Graphic" });
   const findTextInput = () => screen.findByTitle("Custom Color Input");
   const getAllSwatches = () => {
     const dialog = screen.getByRole("dialog");
@@ -36,7 +35,6 @@ const setup = async <R extends MIT>(
     user,
     getItem,
     findButton,
-    getButton,
     findTextInput,
     getAllSwatches,
     getCalculatedProp,

--- a/packages/app/src/features/sceneControls/mathItems/__tests__/implicitSurface.spec.tsx
+++ b/packages/app/src/features/sceneControls/mathItems/__tests__/implicitSurface.spec.tsx
@@ -52,7 +52,8 @@ test("Updating parameter names updates the lhs and rhs appropriately", async () 
     rhs: rhs.initial,
   });
   const scene = seedDb.withSceneFromItems([item]);
-  const { store } = await renderTestApp(`/${scene.key}`);
+  const { store } = renderTestApp(`/${scene.key}`);
+  await screen.findByLabelText("Name for 1st parameter");
   const mathScope = store.getState().scene.mathScope();
   const [paramInput] = getParamNameInputs();
   await user.clear(paramInput);
@@ -88,11 +89,11 @@ test.each([{ name: "lhs" as const }, { name: "rhs" as const }])(
       [name]: initial,
     });
     const scene = seedDb.withSceneFromItems([item]);
-    const { store } = await renderTestApp(`/${scene.key}`);
+    const { store } = renderTestApp(`/${scene.key}`);
 
-    const input = screen.getByLabelText(
+    const input = (await screen.findByLabelText(
       config.properties[name].label,
-    ) as HTMLInputElement;
+    )) as HTMLInputElement;
     expect(input.value).toBe(initialDisplay);
     await user.clear(input);
     await user.click(input);

--- a/packages/app/src/features/sceneControls/mathItems/__tests__/item-insertion.spec.tsx
+++ b/packages/app/src/features/sceneControls/mathItems/__tests__/item-insertion.spec.tsx
@@ -6,14 +6,16 @@ import { faker } from "@faker-js/faker/locale/en";
 import {
   addItem,
   clickRemoveItem,
+  findItemByDescription,
   getActiveItem,
   getItemByDescription,
   getItemByTestId,
 } from "./__utils__";
 
 test("setup renders 9 points in 3 folders", async () => {
-  await renderTestApp("/test_folders");
+  renderTestApp("/test_folders");
 
+  await findItemByDescription("F1");
   const descriptions = screen
     .getAllByLabelText("Description")
     .map((x) => x.textContent);
@@ -69,8 +71,9 @@ test.each([
     description: "[Active Item = Folder] folders are inserted after it",
   },
 ])("$description", async ({ itemToAdd, expected, beforeAdd }) => {
-  await renderTestApp("/test_folders");
+  renderTestApp("/test_folders");
 
+  await findItemByDescription("F1");
   await beforeAdd();
   await addItem(itemToAdd);
 
@@ -83,7 +86,7 @@ test.each([
 });
 
 test("Newly inserted item is activated", async () => {
-  await renderTestApp("/test_folders");
+  renderTestApp("/test_folders");
 
   /**
    * The behaviors associated with "being active item" are
@@ -93,6 +96,7 @@ test("Newly inserted item is activated", async () => {
    * We'll make assertions about the insertion part.
    */
 
+  await findItemByDescription("P2a");
   await activateItem("P2a")();
   await addItem("Point");
   await addItem("Line");
@@ -107,8 +111,8 @@ test("Newly inserted item is activated", async () => {
 });
 
 test("Inserting items after deletion---active item resets", async () => {
-  await renderTestApp("/test_folders");
-  const p2b = getItemByDescription("P2b");
+  renderTestApp("/test_folders");
+  const p2b = await findItemByDescription("P2b");
   const description = within(p2b).getByLabelText("Description");
   await user.click(description);
   await clickRemoveItem(p2b);
@@ -142,7 +146,8 @@ test.each(permanentItems)(
   "Cannot insert items into permanent folders",
   async ({ itemId }) => {
     // insertion should be allowed but should be into default folder and refocus tab
-    const { store } = await renderTestApp("/");
+    const { store } = renderTestApp("/");
+    await findItemByDescription("Explicit Surface");
     await user.click(screen.getByRole("tab", { name: "Axes & Camera" }));
     const item = getItemByTestId(itemId);
     const description = within(item).getByLabelText("Description");
@@ -159,9 +164,9 @@ test.each(permanentItems)(
 );
 
 test.each(permanentItems)("Removing items", async ({ itemId }) => {
-  await renderTestApp("/");
+  renderTestApp("/");
   const removeBtnLabel = "Remove Item";
-  within(getItemByDescription("Explicit Surface")).getByRole("button", {
+  within(await findItemByDescription("Explicit Surface")).getByRole("button", {
     name: removeBtnLabel,
   });
   await user.click(screen.getByRole("tab", { name: "Axes & Camera" }));
@@ -176,8 +181,8 @@ test.each(permanentItems)("Removing items", async ({ itemId }) => {
 test.each(permanentItems)(
   "Cannot move permanent folders or their items",
   async ({ itemId }) => {
-    await renderTestApp("/");
-    const surface = getItemByDescription("Explicit Surface");
+    renderTestApp("/");
+    const surface = await findItemByDescription("Explicit Surface");
     expect(
       surface.closest('[aria-roledescription="sortable"]'),
     ).not.toHaveAttribute("aria-disabled", "true");
@@ -199,8 +204,8 @@ test.each([
   },
 ])("Cannot delete non-empty folders", async ({ items, isRemoveDisabled }) => {
   const scene = seedDb.withSceneFromItems(items);
-  await renderTestApp(`/${scene.key}`);
-  const folder = getItemByDescription("Folder");
+  renderTestApp(`/${scene.key}`);
+  const folder = await findItemByDescription("Folder");
   const removeBtn = within(folder).getByRole("button", {
     name: "Remove Item",
   }) as HTMLButtonElement;
@@ -211,7 +216,8 @@ test("Inserted item id is not already used", async () => {
   const count = faker.number.int({ min: 1, max: 10 });
   const items = _.times(count, () => makeItem(MIT.Point));
   const scene = seedDb.withSceneFromItems(items);
-  const { store } = await renderTestApp(`/${scene.key}`);
+  const { store } = renderTestApp(`/${scene.key}`);
+  await findItemByDescription("Folder");
   const idsA = Object.keys(store.getState().scene.items).map((x) => +x);
 
   await addItem("Point");

--- a/packages/app/src/features/sceneControls/mathItems/__tests__/parametricSurface.spec.tsx
+++ b/packages/app/src/features/sceneControls/mathItems/__tests__/parametricSurface.spec.tsx
@@ -123,12 +123,10 @@ test.each([
     });
     const id = nodeId(item);
     const scene = seedDb.withSceneFromItems([item]);
-    const { store } = await renderTestApp(`/${scene.key}`);
+    const { store } = renderTestApp(`/${scene.key}`);
 
+    await screen.findByLabelText("Name for 1st parameter");
     const mathScope = store.getState().scene.mathScope();
-    await new Promise((resolve) => {
-      setTimeout(resolve);
-    });
     // initiall there is an error since the expr RHS contains "abc" which is not a param name or defined variable
     expect(mathScope.errors.has(id("expr"))).toBe(true);
     const inputs = getParamNameInputs();
@@ -182,8 +180,9 @@ test.each([
     const item = makeItem(MIT.ParametricSurface, { expr: expression.initial });
     const id = nodeId(item);
     const scene = seedDb.withSceneFromItems([item]);
-    const { store } = await renderTestApp(`/${scene.key}`);
+    const { store } = renderTestApp(`/${scene.key}`);
 
+    await screen.findByLabelText("Name for 1st parameter");
     const mathScope = store.getState().scene.mathScope();
     const inputs = getParamNameInputs();
 

--- a/packages/app/src/features/sceneControls/mathItems/__tests__/point.spec.tsx
+++ b/packages/app/src/features/sceneControls/mathItems/__tests__/point.spec.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/test_util";
 import { seedDb, makeItem } from "@math3d/mock-api";
 import { assertNotNil } from "@/util/predicates";
-import { getItemByDescription } from "./__utils__";
+import { findItemByDescription, getItemByDescription } from "./__utils__";
 
 test.each([
   {
@@ -37,8 +37,9 @@ test.each([
     const item = makeItem(MIT.Point, { coords: coordsString });
     const id = nodeId(item);
     const scene = seedDb.withSceneFromItems([item]);
-    const { store } = await renderTestApp(`/${scene.key}`);
+    const { store } = renderTestApp(`/${scene.key}`);
 
+    await findItemByDescription(item.properties.description);
     const mathScope = store.getState().scene.mathScope();
     expect(mathScope.errors.size).toBe(numEvalErrors + numParseErrors);
     expect(mathScope.results.get(id("coords"))).toStrictEqual(coords);
@@ -71,10 +72,10 @@ test.each([
     const item = makeItem(MIT.Point);
     const id = nodeId(item);
     const scene = seedDb.withSceneFromItems([item]);
-    const { store } = await renderTestApp(`/${scene.key}`);
+    const { store } = renderTestApp(`/${scene.key}`);
 
-    const mathScope = store.getState().scene.mathScope();
     const coordsInput = await screen.findByLabelText("Coordinates");
+    const mathScope = store.getState().scene.mathScope();
 
     pasteText(coordsInput, coordsString);
     expect(mathScope.errors.size).toBe(numEvalErrors + numParseErrors);
@@ -84,9 +85,8 @@ test.each([
 
 test("Adding items adds to mathScope", async () => {
   const scene = seedDb.withSceneFromItems([]);
-  const { store } = await renderTestApp(`/${scene.key}`);
+  const { store } = renderTestApp(`/${scene.key}`);
 
-  const mathScope = store.getState().scene.mathScope();
   await user.click(await screen.findByText("Add Object"));
   const menu = await screen.findByRole("menu");
   const addPoint = await within(menu).findByText("Point");
@@ -100,6 +100,7 @@ test("Adding items adds to mathScope", async () => {
   assertNotNil(point);
   const id = nodeId(point);
   getItemByDescription(point.properties.description);
+  const mathScope = store.getState().scene.mathScope();
   expect(mathScope.results.get(id("coords"))).toStrictEqual([[0, 0, 0]]);
   expect(mathScope.errors.size).toBe(0);
 });
@@ -113,13 +114,13 @@ test("Deleting items removes them from mathScope", async () => {
     opacity: "2^[1,2,3]",
   });
   const scene = seedDb.withSceneFromItems([point]);
-  const { store } = await renderTestApp(`/${scene.key}`);
+  const { store } = renderTestApp(`/${scene.key}`);
 
+  const item = await findItemByDescription(point.properties.description);
   const mathScope = store.getState().scene.mathScope();
   expect(mathScope.results.size).toBeGreaterThan(1); // point + folder visibility
   expect(mathScope.errors.size).toBeGreaterThan(0);
 
-  const item = getItemByDescription(point.properties.description);
   const remove = within(item).getByLabelText("Remove Item");
   await user.click(remove);
   expect(mathScope.results.size).toBe(1); // folder visibility

--- a/packages/app/src/features/sceneControls/mathItems/__tests__/shows-error-tooltips.spec.tsx
+++ b/packages/app/src/features/sceneControls/mathItems/__tests__/shows-error-tooltips.spec.tsx
@@ -17,14 +17,14 @@ const queryTooltip = () => screen.queryByRole("tooltip");
 
 test.each([
   {
-    getInput: () => screen.getByLabelText("Value (left-hand side)"),
+    getInput: () => screen.findByLabelText("Value (left-hand side)"),
     item: makeItem(MIT.Variable, {
       value: { lhs: "a + ", rhs: "1", type: "assignment" },
     }),
     errMatcher: /Invalid left-hand side/,
   },
   {
-    getInput: () => screen.getByLabelText("Value (right-hand side)"),
+    getInput: () => screen.findByLabelText("Value (right-hand side)"),
     item: makeItem(MIT.Variable, {
       value: { lhs: "a", rhs: "1 + ", type: "assignment" },
     }),
@@ -39,8 +39,8 @@ test.each([
   "Widgets display error message in tooltip only when focused",
   async ({ getInput, item, errMatcher }) => {
     const scene = seedDb.withSceneFromItems([item]);
-    await renderTestApp(`/${scene.key}`);
-    const theInput = getInput();
+    renderTestApp(`/${scene.key}`);
+    const theInput = await getInput();
 
     // not initially shown
     expect(queryTooltip()).not.toBeInTheDocument();
@@ -60,9 +60,9 @@ test.each([
 test("Widget does not show a tooltip when focused if no error", async () => {
   const item = makeItem(MIT.Point, { coords: "[1,2,3] + 1" });
   const scene = seedDb.withSceneFromItems([item]);
-  await renderTestApp(`/${scene.key}`);
+  renderTestApp(`/${scene.key}`);
 
-  const theInput = screen.getByLabelText("Coordinates");
+  const theInput = await screen.findByLabelText("Coordinates");
 
   // not initially shown
   expect(queryTooltip()).not.toBeInTheDocument();

--- a/packages/app/src/features/sceneControls/mathItems/__tests__/variable-slider.spec.tsx
+++ b/packages/app/src/features/sceneControls/mathItems/__tests__/variable-slider.spec.tsx
@@ -14,7 +14,7 @@ import {
 import { seedDb, makeItem } from "@math3d/mock-api";
 import type { ResolvePromise } from "@math3d/utils";
 import { ParseableObjs } from "@math3d/parser";
-import { getItemByDescription, findBtn } from "./__utils__";
+import { findItemByDescription, findBtn } from "./__utils__";
 import { mathScopeId } from "../mathScope";
 
 const valueObj = (v: string): ParseableObjs["assignment"] => {
@@ -60,9 +60,9 @@ const setupTest = async (overrides: Overrides = {}) => {
 
   const item = makeItem(MIT.VariableSlider, props);
   const scene = seedDb.withSceneFromItems([item]);
-  const { store } = await renderTestApp(`/${scene.key}`);
+  const { store } = renderTestApp(`/${scene.key}`);
 
-  const itemEl = getItemByDescription(item.properties.description);
+  const itemEl = await findItemByDescription(item.properties.description);
   const btnToggle = await findBtn(itemEl, /(Pause)|(Play)/);
   const btnFaster = await findBtn(itemEl, btnLabels.faster);
   const btnSlower = await findBtn(itemEl, btnLabels.slower);

--- a/packages/app/src/features/sceneControls/mathItems/__tests__/variable.spec.tsx
+++ b/packages/app/src/features/sceneControls/mathItems/__tests__/variable.spec.tsx
@@ -7,12 +7,12 @@ test("left-hand parse errors are indicated on left-hand side", async () => {
     value: { lhs: "a+", rhs: "123", type: "assignment" },
   });
   const scene = seedDb.withSceneFromItems([variable]);
-  const { store } = await renderTestApp(`/${scene.key}`);
+  const { store } = renderTestApp(`/${scene.key}`);
 
-  const mathScope = store.getState().scene.mathScope();
-  expect(mathScope.errors.size).toBe(1);
   const lhs = await screen.findByLabelText("left-hand side", { exact: false });
   const rhs = await screen.findByLabelText("right-hand side", { exact: false });
+  const mathScope = store.getState().scene.mathScope();
+  expect(mathScope.errors.size).toBe(1);
   expect(lhs).toHaveClass("has-error");
   expect(rhs).not.toHaveClass("has-error");
 });
@@ -22,12 +22,12 @@ test("right-hand parse errors are indicated on right-hand side", async () => {
     value: { lhs: "a", rhs: "123 + ", type: "assignment" },
   });
   const scene = seedDb.withSceneFromItems([variable]);
-  const { store } = await renderTestApp(`/${scene.key}`);
+  const { store } = renderTestApp(`/${scene.key}`);
 
-  const mathScope = store.getState().scene.mathScope();
-  expect(mathScope.errors.size).toBe(1);
   const lhs = await screen.findByLabelText("left-hand side", { exact: false });
   const rhs = await screen.findByLabelText("right-hand side", { exact: false });
+  const mathScope = store.getState().scene.mathScope();
+  expect(mathScope.errors.size).toBe(1);
   expect(lhs).not.toHaveClass("has-error");
   expect(rhs).toHaveClass("has-error");
 });

--- a/packages/app/src/features/sceneControls/mathItems/__tests__/visibility.spec.tsx
+++ b/packages/app/src/features/sceneControls/mathItems/__tests__/visibility.spec.tsx
@@ -25,7 +25,7 @@ describe("Visible and calculatedVisibility", () => {
       initialItems.boolean,
       initialItems.point,
     ]);
-    const { store } = await renderTestApp(`/${scene.key}`);
+    const { store } = renderTestApp(`/${scene.key}`);
 
     const getPointData = () =>
       store.getState().scene.items[initialItems.point.id];

--- a/packages/app/src/pages/HelpPage/HelpPage.spec.tsx
+++ b/packages/app/src/pages/HelpPage/HelpPage.spec.tsx
@@ -2,7 +2,7 @@ import { test, expect } from "vitest";
 import { renderTestApp, screen } from "@/test_util";
 
 test("help reference loads at /app/help/reference", async () => {
-  await renderTestApp("/app/help/reference");
+  renderTestApp("/app/help/reference");
   expect(
     await screen.findByRole("heading", { name: "Function Reference" }),
   ).toBeVisible();
@@ -10,7 +10,7 @@ test("help reference loads at /app/help/reference", async () => {
 
 test("an overlay opens over an /app page (host wraps both subtrees)", async () => {
   // R3 AC: overlays are openable from any route, including /app/... pages.
-  await renderTestApp("/app/help/reference?overlay=login");
+  renderTestApp("/app/help/reference?overlay=login");
   // HelpPage is in the tree — MUI Dialog sets aria-hidden on the background, so
   // query with { hidden: true } to reach it; toBeInTheDocument() confirms presence.
   expect(

--- a/packages/app/src/pages/MainPage/MainPage.spec.tsx
+++ b/packages/app/src/pages/MainPage/MainPage.spec.tsx
@@ -24,7 +24,7 @@ test.each([
 ])(
   "'controls' URL query parameter controls whether the controls are visible",
   async ({ controlsVisible, url, expectedHidden, expectedInert }) => {
-    await renderTestApp(url);
+    renderTestApp(url);
     const expandBtn = screen.queryByRole("button", { name: "Expand Controls" });
     const collapseBtn = screen.queryByRole("button", {
       name: "Collapse Controls",
@@ -45,7 +45,7 @@ test.each([
 );
 
 test("Clicking the 'Expand/Collapse Controls' button toggles the controls and preserves hash", async () => {
-  const { location } = await renderTestApp("#foo");
+  const { location } = renderTestApp("#foo");
   const btn = screen.getByRole("button", { name: "Collapse Controls" });
   expect(location.current).toMatchObject({
     hash: "#foo",
@@ -66,11 +66,8 @@ test("Clicking the 'Expand/Collapse Controls' button toggles the controls and pr
 test("Alerts and redirects home when the scene key is not found", async () => {
   // MSW returns 404 for an unknown scene key; useScene surfaces it as an
   // ApiError, which SceneControls maps to a "Not found" alert + redirect to "/".
-  // waitForReady is skipped: the scene never loads, so the controls stay busy —
-  // we key off the alert dialog instead.
-  const { location } = await renderTestApp("/nonexistent-scene-key", {
-    waitForReady: false,
-  });
+  // The scene never loads (controls stay busy), so we key off the alert dialog.
+  const { location } = renderTestApp("/nonexistent-scene-key");
 
   const dialog = await screen.findByRole("dialog");
   expect(dialog).toHaveTextContent("Not found");

--- a/packages/app/src/pages/MainPage/MainPage.spec.tsx
+++ b/packages/app/src/pages/MainPage/MainPage.spec.tsx
@@ -23,7 +23,7 @@ test.each([
   },
 ])(
   "'controls' URL query parameter controls whether the controls are visible",
-  async ({ controlsVisible, url, expectedHidden, expectedInert }) => {
+  ({ controlsVisible, url, expectedHidden, expectedInert }) => {
     renderTestApp(url);
     const expandBtn = screen.queryByRole("button", { name: "Expand Controls" });
     const collapseBtn = screen.queryByRole("button", {

--- a/packages/app/src/pages/MainPage/components/Header.authHidden.spec.tsx
+++ b/packages/app/src/pages/MainPage/components/Header.authHidden.spec.tsx
@@ -1,12 +1,12 @@
 import { test, expect } from "vitest";
-import { renderTestApp, screen, user } from "@/test_util";
+import { renderTestApp, screen, user, waitForAppReady } from "@/test_util";
 
 vi.mock("@/features/auth/displayAuthFlows", () => ({
   DISPLAY_AUTH_FLOWS: false,
 }));
 
 test("Sign in and Sign up header buttons are hidden when DISPLAY_AUTH_FLOWS is false", async () => {
-  await renderTestApp("", { isAuthenticated: false });
+  renderTestApp("", { isAuthenticated: false });
   await screen.findByRole("button", { name: "Open User Menu" });
 
   expect(screen.queryByRole("button", { name: "Sign in" })).toBeNull();
@@ -14,7 +14,7 @@ test("Sign in and Sign up header buttons are hidden when DISPLAY_AUTH_FLOWS is f
 });
 
 test("Sign in and Sign up menu items are hidden when DISPLAY_AUTH_FLOWS is false", async () => {
-  await renderTestApp("", { isAuthenticated: false });
+  renderTestApp("", { isAuthenticated: false });
   const button = screen.getByRole("button", { name: "Open User Menu" });
   await user.click(button);
   await screen.findByRole("menu");
@@ -26,7 +26,12 @@ test("Sign in and Sign up menu items are hidden when DISPLAY_AUTH_FLOWS is false
 test("Logged-in users still get account menu items when DISPLAY_AUTH_FLOWS is false", async () => {
   // Admin-created users who reach the login page directly should get the full
   // authenticated experience even though auth UI is hidden by the flag.
-  await renderTestApp("", { isAuthenticated: true });
+  const { queryClient } = renderTestApp("", { isAuthenticated: true });
+  // The menu trigger swaps from a hamburger to the user avatar once the ["me"]
+  // query resolves (UserMenu's `useHamburger = !DISPLAY_AUTH_FLOWS && !user`).
+  // Wait for auth to settle so we click the stable avatar, not a hamburger
+  // that unmounts mid-interaction.
+  await waitForAppReady(queryClient);
   const button = screen.getByRole("button", { name: "Open User Menu" });
   await user.click(button);
   await screen.findByRole("menu");

--- a/packages/app/src/pages/MainPage/components/Header.authHidden.spec.tsx
+++ b/packages/app/src/pages/MainPage/components/Header.authHidden.spec.tsx
@@ -1,5 +1,5 @@
 import { test, expect } from "vitest";
-import { renderTestApp, screen, user, waitForAppReady } from "@/test_util";
+import { renderTestApp, screen, user } from "@/test_util";
 
 vi.mock("@/features/auth/displayAuthFlows", () => ({
   DISPLAY_AUTH_FLOWS: false,
@@ -7,7 +7,7 @@ vi.mock("@/features/auth/displayAuthFlows", () => ({
 
 test("Sign in and Sign up header buttons are hidden when DISPLAY_AUTH_FLOWS is false", async () => {
   renderTestApp("", { isAuthenticated: false });
-  await screen.findByRole("button", { name: "Open User Menu" });
+  await screen.findByRole("button", { name: "Open Menu" });
 
   expect(screen.queryByRole("button", { name: "Sign in" })).toBeNull();
   expect(screen.queryByRole("button", { name: "Sign up" })).toBeNull();
@@ -15,7 +15,7 @@ test("Sign in and Sign up header buttons are hidden when DISPLAY_AUTH_FLOWS is f
 
 test("Sign in and Sign up menu items are hidden when DISPLAY_AUTH_FLOWS is false", async () => {
   renderTestApp("", { isAuthenticated: false });
-  const button = screen.getByRole("button", { name: "Open User Menu" });
+  const button = await screen.findByRole("button", { name: "Open Menu" });
   await user.click(button);
   await screen.findByRole("menu");
 
@@ -26,13 +26,11 @@ test("Sign in and Sign up menu items are hidden when DISPLAY_AUTH_FLOWS is false
 test("Logged-in users still get account menu items when DISPLAY_AUTH_FLOWS is false", async () => {
   // Admin-created users who reach the login page directly should get the full
   // authenticated experience even though auth UI is hidden by the flag.
-  const { queryClient } = renderTestApp("", { isAuthenticated: true });
-  // The menu trigger swaps from a hamburger to the user avatar once the ["me"]
-  // query resolves (UserMenu's `useHamburger = !DISPLAY_AUTH_FLOWS && !user`).
-  // Wait for auth to settle so we click the stable avatar, not a hamburger
-  // that unmounts mid-interaction.
-  await waitForAppReady(queryClient);
-  const button = screen.getByRole("button", { name: "Open User Menu" });
+  renderTestApp("", { isAuthenticated: true });
+  // The trigger swaps from a hamburger ("Open Menu") to the user avatar
+  // ("Open User Menu") once the ["me"] query resolves. Anchoring on the
+  // avatar's name waits past the transient hamburger to the stable node.
+  const button = await screen.findByRole("button", { name: "Open User Menu" });
   await user.click(button);
   await screen.findByRole("menu");
 

--- a/packages/app/src/pages/MainPage/components/Header.spec.tsx
+++ b/packages/app/src/pages/MainPage/components/Header.spec.tsx
@@ -1,7 +1,7 @@
 import { test, expect } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "@math3d/mock-api/node";
-import { renderTestApp, screen, user } from "@/test_util";
+import { renderTestApp, screen, user, waitForAppReady } from "@/test_util";
 
 test.each([
   { authStatus: true, expected: { hasSigin: false, hasSigout: true } },
@@ -9,8 +9,12 @@ test.each([
 ])(
   "Header includes signin / signout links based on current auth status (authenticated=$authStatus)",
   async ({ authStatus, expected }) => {
-    await renderTestApp("", { isAuthenticated: authStatus });
-    await screen.findByRole("button", { name: "Open User Menu" });
+    const { queryClient } = renderTestApp("", { isAuthenticated: authStatus });
+    // Sign in/out visibility is gated on the ["me"] auth query resolving, and
+    // the header has no positive anchor for the absent state (e.g. "Sign in"
+    // is simply absent when authenticated). Wait for auth to settle so these
+    // presence/absence assertions aren't false-greens.
+    await waitForAppReady(queryClient);
 
     const signin = screen.queryByRole("button", { name: "Sign in" });
 
@@ -38,7 +42,7 @@ test("treats an empty-bodied 403 from /me as unauthenticated, not 'loading'", as
     ),
   );
 
-  await renderTestApp("", { isAuthenticated: false });
+  renderTestApp("", { isAuthenticated: false });
 
   expect(
     await screen.findByRole("button", { name: "Sign in" }),
@@ -46,14 +50,14 @@ test("treats an empty-bodied 403 from /me as unauthenticated, not 'loading'", as
 });
 
 test("Login button opens login overlay", async () => {
-  const { location } = await renderTestApp("", { isAuthenticated: false });
-  const signin = screen.getByRole("button", { name: "Sign in" });
+  const { location } = renderTestApp("", { isAuthenticated: false });
+  const signin = await screen.findByRole("button", { name: "Sign in" });
   await user.click(signin);
   expect(location.current.search).toContain("overlay=login");
 });
 
 test("Contact links to the GitHub issues page in a new tab", async () => {
-  await renderTestApp("", { isAuthenticated: false });
+  renderTestApp("", { isAuthenticated: false });
   const button = screen.getByRole("button", { name: "Open User Menu" });
   await user.click(button);
   const contact = await screen.findByRole("menuitem", { name: "Contact" });
@@ -63,7 +67,7 @@ test("Contact links to the GitHub issues page in a new tab", async () => {
 });
 
 test("Sign out opens logout overlay", async () => {
-  const { location } = await renderTestApp("", { isAuthenticated: true });
+  const { location } = renderTestApp("", { isAuthenticated: true });
   const button = screen.getByRole("button", { name: "Open User Menu" });
   await user.click(button);
   const signout = screen.getByRole("menuitem", { name: "Sign out" });
@@ -72,7 +76,7 @@ test("Sign out opens logout overlay", async () => {
 });
 
 test("Account Settings opens settings overlay", async () => {
-  const { location } = await renderTestApp("", { isAuthenticated: true });
+  const { location } = renderTestApp("", { isAuthenticated: true });
   const button = screen.getByRole("button", { name: "Open User Menu" });
   await user.click(button);
   const settings = screen.getByRole("menuitem", { name: "Account Settings" });

--- a/packages/app/src/pages/MainPage/components/LegacyDialog.spec.tsx
+++ b/packages/app/src/pages/MainPage/components/LegacyDialog.spec.tsx
@@ -13,7 +13,7 @@ test.each([
   async ({ isLegacy }) => {
     const item = makeItem(MIT.Point);
     const scene = seedDb.withSceneFromItems([item], { isLegacy });
-    await renderTestApp(`/${scene.key}`);
+    renderTestApp(`/${scene.key}`);
 
     await findItemByTestId(item.id);
     const legacyButton = screen.queryByRole("button", { name: "Legacy Scene" });
@@ -24,7 +24,7 @@ test.each([
 test("Legacy Dialog opens and closes", async () => {
   const item = makeItem(MIT.Point);
   const scene = seedDb.withSceneFromItems([item], { isLegacy: true });
-  await renderTestApp(`/${scene.key}`);
+  renderTestApp(`/${scene.key}`);
 
   const legacyButton = await screen.findByRole("button", {
     name: "Legacy Scene",

--- a/packages/app/src/pages/MainPage/components/UserMenu.tsx
+++ b/packages/app/src/pages/MainPage/components/UserMenu.tsx
@@ -31,8 +31,12 @@ const UserMenu: React.FC<{
   const [visible, setVisible] = useState(false);
 
   const useHamburger = !DISPLAY_AUTH_FLOWS && !user;
+  // The hamburger (no user, auth flows hidden) and the avatar (signed-in user)
+  // carry distinct accessible names: they open different menus, and the name
+  // difference lets tests await the avatar specifically rather than matching
+  // the hamburger that is shown transiently while the ["me"] query resolves.
   const trigger = useHamburger ? (
-    <IconButton aria-label="Open User Menu" color="inherit">
+    <IconButton aria-label="Open Menu" color="inherit">
       <MenuIcon />
     </IconButton>
   ) : (

--- a/packages/app/src/pages/NotFound/NotFoundPage.spec.tsx
+++ b/packages/app/src/pages/NotFound/NotFoundPage.spec.tsx
@@ -2,14 +2,14 @@ import { test, expect } from "vitest";
 import { renderTestApp, screen, user, within, waitFor } from "@/test_util";
 
 test("unmatched /app path renders soft-404", async () => {
-  await renderTestApp("/app/does-not-exist");
+  renderTestApp("/app/does-not-exist");
   expect(
     await screen.findByRole("heading", { name: /not found/i }),
   ).toBeVisible();
 });
 
 test("bare /app renders soft-404", async () => {
-  await renderTestApp("/app");
+  renderTestApp("/app");
   expect(
     await screen.findByRole("heading", { name: /not found/i }),
   ).toBeVisible();
@@ -18,7 +18,7 @@ test("bare /app renders soft-404", async () => {
 test("unmatched non-app multi-segment path renders soft-404, not a crash", async () => {
   // R1: a reserved-web-infra-shaped path that reaches the router must NOT hit React
   // Router's default error boundary. Requires the ROOT-level "*" catch-all below.
-  await renderTestApp("/.well-known/foo");
+  renderTestApp("/.well-known/foo");
   expect(
     await screen.findByRole("heading", { name: /not found/i }),
   ).toBeVisible();
@@ -28,7 +28,7 @@ test("a non-existent scene key still notifies and redirects to /", async () => {
   // Missing-scene behavior is unchanged (handled in SceneControls), NOT the soft-404 page.
   // The notification is a plain MUI <Dialog> (role "dialog", not "alertdialog") with an "OK"
   // button (NotificationsDisplay renders "OK" for type:"alert"; SceneControls uses type:"alert").
-  const { location } = await renderTestApp("/definitelynotascene");
+  const { location } = renderTestApp("/definitelynotascene");
   const dialog = await screen.findByRole("dialog");
   await user.click(within(dialog).getByRole("button", { name: "OK" }));
   await waitFor(() => expect(location.current.pathname).toBe("/"));

--- a/packages/app/src/pages/ScenesList/ScenesListPage.authHidden.spec.tsx
+++ b/packages/app/src/pages/ScenesList/ScenesListPage.authHidden.spec.tsx
@@ -8,7 +8,7 @@ vi.mock("@/features/auth/displayAuthFlows", () => ({
 
 test("My Scenes tab is hidden for unauthenticated users when DISPLAY_AUTH_FLOWS is false", async () => {
   const scene = seedDb.withSceneFromItems([]);
-  await renderTestApp(`/${scene.key}?overlay=scenes&list=examples`);
+  renderTestApp(`/${scene.key}?overlay=scenes&list=examples`);
   const tablist = await screen.findByRole("tablist", { name: "Scenes" });
   expect(within(tablist).queryByRole("tab", { name: "My Scenes" })).toBeNull();
   expect(
@@ -18,18 +18,18 @@ test("My Scenes tab is hidden for unauthenticated users when DISPLAY_AUTH_FLOWS 
 
 test("My Scenes tab is shown for authenticated users even when DISPLAY_AUTH_FLOWS is false", async () => {
   const scene = seedDb.withSceneFromItems([]);
-  await renderTestApp(`/${scene.key}?overlay=scenes&list=examples`, {
+  renderTestApp(`/${scene.key}?overlay=scenes&list=examples`, {
     isAuthenticated: true,
   });
   const tablist = await screen.findByRole("tablist", { name: "Scenes" });
-  expect(within(tablist).getByRole("tab", { name: "My Scenes" })).toBeTruthy();
+  expect(
+    await within(tablist).findByRole("tab", { name: "My Scenes" }),
+  ).toBeTruthy();
 });
 
 test("?overlay=scenes&list=me redirects to list=examples when DISPLAY_AUTH_FLOWS is false", async () => {
   const scene = seedDb.withSceneFromItems([]);
-  const { location } = await renderTestApp(
-    `/${scene.key}?overlay=scenes&list=me`,
-  );
+  const { location } = renderTestApp(`/${scene.key}?overlay=scenes&list=me`);
   const tablist = await screen.findByRole("tablist", { name: "Scenes" });
   await within(tablist).findByRole("tab", {
     selected: true,

--- a/packages/app/src/pages/ScenesList/ScenesListPage.spec.tsx
+++ b/packages/app/src/pages/ScenesList/ScenesListPage.spec.tsx
@@ -4,13 +4,13 @@ import { test, expect } from "vitest";
 
 test("scenes drawer opens via ?overlay=scenes&list=examples", async () => {
   const scene = seedDb.withSceneFromItems([]);
-  await renderTestApp(`/${scene.key}?overlay=scenes&list=examples`);
+  renderTestApp(`/${scene.key}?overlay=scenes&list=examples`);
   expect(await screen.findByRole("tab", { name: "Examples" })).toBeVisible();
 });
 
 test("an unknown ?list= value self-corrects to list=examples", async () => {
   const scene = seedDb.withSceneFromItems([]);
-  const { location } = await renderTestApp(
+  const { location } = renderTestApp(
     `/${scene.key}?overlay=scenes&list=garbage`,
   );
   expect(await screen.findByRole("tab", { name: "Examples" })).toBeVisible();
@@ -21,7 +21,7 @@ test("an unknown ?list= value self-corrects to list=examples", async () => {
 
 test("closing the drawer (Escape) returns to the scene", async () => {
   const scene = seedDb.withSceneFromItems([]);
-  const { location } = await renderTestApp(
+  const { location } = renderTestApp(
     `/${scene.key}?overlay=scenes&list=examples`,
   );
   await screen.findByRole("tab", { name: "Examples" });

--- a/packages/app/src/pages/UserSettingsPage/UserSettingsPage.spec.tsx
+++ b/packages/app/src/pages/UserSettingsPage/UserSettingsPage.spec.tsx
@@ -3,7 +3,7 @@ import { mockAuth } from "@math3d/mock-api";
 import { renderTestApp, screen, user, waitFor, within } from "@/test_util";
 
 test("Settings dialog opens via overlay param and closes by clearing it", async () => {
-  const { location } = await renderTestApp("/?overlay=settings", {
+  const { location } = renderTestApp("/?overlay=settings", {
     isAuthenticated: true,
   });
   const dialog = await screen.findByRole("dialog", {
@@ -17,7 +17,7 @@ test("Settings dialog opens via overlay param and closes by clearing it", async 
 });
 
 test("If not authenticated, redirects to the login overlay", async () => {
-  const { location } = await renderTestApp("/?overlay=settings", {
+  const { location } = renderTestApp("/?overlay=settings", {
     isAuthenticated: false,
   });
   await waitFor(() =>
@@ -27,7 +27,7 @@ test("If not authenticated, redirects to the login overlay", async () => {
 });
 
 test("session expiring mid-dialog redirects to the login overlay", async () => {
-  const { location, queryClient } = await renderTestApp("/?overlay=settings", {
+  const { location, queryClient } = renderTestApp("/?overlay=settings", {
     isAuthenticated: true,
   });
   await screen.findByRole("dialog", { name: "Account Settings" });
@@ -40,7 +40,7 @@ test("session expiring mid-dialog redirects to the login overlay", async () => {
 });
 
 test("deleting your own account does not redirect to login", async () => {
-  const { location } = await renderTestApp("/?overlay=settings", {
+  const { location } = renderTestApp("/?overlay=settings", {
     isAuthenticated: true,
   });
   const dialog = await screen.findByRole("dialog", {

--- a/packages/app/src/pages/auth/ActivationPage.spec.tsx
+++ b/packages/app/src/pages/auth/ActivationPage.spec.tsx
@@ -5,14 +5,14 @@ import { urls } from "@math3d/mock-api";
 import { mockResponseOnce } from "@math3d/mock-api/node";
 
 test("activation opens as an overlay from the email link", async () => {
-  await renderTestApp(`/?overlay=activate&key=${faker.string.uuid()}`);
+  renderTestApp(`/?overlay=activate&key=${faker.string.uuid()}`);
   expect(
     await screen.findByRole("dialog", { name: "Account Activation" }),
   ).toBeVisible();
 });
 
 test("Authorization form happy path: API call, success indication, & log in", async () => {
-  const { location } = await renderTestApp(
+  const { location } = renderTestApp(
     `/?overlay=activate&key=${faker.string.uuid()}`,
   );
   const alert = await screen.findByRole("alert");
@@ -45,7 +45,7 @@ test("Error message for invalid key", async () => {
       ],
     },
   });
-  await renderTestApp(`/?overlay=activate&key=${faker.string.uuid()}`);
+  renderTestApp(`/?overlay=activate&key=${faker.string.uuid()}`);
   const alert = await screen.findByRole("alert");
   expect(alert).toHaveTextContent(/activation link/);
 });

--- a/packages/app/src/pages/auth/LoginPage.spec.tsx
+++ b/packages/app/src/pages/auth/LoginPage.spec.tsx
@@ -4,7 +4,7 @@ import { seedDb } from "@math3d/mock-api";
 
 test("Login form logs user in", async () => {
   const userData = seedDb.withUser();
-  const { location } = await renderTestApp("/?overlay=login");
+  const { location } = renderTestApp("/?overlay=login");
 
   const dialog = await screen.findByRole("dialog");
   const email = within(dialog).getByRole("textbox", { name: "Email" });
@@ -24,7 +24,7 @@ test("Login form logs user in", async () => {
 test("Login form displays error if password/email wrong", async () => {
   const userData = seedDb.withUser();
 
-  await renderTestApp("/?overlay=login");
+  renderTestApp("/?overlay=login");
 
   const dialog = await screen.findByRole("dialog");
 
@@ -49,7 +49,7 @@ test("Login form displays error if password/email wrong", async () => {
 });
 
 test("If authenticated already, closes the overlay", async () => {
-  const { location } = await renderTestApp("/?overlay=login", {
+  const { location } = renderTestApp("/?overlay=login", {
     isAuthenticated: true,
   });
   await waitFor(() =>
@@ -62,7 +62,7 @@ test("Create Account link switches to the register overlay (replace, no extra hi
   // notification <Dialog> mounts alongside the overlay and a bare findByRole("dialog")
   // throws "multiple elements". (Always seed, or scope dialog queries by name.)
   const scene = seedDb.withSceneFromItems([]);
-  const { location } = await renderTestApp(`/${scene.key}?overlay=login`);
+  const { location } = renderTestApp(`/${scene.key}?overlay=login`);
   await screen.findByRole("dialog", { name: "Sign in" });
   await user.click(screen.getByRole("button", { name: "Create Account" }));
   await waitFor(() =>
@@ -73,7 +73,7 @@ test("Create Account link switches to the register overlay (replace, no extra hi
 
 test("open pushes one history entry; Back returns to the underlying view", async () => {
   const scene = seedDb.withSceneFromItems([]);
-  const { location, router } = await renderTestApp(`/${scene.key}`);
+  const { location, router } = renderTestApp(`/${scene.key}`);
   // open login from the header trigger
   await user.click(
     await screen.findByRole("button", { name: "Sign in", hidden: true }),
@@ -89,7 +89,7 @@ test("open pushes one history entry; Back returns to the underlying view", async
 
 test("switching login → register does not add a history entry (Back skips both)", async () => {
   const scene = seedDb.withSceneFromItems([]);
-  const { location, router } = await renderTestApp(`/${scene.key}`);
+  const { location, router } = renderTestApp(`/${scene.key}`);
   // Open login overlay (push → now 2 history entries)
   await user.click(
     await screen.findByRole("button", { name: "Sign in", hidden: true }),
@@ -107,7 +107,7 @@ test("switching login → register does not add a history entry (Back skips both
 
 test("opening/closing an overlay preserves other params and the hash", async () => {
   const scene = seedDb.withSceneFromItems([]);
-  const { location } = await renderTestApp(`/${scene.key}?controls=0#frag`);
+  const { location } = renderTestApp(`/${scene.key}?controls=0#frag`);
   await user.click(
     await screen.findByRole("button", { name: "Sign in", hidden: true }),
   );

--- a/packages/app/src/pages/auth/LogoutPage.loading.spec.tsx
+++ b/packages/app/src/pages/auth/LogoutPage.loading.spec.tsx
@@ -11,7 +11,7 @@ vi.mock("@/features/auth/useAuthStatus", () => ({
 
 test("Does not redirect while auth status is loading", async () => {
   const scene = seedDb.withSceneFromItems([]);
-  const { location } = await renderTestApp(`/${scene.key}?overlay=logout`, {
+  const { location } = renderTestApp(`/${scene.key}?overlay=logout`, {
     isAuthenticated: true,
   });
 

--- a/packages/app/src/pages/auth/LogoutPage.loading.spec.tsx
+++ b/packages/app/src/pages/auth/LogoutPage.loading.spec.tsx
@@ -9,7 +9,7 @@ vi.mock("@/features/auth/useAuthStatus", () => ({
   useAuthStatus: () => "loading",
 }));
 
-test("Does not redirect while auth status is loading", async () => {
+test("Does not redirect while auth status is loading", () => {
   const scene = seedDb.withSceneFromItems([]);
   const { location } = renderTestApp(`/${scene.key}?overlay=logout`, {
     isAuthenticated: true,

--- a/packages/app/src/pages/auth/LogoutPage.spec.tsx
+++ b/packages/app/src/pages/auth/LogoutPage.spec.tsx
@@ -4,7 +4,7 @@ import { seedDb } from "@math3d/mock-api";
 
 test("Sign out closes the overlay and signs the user out", async () => {
   const scene = seedDb.withSceneFromItems([]);
-  const { location } = await renderTestApp(`/${scene.key}?overlay=logout`, {
+  const { location } = renderTestApp(`/${scene.key}?overlay=logout`, {
     isAuthenticated: true,
   });
   const dialog = await screen.findByRole("dialog", { name: "Sign out" });
@@ -19,7 +19,7 @@ test("Sign out closes the overlay and signs the user out", async () => {
 
 test("Cancel closes the overlay without signing the user out", async () => {
   const scene = seedDb.withSceneFromItems([]);
-  const { location } = await renderTestApp(`/${scene.key}?overlay=logout`, {
+  const { location } = renderTestApp(`/${scene.key}?overlay=logout`, {
     isAuthenticated: true,
   });
   const dialog = await screen.findByRole("dialog", { name: "Sign out" });
@@ -31,7 +31,7 @@ test("Cancel closes the overlay without signing the user out", async () => {
 });
 
 test("If not authenticated, closes the overlay", async () => {
-  const { location } = await renderTestApp("/?overlay=logout", {
+  const { location } = renderTestApp("/?overlay=logout", {
     isAuthenticated: false,
   });
   await waitFor(() =>

--- a/packages/app/src/pages/auth/RegistrationPage.spec.tsx
+++ b/packages/app/src/pages/auth/RegistrationPage.spec.tsx
@@ -48,7 +48,7 @@ const submitForm = async (data: FormValues) => {
 };
 
 test("Displays client-side form errors", async () => {
-  await renderTestApp("/?overlay=register");
+  renderTestApp("/?overlay=register");
   const fields = await submitForm({
     email: "",
     nickname: "",
@@ -88,7 +88,7 @@ test("Server errors are reflected in form", async () => {
     },
   });
 
-  await renderTestApp("/?overlay=register");
+  renderTestApp("/?overlay=register");
   const fields = await submitForm({
     email: "leo@dog.com",
     nickname: "leo",
@@ -113,7 +113,7 @@ test("non-field errors are shown in an alert", async () => {
     },
   });
 
-  await renderTestApp("/?overlay=register");
+  renderTestApp("/?overlay=register");
   await submitForm({
     email: "leo@dog.com",
     nickname: "leo",
@@ -125,7 +125,7 @@ test("non-field errors are shown in an alert", async () => {
 });
 
 test("Informs user about confirmation email", async () => {
-  const { location } = await renderTestApp("/?overlay=register");
+  const { location } = renderTestApp("/?overlay=register");
   const userInfo = {
     email: faker.internet.email(),
     nickname: faker.person.firstName(),

--- a/packages/app/src/pages/auth/ResetPasswordConfirmPage.spec.tsx
+++ b/packages/app/src/pages/auth/ResetPasswordConfirmPage.spec.tsx
@@ -37,7 +37,7 @@ const submitForm = async (data: FormValues) => {
 };
 
 test("reset-confirm opens as an overlay from the email link", async () => {
-  await renderTestApp(`/?overlay=reset-confirm&key=${faker.string.uuid()}`);
+  renderTestApp(`/?overlay=reset-confirm&key=${faker.string.uuid()}`);
   expect(
     await screen.findByRole("dialog", { name: "Change Password" }),
   ).toBeVisible();
@@ -45,9 +45,7 @@ test("reset-confirm opens as an overlay from the email link", async () => {
 
 test("Happy path: Expected API call and form states", async () => {
   const key = makeKey();
-  const { location } = await renderTestApp(
-    `/?overlay=reset-confirm&key=${key}`,
-  );
+  const { location } = renderTestApp(`/?overlay=reset-confirm&key=${key}`);
 
   await screen.findByRole("dialog", { name: "Change Password" });
 
@@ -69,7 +67,7 @@ test("Happy path: Expected API call and form states", async () => {
 
 test("Requires passwords match", async () => {
   const key = makeKey();
-  await renderTestApp(`/?overlay=reset-confirm&key=${key}`);
+  renderTestApp(`/?overlay=reset-confirm&key=${key}`);
 
   const controls = await submitForm({
     password: "Password1234", // pragma: allowlist secret
@@ -82,7 +80,7 @@ test("Requires passwords match", async () => {
 
 test("Reports API errors (password field)", async () => {
   const key = makeKey();
-  await renderTestApp(`/?overlay=reset-confirm&key=${key}`);
+  renderTestApp(`/?overlay=reset-confirm&key=${key}`);
 
   mockResponseOnce({
     status: 400,
@@ -112,7 +110,7 @@ test("Reports API errors (password field)", async () => {
 
 test("key errors suggest to check link", async () => {
   const key = makeKey();
-  await renderTestApp(`/?overlay=reset-confirm&key=${key}`);
+  renderTestApp(`/?overlay=reset-confirm&key=${key}`);
 
   mockResponseOnce({
     status: 400,

--- a/packages/app/src/pages/auth/ResetPasswordPage.spec.tsx
+++ b/packages/app/src/pages/auth/ResetPasswordPage.spec.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/test_util";
 
 test("Happy path: Expected API call and form states", async () => {
-  const { location } = await renderTestApp("/?overlay=reset-request");
+  const { location } = renderTestApp("/?overlay=reset-request");
 
   const dialog = await screen.findByRole("dialog");
   const controls = {
@@ -39,7 +39,7 @@ test("Happy path: Expected API call and form states", async () => {
 });
 
 test("Form requires email", async () => {
-  await renderTestApp("/?overlay=reset-request");
+  renderTestApp("/?overlay=reset-request");
 
   const dialog = await screen.findByRole("dialog");
   const controls = {

--- a/packages/app/src/test_util/index.ts
+++ b/packages/app/src/test_util/index.ts
@@ -8,7 +8,7 @@ import {
 import { act } from "react";
 import user from "@testing-library/user-event";
 
-import renderTestApp from "./renderTestApp";
+import renderTestApp, { waitForAppReady } from "./renderTestApp";
 
 export * from "./test_util";
 export {
@@ -20,4 +20,5 @@ export {
   waitFor,
   within,
   renderTestApp,
+  waitForAppReady,
 };

--- a/packages/app/src/test_util/renderTestApp.tsx
+++ b/packages/app/src/test_util/renderTestApp.tsx
@@ -10,8 +10,24 @@ import { mockAuth, seedDb } from "@math3d/mock-api";
 import AppProviders from "@/AppProviders";
 import routes from "@/routes";
 
-const waitForNotBusy = () =>
-  waitFor(
+/**
+ * Wait until the app has settled: no `[aria-busy="true"]` element remains and
+ * the `["me"]` auth query is no longer `pending`.
+ *
+ * Prefer awaiting a positive observable at the assertion instead — `findBy*`
+ * (which is `getBy*` + `waitFor`) names what's missing when it times out. Use
+ * this helper only for an **async-gated negative assertion** that has no
+ * natural positive anchor to await first, e.g.:
+ *
+ *   await waitForAppReady(queryClient);
+ *   expect(screen.queryByRole("dialog")).toBeNull();
+ *
+ * A bare `queryBy*` after a synchronous render can pass because nothing has
+ * rendered *yet*, not because the app is correct; anchoring on "app ready"
+ * before asserting absence prevents that false-green.
+ */
+export const waitForAppReady = async (queryClient: QueryClient) => {
+  await waitFor(
     () => {
       const busy = document.querySelector('[aria-busy="true"]');
       if (busy !== null) {
@@ -20,14 +36,29 @@ const waitForNotBusy = () =>
     },
     { timeout: 2000 },
   );
+  await waitFor(
+    () => {
+      const meState = queryClient.getQueryState(["me"]);
+      if (meState?.status === "pending") {
+        throw new Error("User me query not yet resolved");
+      }
+    },
+    { timeout: 3000 },
+  );
+};
 
 /**
  * Render the app using a MemoryRouter instead of a BrowserRouter.
  * Optionally, provide an initial route.
+ *
+ * Returns synchronously: waiting is co-located with assertions (`findBy*` /
+ * explicit `waitFor`), not hoisted into setup. See {@link waitForAppReady} for
+ * the one case (async-gated negative assertions) where an explicit settle is
+ * still the right tool.
  */
-const renderTestApp = async (
+const renderTestApp = (
   initialRoute: InitialEntry = "/",
-  { waitForReady = true, isAuthenticated = false } = {},
+  { isAuthenticated = false } = {},
 ) => {
   const initialEntries: InitialEntry[] = [initialRoute];
   const store = getStore();
@@ -64,22 +95,6 @@ const renderTestApp = async (
         router={router}
       />
     </React.StrictMode>,
-  );
-  if (waitForReady) {
-    await waitForNotBusy();
-  }
-
-  // Wait for the user-me query to resolve so auth status is reflected in
-  // the UI before test assertions run. If the query was never initiated
-  // (e.g. a page that doesn't render MainPage), skip the wait.
-  await waitFor(
-    () => {
-      const meState = queryClient.getQueryState(["me"]);
-      if (meState?.status === "pending") {
-        throw new Error("User me query not yet resolved");
-      }
-    },
-    { timeout: 3000 },
   );
 
   const location = {

--- a/packages/app/src/util/components/TextareaAutoWidthHeight/TextareaAutoWidthHeight.tsx
+++ b/packages/app/src/util/components/TextareaAutoWidthHeight/TextareaAutoWidthHeight.tsx
@@ -42,7 +42,6 @@ const TextareaAutoWidthHeight: React.FC<Props> = (props) => {
   };
   return (
     <TextareaAutosize
-      aria-busy={!hasRendered}
       ref={composeRefs(ref, textarea)}
       style={mergedStyle}
       onChange={props.onChange}


### PR DESCRIPTION
### What are the relevant tickets?

- https://github.com/ChristopherChudzicki/math3d-next/issues/1163

### Description (What does it do?)

Makes `renderTestApp` **synchronous**. It previously awaited two blanket "settle the whole tree" barriers before returning — `waitForNotBusy()` and a `["me"]`-query wait. That hoisted waiting into setup (non-idiomatic RTL), coupled the harness to the assumption that *every* page resolves auth (which broke the standalone `/app/*` routes and forced a prior workaround), and produced opaque timeout failures.

Now `renderTestApp` renders and returns immediately, and waiting is co-located with assertions (`findBy*` / explicit `waitFor`). The barrier logic is preserved as an exported, opt-in `waitForAppReady(queryClient)` helper for the one case where it's still the right tool.

Main changes:

- **`renderTestApp` returns synchronously.** Dropped the now-meaningless `waitForReady` option and stripped `await` from all call sites.
- **`waitForAppReady(queryClient)` extracted + exported** from `test_util`, with a docstring stating its guideline: use it only for an async-gated *negative* assertion that has no natural positive anchor; prefer `findBy*` otherwise. It ends up used at exactly **one** site.
- **`getBy*`-after-render → `findBy*` sweep** across the tests that relied on the pre-wait (mostly scene-content tests that also read `store.getState().scene.mathScope()` before the scene finished loading).
- **Negative-assertion audit** for false-greens (`queryBy…toBeNull()` passing because nothing rendered *yet*). Async-gated negatives now anchor a positive signal first; synchronous-first-render absences were left as-is.
- **`fix(a11y)`: removed an incorrect `aria-busy`** from `TextareaAutoWidthHeight` — it was a one-render-tick "width not yet measured" layout flag, not a semantic busy state, and made every autosize textarea flash `aria-busy` on mount. The value-gating that prevents the text flash stays.
- **`refactor(header)`: distinct accessible name for the hamburger menu trigger.** `UserMenu`'s trigger swaps from a hamburger to the user avatar once `["me"]` resolves; both had the same name ("Open User Menu"), which is also inaccurate (the hamburger shows precisely when there is *no* user). Giving the hamburger a distinct name ("Open Menu") is an a11y improvement and lets the authenticated test await the avatar by name instead of a blanket settle.

### How can this be tested?

Frontend unit tests (`yarn workspace app test`) are the substance of this change — the whole suite continues to pass with `renderTestApp` synchronous. Reviewers may want to focus on:

- **The negative-assertion audit** (the sharp edge): a `queryBy…toBeNull()` can go false-green under a synchronous render. See `Header.spec` (the one `waitForAppReady` site), `OverlayHost.spec`, `Header.authHidden.spec`, `ScenesListPage.authHidden.spec`, and the auth-page specs.
- **`waitForAppReady` usage**: it should appear at exactly one call site, and that site should be a genuinely async-gated negative assertion.

No user-facing behavior changes; the a11y tweaks (removed `aria-busy`, renamed hamburger label) are the only runtime-visible differences and are covered by the header specs.

### Additional Context

- **Migration approach was failure-guided, not scaffolded.** After flipping `renderTestApp` to sync, the failing suite pinpointed every `getBy`-after-render site to convert. The false-green negatives don't self-report, so those were audited by hand.
- **`waitForAppReady` guideline is intentionally narrow.** During development a second candidate use surfaced (an interaction whose target element swaps identity when auth resolves). Rather than broaden the helper, that was fixed in the app via the distinct-name change above — an interaction target gated on async resolution is better made distinguishable than papered over with a blanket settle.