### PR TITLE
docs(api): tag v1 endpoints and serve allauth docs via Swagger

### DIFF
--- a/webserver/main/api.py
+++ b/webserver/main/api.py
@@ -2,7 +2,40 @@ from django.http import HttpRequest
 from ninja import NinjaAPI
 from ninja.errors import AuthenticationError, ValidationError
 
-api = NinjaAPI(title="Math3d API", version="1.0.0", urls_namespace="v1")
+api = NinjaAPI(
+    title="Math3d API",
+    version="1.0.0",
+    urls_namespace="v1",
+    # Top-level tag metadata. django-ninja only emits tag *names* on operations
+    # (via add_router(tags=...) below); the descriptions/grouping order come from
+    # this list. The allauth link is a markdown link in the description because
+    # Swagger UI (this API's /v1/docs) renders markdown in tag descriptions
+    # reliably, whereas its support for tag-level `externalDocs` is spotty.
+    openapi_extra={
+        "tags": [
+            {
+                "name": "Scenes",
+                "description": "Saved 3D scenes: create, read, update, and delete.",
+            },
+            {
+                "name": "Auth",
+                "description": (
+                    "Current-user profile and account management. Authentication "
+                    "*flows* — login, signup, email verification, and password "
+                    "reset — are served by the separate allauth headless API; see "
+                    "its [interactive API docs](/_allauth/openapi.html)."
+                ),
+            },
+            {
+                "name": "Legacy Scenes",
+                "description": (
+                    "Legacy v0-format scenes (`dehydrated` blobs), retained for "
+                    "backward compatibility. Prefer **Scenes** for new work."
+                ),
+            },
+        ]
+    },
+)
 
 
 @api.exception_handler(AuthenticationError)
@@ -24,6 +57,6 @@ def on_validation_error(request: HttpRequest, exc: ValidationError):
 from authentication.api import router as auth_router  # noqa: E402
 from scenes.api import legacy_router, scenes_router  # noqa: E402
 
-api.add_router("/auth", auth_router)
-api.add_router("/scenes", scenes_router)
-api.add_router("/legacy_scenes", legacy_router)
+api.add_router("/auth", auth_router, tags=["Auth"])
+api.add_router("/scenes", scenes_router, tags=["Scenes"])
+api.add_router("/legacy_scenes", legacy_router, tags=["Legacy Scenes"])

--- a/webserver/main/settings.py
+++ b/webserver/main/settings.py
@@ -253,6 +253,9 @@ HEADLESS_ONLY = True
 HEADLESS_ADAPTER = "authentication.adapter.CustomHeadlessAdapter"
 HEADLESS_CLIENTS = ["browser"]
 HEADLESS_SERVE_SPECIFICATION = True
+# Serve the headless spec via Swagger UI (ships with allauth) to match the v1
+# API's /v1/docs; the default is Redoc (headless/spec/redoc_cdn.html).
+HEADLESS_SPECIFICATION_TEMPLATE_NAME = "headless/spec/swagger_cdn.html"
 HEADLESS_FRONTEND_URLS = {
     "account_confirm_email": f"{env('APP_BASE_URL')}/?overlay=activate&key={{key}}",
     "account_reset_password_from_key": f"{env('APP_BASE_URL')}/?overlay=reset-confirm&key={{key}}",

--- a/webserver/openapi.v1.yaml
+++ b/webserver/openapi.v1.yaml
@@ -1641,6 +1641,8 @@ paths:
       security:
       - StaffSessionAuth: []
       summary: Activate
+      tags:
+      - Auth
   /v1/auth/users/me/:
     get:
       operationId: authentication_api_get_me
@@ -1655,6 +1657,8 @@ paths:
         '403':
           description: Forbidden
       summary: Get Me
+      tags:
+      - Auth
     patch:
       operationId: authentication_api_patch_me
       parameters: []
@@ -1674,6 +1678,8 @@ paths:
       security:
       - SessionAuth: []
       summary: Patch Me
+      tags:
+      - Auth
   /v1/auth/users/me/delete/:
     post:
       operationId: authentication_api_delete_me
@@ -1696,6 +1702,8 @@ paths:
       security:
       - SessionAuth: []
       summary: Delete Me
+      tags:
+      - Auth
   /v1/legacy_scenes/:
     post:
       operationId: scenes_api_create_legacy
@@ -1714,6 +1722,8 @@ paths:
                 $ref: '#/components/schemas/LegacySceneOutSchema'
           description: Created
       summary: Create Legacy
+      tags:
+      - Legacy Scenes
   /v1/legacy_scenes/{key}/:
     get:
       operationId: scenes_api_get_legacy
@@ -1732,6 +1742,8 @@ paths:
                 $ref: '#/components/schemas/LegacySceneOutSchema'
           description: OK
       summary: Get Legacy
+      tags:
+      - Legacy Scenes
   /v1/scenes/:
     get:
       operationId: scenes_api_list_scenes
@@ -1776,6 +1788,8 @@ paths:
                 $ref: '#/components/schemas/PagedMiniSceneSchema'
           description: OK
       summary: List Scenes
+      tags:
+      - Scenes
     post:
       operationId: scenes_api_create_scene
       parameters: []
@@ -1793,6 +1807,8 @@ paths:
                 $ref: '#/components/schemas/SceneSchema'
           description: Created
       summary: Create Scene
+      tags:
+      - Scenes
   /v1/scenes/me/:
     get:
       operationId: scenes_api_my_scenes
@@ -1839,6 +1855,8 @@ paths:
       security:
       - SessionAuth: []
       summary: My Scenes
+      tags:
+      - Scenes
   /v1/scenes/{key}/:
     delete:
       operationId: scenes_api_delete_scene
@@ -1855,6 +1873,8 @@ paths:
       security:
       - SessionAuth: []
       summary: Delete Scene
+      tags:
+      - Scenes
     get:
       operationId: scenes_api_get_scene
       parameters:
@@ -1872,6 +1892,8 @@ paths:
                 $ref: '#/components/schemas/SceneSchema'
           description: OK
       summary: Get Scene
+      tags:
+      - Scenes
     patch:
       operationId: scenes_api_update_scene
       parameters:
@@ -1897,4 +1919,13 @@ paths:
       security:
       - SessionAuth: []
       summary: Update Scene
+      tags:
+      - Scenes
 servers: []
+tags:
+- description: 'Saved 3D scenes: create, read, update, and delete.'
+  name: Scenes
+- description: Current-user profile and account management. Authentication *flows* — login, signup, email verification, and password reset — are served by the separate allauth headless API; see its [interactive API docs](/_allauth/openapi.html).
+  name: Auth
+- description: Legacy v0-format scenes (`dehydrated` blobs), retained for backward compatibility. Prefer **Scenes** for new work.
+  name: Legacy Scenes


### PR DESCRIPTION
### What are the relevant tickets?

N/A

### Description (What does it do?)

Improves the auto-generated API docs at `/v1/docs`, which previously listed every endpoint under a single "default" heading.

- **Groups v1 endpoints by tag** — `Auth`, `Scenes`, and `Legacy Scenes` — via `tags=` on the router registrations in `main/api.py`.
- **Adds top-level tag descriptions** (via `NinjaAPI(openapi_extra={"tags": [...]})`). The `Auth` description links out to the allauth headless API's interactive docs, since the actual authentication *flows* (login, signup, email verification, password reset) live in that separate API rather than the v1 Ninja app.
- **Serves the allauth docs via Swagger UI** instead of Redoc (`HEADLESS_SPECIFICATION_TEMPLATE_NAME`, a template that already ships with allauth), so both docs surfaces look the same.

### How can this be tested?

Run the backend (`docker compose up -d`) and open:

- `/v1/docs` — endpoints are now grouped under **Auth / Scenes / Legacy Scenes**; the Auth group shows a description with a link to the allauth docs.
- `/_allauth/openapi.html` — now renders as Swagger UI (previously Redoc), and the Auth-tag link on `/v1/docs` points here.

### Additional Context

Tags, tag descriptions, and the docs-template choice are **docs-only**. `openapi-typescript` ignores tags entirely, so the regenerated `webserver/openapi.v1.yaml` gained a top-level `tags` block but the generated frontend client (`packages/api/src/generated-v1/index.ts`) is byte-for-byte unchanged, and no consuming code references operation tags/ids (hooks call by path string). The allauth Swagger switch is a single settings value — no custom template or CDN wiring, as allauth bundles `headless/spec/swagger_cdn.html`.