### PR TITLE
feat(cors): union configured origins with dev defaults

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,9 +31,9 @@ services:
       - .env
     environment:
       DATABASE_URL: postgresql://docker:docker@db:5432/math3d
-      # CORS_ALLOWED_ORIGINS is not pinned here: unless .env sets it, the
-      # default derives from APP_BASE_URL (main checkout + worktree frontend
-      # ports) in webserver/main/origins.py.
+      # CORS_ALLOWED_ORIGINS is not pinned here: the dev defaults derive from
+      # APP_BASE_URL (main checkout + worktree frontend ports) in
+      # webserver/main/origins.py, and anything .env sets is unioned on top.
     command: just devserver
     volumes:
       - ./webserver:/src/webserver

--- a/webserver/main/origins.py
+++ b/webserver/main/origins.py
@@ -2,20 +2,24 @@ from urllib.parse import urlparse
 
 # Frontend ports git worktrees may claim (scripts/setup_worktree_env.sh
 # allocates from this range; keep the two in sync). Port 3000 is the main
-# checkout's dev server; 3001 is skipped because the legacy app's dev server
-# owns it (and serves on localhost, so it is not a CORS consumer).
+# checkout's dev server. The legacy math3d-react app is a genuine cross-origin
+# CORS consumer (it runs on its own port and posts to /v1/legacy_scenes/); its
+# origin is added per-developer via the CORS_ALLOWED_ORIGINS env var rather
+# than baked in here.
 WORKTREE_PORTS = range(3002, 3010)
 
 
-def default_cors_allowed_origins(*, is_heroku: bool, app_base_url: str) -> list[str]:
+def dev_cors_allowed_origins(*, is_heroku: bool, app_base_url: str) -> list[str]:
     """
-    Compute CORS_ALLOWED_ORIGINS when none are configured explicitly.
+    Compute the development-only CORS origins (empty in production).
 
     In local dev, one backend serves the main checkout's frontend
     (APP_BASE_URL) plus git-worktree frontends on sibling ports, so trust
-    APP_BASE_URL's origin and its WORKTREE_PORTS siblings.
+    APP_BASE_URL's origin and its WORKTREE_PORTS siblings. Explicitly
+    configured origins (CORS_ALLOWED_ORIGINS) are unioned with these in
+    settings.py.
 
-    In production, origins must be configured explicitly; default to none.
+    In production, origins must be configured explicitly; return none.
     """
     if is_heroku or not app_base_url:
         return []
@@ -23,6 +27,23 @@ def default_cors_allowed_origins(*, is_heroku: bool, app_base_url: str) -> list[
     return [app_base_url] + [
         f"{base.scheme}://{base.hostname}:{port}" for port in WORKTREE_PORTS
     ]
+
+
+def cors_allowed_origins(
+    *,
+    configured: list[str],
+    dev: list[str],
+) -> list[str]:
+    """
+    Union of explicitly configured origins (CORS_ALLOWED_ORIGINS) and the
+    dev-only origins, order-preserving and de-duplicated.
+
+    Configured origins add to — never replace — the dev defaults, so setting
+    CORS_ALLOWED_ORIGINS (e.g. the legacy math3d-react frontend's origin) in a
+    local .env can't silently drop the worktree frontend ports. In production
+    the dev list is empty, so the result is exactly what's configured.
+    """
+    return list(dict.fromkeys(configured + dev))
 
 
 def csrf_trusted_origins(

--- a/webserver/main/settings.py
+++ b/webserver/main/settings.py
@@ -19,7 +19,11 @@ from django.core.exceptions import ImproperlyConfigured
 import dj_database_url
 import environ
 
-from main.origins import csrf_trusted_origins, default_cors_allowed_origins
+from main.origins import (
+    cors_allowed_origins,
+    csrf_trusted_origins,
+    dev_cors_allowed_origins,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -176,11 +180,16 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 
-# Explicit config wins (Heroku config vars, or a local .env); otherwise local
-# dev trusts APP_BASE_URL's origin plus the worktree frontend ports.
-CORS_ALLOWED_ORIGINS = env("CORS_ALLOWED_ORIGINS") or default_cors_allowed_origins(
-    is_heroku=env("IS_HEROKU"),
-    app_base_url=env("APP_BASE_URL"),
+# Explicitly configured origins (Heroku config vars, or a local .env — e.g. the
+# legacy math3d-react frontend) are unioned with the dev-only origins
+# (APP_BASE_URL plus the worktree frontend ports). In production the dev list is
+# empty, so CORS_ALLOWED_ORIGINS is exactly what's configured.
+CORS_ALLOWED_ORIGINS = cors_allowed_origins(
+    configured=env("CORS_ALLOWED_ORIGINS"),
+    dev=dev_cors_allowed_origins(
+        is_heroku=env("IS_HEROKU"),
+        app_base_url=env("APP_BASE_URL"),
+    ),
 )
 CORS_ALLOW_CREDENTIALS = True
 # Prod trusts only APP_BASE_URL; local dev also trusts the CORS origins

--- a/webserver/main/settings_test.py
+++ b/webserver/main/settings_test.py
@@ -2,19 +2,19 @@ from django.conf import settings
 
 from main.origins import (
     WORKTREE_PORTS,
+    cors_allowed_origins,
     csrf_trusted_origins,
-    default_cors_allowed_origins,
+    dev_cors_allowed_origins,
 )
 
 
-def test_default_cors_origins_cover_app_and_worktree_ports():
+def test_dev_cors_origins_cover_app_and_worktree_ports():
     """
     Locally the one docker backend serves the main checkout's frontend plus
     git-worktree frontends on sibling ports, all of which must be
-    CORS-trusted. 3001 is excluded: the legacy app's dev server owns that
-    port and is not a CORS consumer.
+    CORS-trusted.
     """
-    origins = default_cors_allowed_origins(
+    origins = dev_cors_allowed_origins(
         is_heroku=False,
         app_base_url="http://math3d.localdev:3000",
     )
@@ -23,18 +23,34 @@ def test_default_cors_origins_cover_app_and_worktree_ports():
     assert origins == ["http://math3d.localdev:3000", *worktree_origins]
 
 
-def test_default_cors_origins_empty_in_prod():
+def test_dev_cors_origins_empty_in_prod():
     """Production must configure CORS origins explicitly."""
-    origins = default_cors_allowed_origins(
+    origins = dev_cors_allowed_origins(
         is_heroku=True,
         app_base_url="https://next.math3d.org",
     )
     assert origins == []
 
 
-def test_default_cors_origins_empty_without_app_base_url():
-    origins = default_cors_allowed_origins(is_heroku=False, app_base_url="")
+def test_dev_cors_origins_empty_without_app_base_url():
+    origins = dev_cors_allowed_origins(is_heroku=False, app_base_url="")
     assert origins == []
+
+
+def test_cors_origins_union_adds_configured_without_dropping_dev():
+    """
+    A configured origin (e.g. the legacy math3d-react frontend) must add to,
+    not replace, the dev defaults — and duplicates collapse.
+    """
+    origins = cors_allowed_origins(
+        configured=["http://localhost:3141", "http://math3d.localdev:3000"],
+        dev=["http://math3d.localdev:3000", "http://math3d.localdev:3002"],
+    )
+    assert origins == [
+        "http://localhost:3141",
+        "http://math3d.localdev:3000",
+        "http://math3d.localdev:3002",
+    ]
 
 
 def test_settings_wire_csrf_trust_from_cors_origins():


### PR DESCRIPTION
### What are the relevant tickets?

N/A (no math3d-next issue). This is the backend half of enabling the legacy math3d-react frontend to run against this backend, mirroring what it already does in production. The frontend-side setup:

- https://github.com/ChristopherChudzicki/math3d-react/pull/394

### Description (What does it do?)

Lets the legacy math3d-react frontend hit this backend cross-origin without a footgun.

Previously an explicitly configured `CORS_ALLOWED_ORIGINS` **replaced** the dev defaults (`env(...) or default_...`), so setting it locally would silently drop the main checkout (`:3000`) and git-worktree frontend ports from CORS trust. Now configured origins are **unioned** with the dev-only origins via a new `cors_allowed_origins()` helper (order-preserving, de-duplicated).

The legacy `/v1/legacy_scenes/` endpoints are `auth=None`, so this needs only a CORS origin allowance — no CSRF trust or credentialed cookies. The actual origin (`http://localhost:3141`) stays in each developer's gitignored `.env` rather than committed, so nothing about the legacy app leaks into committed config.

Also:
- Renamed `default_cors_allowed_origins` → `dev_cors_allowed_origins` (it returns `[]` under `IS_HEROKU`, so "default" was a misnomer — it's the development-only set).
- Refreshed the now-stale `origins.py` comment about port 3001 (the legacy app moved to its own port and is now a genuine cross-origin CORS consumer).

**Production behavior is unchanged:** the dev list is empty under `IS_HEROKU`, so `CORS_ALLOWED_ORIGINS` equals exactly what's configured (`configured or []` → `configured + []`), and `csrf_trusted_origins` still ignores CORS origins in prod — a CORS consumer can never gain CSRF-trusted write access.

### How can this be tested?

Unit tests in `webserver/main/settings_test.py` cover the pure functions: the dev-origin computation (app + worktree ports, empty in prod / without `APP_BASE_URL`) and the new `test_cors_origins_union_adds_configured_without_dropping_dev` pinning that a configured origin adds to — not replaces — the dev defaults, with duplicates collapsed.

Manual check against a local backend:

\`\`\`bash
# In repo-root .env (gitignored): CORS_ALLOWED_ORIGINS=http://localhost:3141
docker compose up -d webserver
curl -s -i -X OPTIONS http://api.math3d.localdev:8000/v1/legacy_scenes/ \
  -H 'Origin: http://localhost:3141' \
  -H 'Access-Control-Request-Method: POST' | grep -i access-control-allow-origin
# => access-control-allow-origin: http://localhost:3141
# and http://math3d.localdev:3000 / :3002 still return their allow-origin header;
# an unknown origin returns none.
\`\`\`

### Additional Context

- The behavior change is fully contained to the `is_heroku=False` (local dev) branch — the only environment whose CORS/CSRF surface this widens.
- Running the legacy frontend locally is opt-in per developer: add `CORS_ALLOWED_ORIGINS=http://localhost:3141` to your gitignored `.env` (matching the port from math3d-react#394). No committed config references the legacy app's port.