### PR TITLE
feat(config): secure-by-default settings, typed env schema, /health

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -2,6 +2,8 @@ SECRET_KEY="not-so-secret"
 DEFAULT_FROM_EMAIL="no-reply@math3d-local.org"
 SERVER_EMAIL="maintainers@math3d-local.org"
 
+# Production hardening is the backend default; dev opts out explicitly.
+IS_PRODUCTION=False
 APP_BASE_URL=http://math3d.localdev:3000
 APP_VERSION=dev
 VITE_API_BASE_URL=http://api.math3d.localdev:8000

--- a/.env.development
+++ b/.env.development
@@ -3,7 +3,7 @@ DEFAULT_FROM_EMAIL="no-reply@math3d-local.org"
 SERVER_EMAIL="maintainers@math3d-local.org"
 
 # Production hardening is the backend default; dev opts out explicitly.
-IS_PRODUCTION=False
+IS_DEVELOPMENT=True
 APP_BASE_URL=http://math3d.localdev:3000
 APP_VERSION=dev
 VITE_API_BASE_URL=http://api.math3d.localdev:8000

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -96,3 +96,8 @@ jobs:
           heroku_email: ${{ vars.HEROKU_EMAIL }}
         env:
           HD_APP_VERSION: ${{ inputs.version }}
+          # HD_-prefixed vars become Heroku config vars. IS_PRODUCTION drives
+          # the backend's security hardening (settings.py); setting it here
+          # means every deployed environment is production-hardened without a
+          # manual config step.
+          HD_IS_PRODUCTION: "True"

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -96,8 +96,3 @@ jobs:
           heroku_email: ${{ vars.HEROKU_EMAIL }}
         env:
           HD_APP_VERSION: ${{ inputs.version }}
-          # HD_-prefixed vars become Heroku config vars. IS_PRODUCTION drives
-          # the backend's security hardening (settings.py); setting it here
-          # means every deployed environment is production-hardened without a
-          # manual config step.
-          HD_IS_PRODUCTION: "True"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,6 +34,11 @@ jobs:
 
   webserver-tests:
     runs-on: ubuntu-latest
+    env:
+      # This job runs directly on the runner (no .env.development), and the
+      # backend defaults to production hardening, which requires config this
+      # job doesn't have — opt out like any dev environment.
+      IS_PRODUCTION: "False"
     defaults:
       run:
         working-directory: ./webserver

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,7 +38,7 @@ jobs:
       # This job runs directly on the runner (no .env.development), and the
       # backend defaults to production hardening, which requires config this
       # job doesn't have — opt out like any dev environment.
-      IS_PRODUCTION: "False"
+      IS_DEVELOPMENT: "True"
     defaults:
       run:
         working-directory: ./webserver

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,9 +35,9 @@ jobs:
   webserver-tests:
     runs-on: ubuntu-latest
     env:
-      # This job runs directly on the runner (no .env.development), and the
-      # backend defaults to production hardening, which requires config this
-      # job doesn't have — opt out like any dev environment.
+      # CI is a dev environment: the tests speak plain http (production
+      # posture would 301 everything), and production behavior is pinned
+      # hermetically by the load_settings tests, not by this job's env.
       IS_DEVELOPMENT: "True"
     defaults:
       run:

--- a/webserver/main/env.py
+++ b/webserver/main/env.py
@@ -34,12 +34,13 @@ class EnvConfig(BaseSettings):
     # pydantic-settings' JSON pre-parse and let the field validator split them.
     ALLOWED_HOSTS: Annotated[list[str], NoDecode] = []
     CORS_ALLOWED_ORIGINS: Annotated[list[str], NoDecode] = []
-    # Deployment environment. IS_PRODUCTION drives all production hardening
-    # and DEFAULTS TO TRUE: an unconfigured deploy is secure (or fails loudly
-    # on the required-config guards); dev environments opt out explicitly via
-    # IS_PRODUCTION=False (.env.development, CI). IS_HEROKU is the deprecated
-    # predecessor, read only to reject contradictory config.
-    IS_PRODUCTION: bool = True
+    # Deployment environment. Production hardening is the DEFAULT: an
+    # unconfigured deploy is secure (or fails loudly on the required-config
+    # guards). Dev environments opt out explicitly via IS_DEVELOPMENT=True
+    # (.env.development, CI); production-like deploys (prod, rc) set nothing.
+    # IS_HEROKU is the deprecated production flag, read only to reject
+    # contradictory config.
+    IS_DEVELOPMENT: bool = False
     IS_HEROKU: bool = False
     # Logging
     LOG_LEVEL: str = "INFO"
@@ -80,17 +81,17 @@ class EnvConfig(BaseSettings):
 
     @model_validator(mode="after")
     def _reject_contradictory_legacy_flag(self) -> "EnvConfig":
-        if self.IS_HEROKU and not self.IS_PRODUCTION:
+        if self.IS_HEROKU and self.IS_DEVELOPMENT:
             raise ValueError(
                 "Contradictory config: IS_HEROKU (the deprecated production flag) "
-                "is set but IS_PRODUCTION is explicitly False. Remove IS_HEROKU; "
+                "is set but IS_DEVELOPMENT is also set. Remove IS_HEROKU; "
                 "production hardening is now the default."
             )
         return self
 
     @model_validator(mode="after")
     def _require_production_config(self) -> "EnvConfig":
-        if self.IS_PRODUCTION:
+        if not self.IS_DEVELOPMENT:
             if not self.APP_BASE_URL:
                 raise ValueError(
                     "APP_BASE_URL is required in production (used for "

--- a/webserver/main/env.py
+++ b/webserver/main/env.py
@@ -1,0 +1,129 @@
+"""
+Typed schema for every environment variable the Django settings read.
+
+Field names are the environment variable names. Cross-variable boot guards
+live here as model validators, so they are unit-testable by constructing
+EnvConfig directly; settings.py translates any ValidationError into Django's
+ImproperlyConfigured at import time.
+"""
+
+from typing import Annotated
+from urllib.parse import urlparse
+
+from django.utils.http import is_same_domain
+from pydantic import field_validator, model_validator
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
+
+
+class EnvConfig(BaseSettings):
+    model_config = SettingsConfigDict(case_sensitive=True, extra="forbid")
+
+    SECRET_KEY: str = ""
+    MAILJET_API_KEY: str = ""
+    MAILJET_SECRET_KEY: str = ""
+    DEFAULT_FROM_EMAIL: str = ""
+    SERVER_EMAIL: str = ""
+    # The SPA origin, e.g. https://next.math3d.org. Validated to a bare origin
+    # (and trailing-slash-normalized) because paths are appended to it
+    # (HEADLESS_FRONTEND_URLS) and it is used verbatim as an origin (CORS/CSRF
+    # trust), where a browser's Origin header never carries a path.
+    APP_BASE_URL: str = ""
+    DATABASE_URL: str = ""
+    INGESTION_DATABASE_URL: str = ""
+    # NoDecode: these env vars hold comma-separated lists, not JSON — skip
+    # pydantic-settings' JSON pre-parse and let the field validator split them.
+    ALLOWED_HOSTS: Annotated[list[str], NoDecode] = []
+    CORS_ALLOWED_ORIGINS: Annotated[list[str], NoDecode] = []
+    # Deployment environment. IS_PRODUCTION drives all production hardening
+    # and DEFAULTS TO TRUE: an unconfigured deploy is secure (or fails loudly
+    # on the required-config guards); dev environments opt out explicitly via
+    # IS_PRODUCTION=False (.env.development, CI). IS_HEROKU is the deprecated
+    # predecessor, read only to reject contradictory config.
+    IS_PRODUCTION: bool = True
+    IS_HEROKU: bool = False
+    # Logging
+    LOG_LEVEL: str = "INFO"
+    DJANGO_LOG_LEVEL: str = "INFO"
+    # Version
+    APP_VERSION: str = "unknown"
+    # Feature flags
+    ENABLE_REGISTRATION: bool = False
+    CSRF_COOKIE_DOMAIN: str = ""
+    DISABLE_ALLAUTH_RATE_LIMITS: bool = False
+
+    @field_validator("ALLOWED_HOSTS", "CORS_ALLOWED_ORIGINS", mode="before")
+    @classmethod
+    def _split_comma_separated(cls, value: object) -> object:
+        if isinstance(value, str):
+            return [item.strip() for item in value.split(",") if item.strip()]
+        return value
+
+    @field_validator("APP_BASE_URL")
+    @classmethod
+    def _normalize_and_validate_origin(cls, value: str) -> str:
+        value = value.rstrip("/")
+        if not value:
+            return value
+        parsed = urlparse(value)
+        if (
+            parsed.scheme not in ("http", "https")
+            or not parsed.hostname
+            or parsed.path
+            or parsed.query
+            or parsed.fragment
+        ):
+            raise ValueError(
+                f"APP_BASE_URL {value!r} must be a bare origin — scheme://host[:port] "
+                "with no path, e.g. https://next.math3d.org"
+            )
+        return value
+
+    @model_validator(mode="after")
+    def _reject_contradictory_legacy_flag(self) -> "EnvConfig":
+        if self.IS_HEROKU and not self.IS_PRODUCTION:
+            raise ValueError(
+                "Contradictory config: IS_HEROKU (the deprecated production flag) "
+                "is set but IS_PRODUCTION is explicitly False. Remove IS_HEROKU; "
+                "production hardening is now the default."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _require_production_config(self) -> "EnvConfig":
+        if self.IS_PRODUCTION:
+            if not self.APP_BASE_URL:
+                raise ValueError(
+                    "APP_BASE_URL is required in production (used for "
+                    "CSRF_TRUSTED_ORIGINS and email links)."
+                )
+            if not self.CSRF_COOKIE_DOMAIN:
+                raise ValueError(
+                    "CSRF_COOKIE_DOMAIN is required in production; without it the "
+                    "SPA cannot read the CSRF token and all authenticated writes "
+                    "fail."
+                )
+        return self
+
+    @model_validator(mode="after")
+    def _csrf_cookie_domain_must_cover_spa_host(self) -> "EnvConfig":
+        """
+        Cookie auth requires the SPA (next.math3d.org) and API
+        (api.next.math3d.org) to share a registrable domain: default
+        SameSite=Lax sends the session cookie, and CSRF_COOKIE_DOMAIN
+        (.math3d.org) lets the SPA read the CSRF token. This check makes the
+        shared-domain constraint explicit for the CSRF half.
+        """
+        if self.CSRF_COOKIE_DOMAIN and self.APP_BASE_URL:
+            spa_host = urlparse(self.APP_BASE_URL).hostname or ""
+            # Browsers ignore a leading dot on the cookie Domain attribute
+            # (RFC 6265: "math3d.org" covers subdomains just like
+            # ".math3d.org"), whereas is_same_domain only matches subdomains
+            # for dotted patterns — so normalize to the dotted form.
+            cookie_domain = "." + self.CSRF_COOKIE_DOMAIN.lstrip(".")
+            if not is_same_domain(spa_host, cookie_domain):
+                raise ValueError(
+                    f"CSRF_COOKIE_DOMAIN {self.CSRF_COOKIE_DOMAIN!r} does not "
+                    f"cover the SPA host {spa_host!r} (from APP_BASE_URL), so the "
+                    "SPA could not read the CSRF token."
+                )
+        return self

--- a/webserver/main/management/commands/seed_test_data.py
+++ b/webserver/main/management/commands/seed_test_data.py
@@ -2,17 +2,19 @@ import os
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
 from allauth.account.models import EmailAddress
+from pydantic_settings import BaseSettings
 from scenes.models import Scene
-import environ
 import json
 
 
-env = environ.Env(
-    TEST_USER_ADMIN_EMAIL=(str, ""),
-    TEST_USER_ADMIN_PASSWORD=(str, ""),
-    TEST_USER_STATIC_EMAIL=(str, ""),
-    TEST_USER_STATIC_PASSWORD=(str, ""),
-)
+class SeedEnv(BaseSettings):
+    TEST_USER_ADMIN_EMAIL: str = ""
+    TEST_USER_ADMIN_PASSWORD: str = ""
+    TEST_USER_STATIC_EMAIL: str = ""
+    TEST_USER_STATIC_PASSWORD: str = ""
+
+
+env = SeedEnv()
 
 User = get_user_model()
 
@@ -42,15 +44,15 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         create_test_user(
-            email=env("TEST_USER_ADMIN_EMAIL"),
-            password=env("TEST_USER_ADMIN_PASSWORD"),
+            email=env.TEST_USER_ADMIN_EMAIL,
+            password=env.TEST_USER_ADMIN_PASSWORD,
             public_nickname="Admin Test User",
             is_staff=True,
         )
 
         user_1 = create_test_user(
-            email=env("TEST_USER_STATIC_EMAIL"),
-            password=env("TEST_USER_STATIC_PASSWORD"),
+            email=env.TEST_USER_STATIC_EMAIL,
+            password=env.TEST_USER_STATIC_PASSWORD,
             public_nickname="Static Test User",
         )
 

--- a/webserver/main/origins.py
+++ b/webserver/main/origins.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse
 WORKTREE_PORTS = range(3002, 3010)
 
 
-def dev_cors_allowed_origins(*, is_heroku: bool, app_base_url: str) -> list[str]:
+def dev_cors_allowed_origins(*, is_production: bool, app_base_url: str) -> list[str]:
     """
     Compute the development-only CORS origins (empty in production).
 
@@ -21,7 +21,7 @@ def dev_cors_allowed_origins(*, is_heroku: bool, app_base_url: str) -> list[str]
 
     In production, origins must be configured explicitly; return none.
     """
-    if is_heroku or not app_base_url:
+    if is_production or not app_base_url:
         return []
     base = urlparse(app_base_url)
     return [app_base_url] + [
@@ -48,7 +48,7 @@ def cors_allowed_origins(
 
 def csrf_trusted_origins(
     *,
-    is_heroku: bool,
+    is_production: bool,
     app_base_url: str,
     cors_allowed_origins: list[str],
 ) -> list[str]:
@@ -63,7 +63,7 @@ def csrf_trusted_origins(
     scripts/setup_worktree_env.sh) make credentialed writes, so every CORS
     origin must also pass the CSRF origin check.
     """
-    if is_heroku:
+    if is_production:
         return [app_base_url]
     return list(
         dict.fromkeys(([app_base_url] if app_base_url else []) + cors_allowed_origins)

--- a/webserver/main/origins.py
+++ b/webserver/main/origins.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse
 WORKTREE_PORTS = range(3002, 3010)
 
 
-def dev_cors_allowed_origins(*, is_production: bool, app_base_url: str) -> list[str]:
+def dev_cors_allowed_origins(*, is_development: bool, app_base_url: str) -> list[str]:
     """
     Compute the development-only CORS origins (empty in production).
 
@@ -21,7 +21,7 @@ def dev_cors_allowed_origins(*, is_production: bool, app_base_url: str) -> list[
 
     In production, origins must be configured explicitly; return none.
     """
-    if is_production or not app_base_url:
+    if not is_development or not app_base_url:
         return []
     base = urlparse(app_base_url)
     return [app_base_url] + [
@@ -48,7 +48,7 @@ def cors_allowed_origins(
 
 def csrf_trusted_origins(
     *,
-    is_production: bool,
+    is_development: bool,
     app_base_url: str,
     cors_allowed_origins: list[str],
 ) -> list[str]:
@@ -63,7 +63,7 @@ def csrf_trusted_origins(
     scripts/setup_worktree_env.sh) make credentialed writes, so every CORS
     origin must also pass the CSRF origin check.
     """
-    if is_production:
+    if not is_development:
         return [app_base_url]
     return list(
         dict.fromkeys(([app_base_url] if app_base_url else []) + cors_allowed_origins)

--- a/webserver/main/settings.py
+++ b/webserver/main/settings.py
@@ -12,14 +12,14 @@ https://docs.djangoproject.com/en/4.1/ref/settings/
 
 import os
 from pathlib import Path
-from urllib.parse import urlparse
 import logging
 
 from django.core.exceptions import ImproperlyConfigured
 
 import dj_database_url
-import environ
+from pydantic import ValidationError
 
+from main.env import EnvConfig
 from main.origins import (
     cors_allowed_origins,
     csrf_trusted_origins,
@@ -29,33 +29,13 @@ from main.origins import (
 
 logger = logging.getLogger(__name__)
 
-env = environ.Env(
-    CORS_ALLOWED_ORIGINS=(list, []),
-    SECRET_KEY=(str, ""),
-    MAILJET_API_KEY=(str, ""),
-    MAILJET_SECRET_KEY=(str, ""),
-    DEFAULT_FROM_EMAIL=(str, ""),
-    SERVER_EMAIL=(str, ""),
-    APP_BASE_URL=(str, ""),
-    INGESTION_DATABASE_URL=(str, ""),
-    ALLOWED_HOSTS=(list, []),
-    # Deployment environment. IS_PRODUCTION drives all production hardening
-    # and DEFAULTS TO TRUE: an unconfigured deploy is secure (or fails loudly
-    # on the required-config guards); dev environments opt out explicitly via
-    # IS_PRODUCTION=False (.env.development, CI). IS_HEROKU is the deprecated
-    # predecessor, read only to reject contradictory config.
-    IS_PRODUCTION=(bool, True),
-    IS_HEROKU=(bool, False),
-    # Logging
-    LOG_LEVEL=(str, "INFO"),
-    DJANGO_LOG_LEVEL=(str, "INFO"),
-    # Version
-    APP_VERSION=(str, "unknown"),
-    # Feature flags
-    ENABLE_REGISTRATION=(bool, False),
-    CSRF_COOKIE_DOMAIN=(str, ""),
-    DISABLE_ALLAUTH_RATE_LIMITS=(bool, False),
-)
+# Every env var this module reads, with types, defaults, and the cross-variable
+# boot guards (see main/env.py). Validation errors become the Django-idiomatic
+# ImproperlyConfigured so a misconfigured deploy still fails loudly at import.
+try:
+    ENV = EnvConfig()
+except ValidationError as exc:
+    raise ImproperlyConfigured(str(exc)) from exc
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -65,26 +45,20 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/4.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = env("SECRET_KEY")
+SECRET_KEY = ENV.SECRET_KEY
 
 # Application version
-APP_VERSION = env("APP_VERSION")
+APP_VERSION = ENV.APP_VERSION
 
 # Deployment environment: an explicit flag (not an inference from the hosting
 # platform) that defaults to production, so an unconfigured deploy comes up
-# hardened or fails loudly below — never silently with dev-grade security.
-IS_PRODUCTION = env("IS_PRODUCTION")
-if env("IS_HEROKU") and not IS_PRODUCTION:
-    raise ImproperlyConfigured(
-        "Contradictory config: IS_HEROKU (the deprecated production flag) is set "
-        "but IS_PRODUCTION is explicitly False. Remove IS_HEROKU; production "
-        "hardening is now the default."
-    )
+# hardened or fails loudly (EnvConfig guards) — never silently with dev-grade
+# security.
+IS_PRODUCTION = ENV.IS_PRODUCTION
 
-# The SPA origin, e.g. https://next.math3d.org. Normalized (no trailing slash)
-# because paths are appended to it below (HEADLESS_FRONTEND_URLS) and it is
-# used verbatim as an origin (CORS/CSRF trust).
-APP_BASE_URL = env("APP_BASE_URL").rstrip("/")
+# The SPA origin, e.g. https://next.math3d.org — validated and normalized to a
+# bare origin by EnvConfig.
+APP_BASE_URL = ENV.APP_BASE_URL
 
 DEBUG = False
 
@@ -99,23 +73,14 @@ if IS_PRODUCTION:
     SECURE_HSTS_SECONDS = 31536000  # 1 year
     SECURE_HSTS_INCLUDE_SUBDOMAINS = True
     SECURE_HSTS_PRELOAD = True
-    if not APP_BASE_URL:
-        raise ImproperlyConfigured(
-            "APP_BASE_URL is required in production (used for CSRF_TRUSTED_ORIGINS and email links)."
-        )
-    if not env("CSRF_COOKIE_DOMAIN"):
-        raise ImproperlyConfigured(
-            "CSRF_COOKIE_DOMAIN is required in production; without it the SPA "
-            "cannot read the CSRF token and all authenticated writes fail."
-        )
     # Set ALLOWED_HOSTS for production
-    ALLOWED_HOSTS = env("ALLOWED_HOSTS") if env("ALLOWED_HOSTS") else ["api.math3d.org"]
+    ALLOWED_HOSTS = ENV.ALLOWED_HOSTS if ENV.ALLOWED_HOSTS else ["api.math3d.org"]
 else:
     SESSION_COOKIE_SECURE = False
     CSRF_COOKIE_SECURE = False
     ALLOWED_HOSTS = (
-        env("ALLOWED_HOSTS")
-        if env("ALLOWED_HOSTS")
+        ENV.ALLOWED_HOSTS
+        if ENV.ALLOWED_HOSTS
         else ["localhost", "127.0.0.1", "api.math3d.localdev"]
     )
 
@@ -143,27 +108,27 @@ LOGGING = {
     },
     "root": {
         "handlers": ["console"],
-        "level": env("LOG_LEVEL"),
+        "level": ENV.LOG_LEVEL,
     },
     "loggers": {
         "django": {
             "handlers": ["console"],
-            "level": env("DJANGO_LOG_LEVEL"),
+            "level": ENV.DJANGO_LOG_LEVEL,
             "propagate": False,
         },
         "authentication": {
             "handlers": ["console"],
-            "level": env("LOG_LEVEL"),
+            "level": ENV.LOG_LEVEL,
             "propagate": False,
         },
         "scenes": {
             "handlers": ["console"],
-            "level": env("LOG_LEVEL"),
+            "level": ENV.LOG_LEVEL,
             "propagate": False,
         },
         "main": {
             "handlers": ["console"],
-            "level": env("LOG_LEVEL"),
+            "level": ENV.LOG_LEVEL,
             "propagate": False,
         },
     },
@@ -212,7 +177,7 @@ MIDDLEWARE = [
 # (APP_BASE_URL plus the worktree frontend ports). In production the dev list is
 # empty, so CORS_ALLOWED_ORIGINS is exactly what's configured.
 CORS_ALLOWED_ORIGINS = cors_allowed_origins(
-    configured=env("CORS_ALLOWED_ORIGINS"),
+    configured=ENV.CORS_ALLOWED_ORIGINS,
     dev=dev_cors_allowed_origins(
         is_production=IS_PRODUCTION,
         app_base_url=APP_BASE_URL,
@@ -229,22 +194,10 @@ CSRF_TRUSTED_ORIGINS = csrf_trusted_origins(
 
 # Cookie auth requires the SPA (next.math3d.org) and API (api.next.math3d.org)
 # to share a registrable domain: default SameSite=Lax sends the session cookie,
-# and CSRF_COOKIE_DOMAIN (.math3d.org) lets the SPA read the CSRF token. The
-# check below makes the shared-domain constraint explicit for the CSRF half.
-_csrf_cookie_domain = env("CSRF_COOKIE_DOMAIN")
-if _csrf_cookie_domain:
-    CSRF_COOKIE_DOMAIN = _csrf_cookie_domain
-    _registrable_domain = _csrf_cookie_domain.lstrip(".")
-    _spa_host = urlparse(APP_BASE_URL).hostname or ""
-    if APP_BASE_URL and not (
-        _spa_host == _registrable_domain
-        or _spa_host.endswith("." + _registrable_domain)
-    ):
-        raise ImproperlyConfigured(
-            f"CSRF_COOKIE_DOMAIN {_csrf_cookie_domain!r} does not cover the SPA "
-            f"host {_spa_host!r} (from APP_BASE_URL), so the SPA could not read "
-            "the CSRF token."
-        )
+# and CSRF_COOKIE_DOMAIN (.math3d.org) lets the SPA read the CSRF token.
+# EnvConfig enforces that the domain covers the SPA host.
+if ENV.CSRF_COOKIE_DOMAIN:
+    CSRF_COOKIE_DOMAIN = ENV.CSRF_COOKIE_DOMAIN
 
 
 AUTHENTICATION_BACKENDS = [
@@ -289,7 +242,7 @@ ACCOUNT_ADAPTER = "authentication.adapter.CustomAccountAdapter"
 # injecting extra fields alongside allauth's built-in signup form.
 ACCOUNT_SIGNUP_FORM_CLASS = "authentication.forms.CustomSignupForm"
 
-if env("DISABLE_ALLAUTH_RATE_LIMITS"):
+if ENV.DISABLE_ALLAUTH_RATE_LIMITS:
     if SESSION_COOKIE_SECURE:
         raise ImproperlyConfigured(
             "DISABLE_ALLAUTH_RATE_LIMITS must not be enabled on a secure-cookie "
@@ -318,11 +271,8 @@ HEADLESS_FRONTEND_URLS = {
 # https://docs.djangoproject.com/en/4.1/ref/settings/#databases
 
 DATABASES = {
-    "default": dj_database_url.config(
-        default=os.environ.get(
-            "DATABASE_URL",
-            f"sqlite:///{os.path.join(BASE_DIR, 'db.sqlite3')}",
-        )
+    "default": dj_database_url.parse(
+        ENV.DATABASE_URL or f"sqlite:///{os.path.join(BASE_DIR, 'db.sqlite3')}"
     )
 }
 
@@ -350,12 +300,12 @@ AUTH_PASSWORD_VALIDATORS = [
 
 AUTH_USER_MODEL = "authentication.CustomUser"
 
-MAILJET_API_KEY = env("MAILJET_API_KEY")
-MAILJET_SECRET_KEY = env("MAILJET_SECRET_KEY")
+MAILJET_API_KEY = ENV.MAILJET_API_KEY
+MAILJET_SECRET_KEY = ENV.MAILJET_SECRET_KEY
 
 ANYMAIL = {
-    "MAILJET_API_KEY": env("MAILJET_API_KEY"),
-    "MAILJET_SECRET_KEY": env("MAILJET_SECRET_KEY"),
+    "MAILJET_API_KEY": ENV.MAILJET_API_KEY,
+    "MAILJET_SECRET_KEY": ENV.MAILJET_SECRET_KEY,
 }
 if MAILJET_API_KEY and MAILJET_SECRET_KEY:
     EMAIL_BACKEND = "anymail.backends.mailjet.EmailBackend"
@@ -366,8 +316,8 @@ else:
     EMAIL_BACKEND = "django.core.mail.backends.filebased.EmailBackend"
     EMAIL_FILE_PATH = "./private/email/"
 
-DEFAULT_FROM_EMAIL = env("DEFAULT_FROM_EMAIL")
-SERVER_EMAIL = env("SERVER_EMAIL")
+DEFAULT_FROM_EMAIL = ENV.DEFAULT_FROM_EMAIL
+SERVER_EMAIL = ENV.SERVER_EMAIL
 
 # Internationalization
 # https://docs.djangoproject.com/en/4.1/topics/i18n/
@@ -404,7 +354,7 @@ STATICFILES_FINDERS = [
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
-INGESTION_DATABASE_URL = env("INGESTION_DATABASE_URL")
+INGESTION_DATABASE_URL = ENV.INGESTION_DATABASE_URL
 
 # Feature flags
-ENABLE_REGISTRATION = env("ENABLE_REGISTRATION")
+ENABLE_REGISTRATION = ENV.ENABLE_REGISTRATION

--- a/webserver/main/settings.py
+++ b/webserver/main/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/4.1/ref/settings/
 
 import os
 from pathlib import Path
+from urllib.parse import urlparse
 import logging
 
 from django.core.exceptions import ImproperlyConfigured
@@ -38,7 +39,10 @@ env = environ.Env(
     APP_BASE_URL=(str, ""),
     INGESTION_DATABASE_URL=(str, ""),
     ALLOWED_HOSTS=(list, []),
-    # Heroku
+    # Deployment environment. IS_PRODUCTION drives all production hardening;
+    # IS_HEROKU is its deprecated predecessor, read only to fail loudly if a
+    # deployment still relies on it.
+    IS_PRODUCTION=(bool, False),
     IS_HEROKU=(bool, False),
     # Logging
     LOG_LEVEL=(str, "INFO"),
@@ -64,26 +68,46 @@ SECRET_KEY = env("SECRET_KEY")
 # Application version
 APP_VERSION = env("APP_VERSION")
 
+# Deployment environment: an explicit flag, not an inference from the hosting
+# platform, so a deploy that forgets it fails loudly below instead of silently
+# starting with dev-grade security.
+IS_PRODUCTION = env("IS_PRODUCTION")
+if env("IS_HEROKU") and not IS_PRODUCTION:
+    raise ImproperlyConfigured(
+        "IS_HEROKU is deprecated and no longer drives production hardening. "
+        "Set IS_PRODUCTION=True on this deployment (and remove IS_HEROKU)."
+    )
+
+# The SPA origin, e.g. https://next.math3d.org. Normalized (no trailing slash)
+# because paths are appended to it below (HEADLESS_FRONTEND_URLS) and it is
+# used verbatim as an origin (CORS/CSRF trust).
+APP_BASE_URL = env("APP_BASE_URL").rstrip("/")
+
+DEBUG = False
+
 # Secure cookie defaults — only relaxed for local dev (no TLS).
 SESSION_COOKIE_SECURE = True
 CSRF_COOKIE_SECURE = True
 
 ALLOWED_HOSTS: list[str]
-if env("IS_HEROKU"):
-    DEBUG = False
+if IS_PRODUCTION:
     SECURE_SSL_REDIRECT = True
     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
     SECURE_HSTS_SECONDS = 31536000  # 1 year
     SECURE_HSTS_INCLUDE_SUBDOMAINS = True
     SECURE_HSTS_PRELOAD = True
-    if not env("APP_BASE_URL"):
+    if not APP_BASE_URL:
         raise ImproperlyConfigured(
             "APP_BASE_URL is required in production (used for CSRF_TRUSTED_ORIGINS and email links)."
+        )
+    if not env("CSRF_COOKIE_DOMAIN"):
+        raise ImproperlyConfigured(
+            "CSRF_COOKIE_DOMAIN is required in production; without it the SPA "
+            "cannot read the CSRF token and all authenticated writes fail."
         )
     # Set ALLOWED_HOSTS for production
     ALLOWED_HOSTS = env("ALLOWED_HOSTS") if env("ALLOWED_HOSTS") else ["api.math3d.org"]
 else:
-    DEBUG = False
     SESSION_COOKIE_SECURE = False
     CSRF_COOKIE_SECURE = False
     ALLOWED_HOSTS = (
@@ -187,25 +211,37 @@ MIDDLEWARE = [
 CORS_ALLOWED_ORIGINS = cors_allowed_origins(
     configured=env("CORS_ALLOWED_ORIGINS"),
     dev=dev_cors_allowed_origins(
-        is_heroku=env("IS_HEROKU"),
-        app_base_url=env("APP_BASE_URL"),
+        is_production=IS_PRODUCTION,
+        app_base_url=APP_BASE_URL,
     ),
 )
 CORS_ALLOW_CREDENTIALS = True
 # Prod trusts only APP_BASE_URL; local dev also trusts the CORS origins
 # (worktree frontend ports). See the function's docstring.
 CSRF_TRUSTED_ORIGINS = csrf_trusted_origins(
-    is_heroku=env("IS_HEROKU"),
-    app_base_url=env("APP_BASE_URL"),
+    is_production=IS_PRODUCTION,
+    app_base_url=APP_BASE_URL,
     cors_allowed_origins=CORS_ALLOWED_ORIGINS,
 )
 
 # Cookie auth requires the SPA (next.math3d.org) and API (api.next.math3d.org)
 # to share a registrable domain: default SameSite=Lax sends the session cookie,
-# and CSRF_COOKIE_DOMAIN (.math3d.org) lets the SPA read the CSRF token.
+# and CSRF_COOKIE_DOMAIN (.math3d.org) lets the SPA read the CSRF token. The
+# check below makes the shared-domain constraint explicit for the CSRF half.
 _csrf_cookie_domain = env("CSRF_COOKIE_DOMAIN")
 if _csrf_cookie_domain:
     CSRF_COOKIE_DOMAIN = _csrf_cookie_domain
+    _registrable_domain = _csrf_cookie_domain.lstrip(".")
+    _spa_host = urlparse(APP_BASE_URL).hostname or ""
+    if APP_BASE_URL and not (
+        _spa_host == _registrable_domain
+        or _spa_host.endswith("." + _registrable_domain)
+    ):
+        raise ImproperlyConfigured(
+            f"CSRF_COOKIE_DOMAIN {_csrf_cookie_domain!r} does not cover the SPA "
+            f"host {_spa_host!r} (from APP_BASE_URL), so the SPA could not read "
+            "the CSRF token."
+        )
 
 
 AUTHENTICATION_BACKENDS = [
@@ -251,9 +287,10 @@ ACCOUNT_ADAPTER = "authentication.adapter.CustomAccountAdapter"
 ACCOUNT_SIGNUP_FORM_CLASS = "authentication.forms.CustomSignupForm"
 
 if env("DISABLE_ALLAUTH_RATE_LIMITS"):
-    if env("IS_HEROKU"):
+    if SESSION_COOKIE_SECURE:
         raise ImproperlyConfigured(
-            "DISABLE_ALLAUTH_RATE_LIMITS must not be enabled in production."
+            "DISABLE_ALLAUTH_RATE_LIMITS must not be enabled on a secure-cookie "
+            "(TLS/production) deployment."
         )
     ACCOUNT_RATE_LIMITS = False
 
@@ -266,8 +303,8 @@ HEADLESS_SERVE_SPECIFICATION = True
 # API's /v1/docs; the default is Redoc (headless/spec/redoc_cdn.html).
 HEADLESS_SPECIFICATION_TEMPLATE_NAME = "headless/spec/swagger_cdn.html"
 HEADLESS_FRONTEND_URLS = {
-    "account_confirm_email": f"{env('APP_BASE_URL')}/?overlay=activate&key={{key}}",
-    "account_reset_password_from_key": f"{env('APP_BASE_URL')}/?overlay=reset-confirm&key={{key}}",
+    "account_confirm_email": f"{APP_BASE_URL}/?overlay=activate&key={{key}}",
+    "account_reset_password_from_key": f"{APP_BASE_URL}/?overlay=reset-confirm&key={{key}}",
 }
 
 ##################################################

--- a/webserver/main/settings.py
+++ b/webserver/main/settings.py
@@ -39,10 +39,12 @@ env = environ.Env(
     APP_BASE_URL=(str, ""),
     INGESTION_DATABASE_URL=(str, ""),
     ALLOWED_HOSTS=(list, []),
-    # Deployment environment. IS_PRODUCTION drives all production hardening;
-    # IS_HEROKU is its deprecated predecessor, read only to fail loudly if a
-    # deployment still relies on it.
-    IS_PRODUCTION=(bool, False),
+    # Deployment environment. IS_PRODUCTION drives all production hardening
+    # and DEFAULTS TO TRUE: an unconfigured deploy is secure (or fails loudly
+    # on the required-config guards); dev environments opt out explicitly via
+    # IS_PRODUCTION=False (.env.development, CI). IS_HEROKU is the deprecated
+    # predecessor, read only to reject contradictory config.
+    IS_PRODUCTION=(bool, True),
     IS_HEROKU=(bool, False),
     # Logging
     LOG_LEVEL=(str, "INFO"),
@@ -68,14 +70,15 @@ SECRET_KEY = env("SECRET_KEY")
 # Application version
 APP_VERSION = env("APP_VERSION")
 
-# Deployment environment: an explicit flag, not an inference from the hosting
-# platform, so a deploy that forgets it fails loudly below instead of silently
-# starting with dev-grade security.
+# Deployment environment: an explicit flag (not an inference from the hosting
+# platform) that defaults to production, so an unconfigured deploy comes up
+# hardened or fails loudly below — never silently with dev-grade security.
 IS_PRODUCTION = env("IS_PRODUCTION")
 if env("IS_HEROKU") and not IS_PRODUCTION:
     raise ImproperlyConfigured(
-        "IS_HEROKU is deprecated and no longer drives production hardening. "
-        "Set IS_PRODUCTION=True on this deployment (and remove IS_HEROKU)."
+        "Contradictory config: IS_HEROKU (the deprecated production flag) is set "
+        "but IS_PRODUCTION is explicitly False. Remove IS_HEROKU; production "
+        "hardening is now the default."
     )
 
 # The SPA origin, e.g. https://next.math3d.org. Normalized (no trailing slash)

--- a/webserver/main/settings.py
+++ b/webserver/main/settings.py
@@ -50,11 +50,11 @@ SECRET_KEY = ENV.SECRET_KEY
 # Application version
 APP_VERSION = ENV.APP_VERSION
 
-# Deployment environment: an explicit flag (not an inference from the hosting
-# platform) that defaults to production, so an unconfigured deploy comes up
+# Deployment environment: an explicit dev opt-out (not an inference from the
+# hosting platform) that defaults to False, so an unconfigured deploy comes up
 # hardened or fails loudly (EnvConfig guards) — never silently with dev-grade
-# security.
-IS_PRODUCTION = ENV.IS_PRODUCTION
+# security. Production-like deploys (prod, rc) leave it unset.
+IS_DEVELOPMENT = ENV.IS_DEVELOPMENT
 
 # The SPA origin, e.g. https://next.math3d.org — validated and normalized to a
 # bare origin by EnvConfig.
@@ -67,7 +67,7 @@ SESSION_COOKIE_SECURE = True
 CSRF_COOKIE_SECURE = True
 
 ALLOWED_HOSTS: list[str]
-if IS_PRODUCTION:
+if not IS_DEVELOPMENT:
     SECURE_SSL_REDIRECT = True
     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
     SECURE_HSTS_SECONDS = 31536000  # 1 year
@@ -179,7 +179,7 @@ MIDDLEWARE = [
 CORS_ALLOWED_ORIGINS = cors_allowed_origins(
     configured=ENV.CORS_ALLOWED_ORIGINS,
     dev=dev_cors_allowed_origins(
-        is_production=IS_PRODUCTION,
+        is_development=IS_DEVELOPMENT,
         app_base_url=APP_BASE_URL,
     ),
 )
@@ -187,7 +187,7 @@ CORS_ALLOW_CREDENTIALS = True
 # Prod trusts only APP_BASE_URL; local dev also trusts the CORS origins
 # (worktree frontend ports). See the function's docstring.
 CSRF_TRUSTED_ORIGINS = csrf_trusted_origins(
-    is_production=IS_PRODUCTION,
+    is_development=IS_DEVELOPMENT,
     app_base_url=APP_BASE_URL,
     cors_allowed_origins=CORS_ALLOWED_ORIGINS,
 )

--- a/webserver/main/settings_test.py
+++ b/webserver/main/settings_test.py
@@ -66,19 +66,19 @@ def test_bare_environment_fails_closed(monkeypatch):
 
 
 def test_local_dev_opt_out_relaxes_cookie_security(monkeypatch):
-    loaded = load_settings(monkeypatch, IS_PRODUCTION="False")
+    loaded = load_settings(monkeypatch, IS_DEVELOPMENT="True")
     assert loaded.SESSION_COOKIE_SECURE is False
     assert loaded.CSRF_COOKIE_SECURE is False
     assert not getattr(loaded, "SECURE_SSL_REDIRECT", False)
 
 
-def test_is_heroku_with_production_opt_out_is_contradictory(monkeypatch):
+def test_is_heroku_with_dev_opt_out_is_contradictory(monkeypatch):
     """
-    IS_HEROKU (the legacy prod flag) combined with an explicit IS_PRODUCTION
+    IS_HEROKU (the legacy prod flag) combined with an explicit IS_DEVELOPMENT
     opt-out is contradictory config — refuse to guess which one is stale.
     """
-    with pytest.raises(ImproperlyConfigured, match="IS_PRODUCTION"):
-        load_settings(monkeypatch, **PROD_ENV, IS_HEROKU="True", IS_PRODUCTION="False")
+    with pytest.raises(ImproperlyConfigured, match="IS_DEVELOPMENT"):
+        load_settings(monkeypatch, **PROD_ENV, IS_HEROKU="True", IS_DEVELOPMENT="True")
 
 
 def test_legacy_is_heroku_alone_still_gets_hardened(monkeypatch):
@@ -131,7 +131,7 @@ def test_rate_limit_disable_rejected_when_cookies_secure(monkeypatch):
 
 def test_rate_limit_disable_allowed_in_local_dev(monkeypatch):
     loaded = load_settings(
-        monkeypatch, IS_PRODUCTION="False", DISABLE_ALLAUTH_RATE_LIMITS="True"
+        monkeypatch, IS_DEVELOPMENT="True", DISABLE_ALLAUTH_RATE_LIMITS="True"
     )
     assert loaded.ACCOUNT_RATE_LIMITS is False
 
@@ -144,7 +144,7 @@ def test_local_dev_unions_explicit_cors_origins_with_defaults(monkeypatch):
     """
     loaded = load_settings(
         monkeypatch,
-        IS_PRODUCTION="False",
+        IS_DEVELOPMENT="True",
         APP_BASE_URL="http://math3d.localdev:3000",
         CORS_ALLOWED_ORIGINS="http://localhost:3141",
     )
@@ -167,7 +167,7 @@ def test_app_base_url_must_be_a_bare_origin(monkeypatch):
     """
     for bad in ["https://app.example.org/app", "app.example.org"]:
         with pytest.raises(ImproperlyConfigured, match="APP_BASE_URL"):
-            load_settings(monkeypatch, IS_PRODUCTION="False", APP_BASE_URL=bad)
+            load_settings(monkeypatch, IS_DEVELOPMENT="True", APP_BASE_URL=bad)
 
 
 def test_csrf_cookie_domain_coverage_is_case_insensitive(monkeypatch):
@@ -195,7 +195,7 @@ def test_app_base_url_trailing_slash_is_normalized(monkeypatch):
     built from it (issue #829).
     """
     loaded = load_settings(
-        monkeypatch, IS_PRODUCTION="False", APP_BASE_URL="http://math3d.localdev:3000/"
+        monkeypatch, IS_DEVELOPMENT="True", APP_BASE_URL="http://math3d.localdev:3000/"
     )
     assert loaded.APP_BASE_URL == "http://math3d.localdev:3000"
     assert (
@@ -211,7 +211,7 @@ def test_dev_cors_origins_cover_app_and_worktree_ports():
     CORS-trusted.
     """
     origins = dev_cors_allowed_origins(
-        is_production=False,
+        is_development=True,
         app_base_url="http://math3d.localdev:3000",
     )
     worktree_origins = [f"http://math3d.localdev:{port}" for port in WORKTREE_PORTS]
@@ -222,14 +222,14 @@ def test_dev_cors_origins_cover_app_and_worktree_ports():
 def test_dev_cors_origins_empty_in_prod():
     """Production must configure CORS origins explicitly."""
     origins = dev_cors_allowed_origins(
-        is_production=True,
+        is_development=False,
         app_base_url="https://app.example.org",
     )
     assert origins == []
 
 
 def test_dev_cors_origins_empty_without_app_base_url():
-    origins = dev_cors_allowed_origins(is_production=False, app_base_url="")
+    origins = dev_cors_allowed_origins(is_development=True, app_base_url="")
     assert origins == []
 
 
@@ -264,7 +264,7 @@ def test_prod_csrf_trust_ignores_cors_origins():
     CSRF-trusted write access.
     """
     origins = csrf_trusted_origins(
-        is_production=True,
+        is_development=False,
         app_base_url="https://app.example.org",
         cors_allowed_origins=["https://app.example.org", "https://partner.example"],
     )
@@ -277,7 +277,7 @@ def test_local_csrf_trust_covers_cors_origins():
     every CORS origin must also pass Django's CSRF origin check.
     """
     origins = csrf_trusted_origins(
-        is_production=False,
+        is_development=True,
         app_base_url="http://math3d.localdev:3000",
         cors_allowed_origins=[
             "http://math3d.localdev:3000",
@@ -292,7 +292,7 @@ def test_local_csrf_trust_covers_cors_origins():
 
 def test_local_csrf_trust_handles_unset_app_base_url():
     origins = csrf_trusted_origins(
-        is_production=False,
+        is_development=True,
         app_base_url="",
         cors_allowed_origins=["http://math3d.localdev:3000"],
     )

--- a/webserver/main/settings_test.py
+++ b/webserver/main/settings_test.py
@@ -1,4 +1,9 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 
 from main.origins import (
     WORKTREE_PORTS,
@@ -6,6 +11,168 @@ from main.origins import (
     csrf_trusted_origins,
     dev_cors_allowed_origins,
 )
+
+SETTINGS_PATH = Path(__file__).parent / "settings.py"
+
+# Every env var settings.py reads; cleared before each load so ambient values
+# (docker-compose env, developer shells) can't leak into the scenario under test.
+SETTINGS_ENV_VARS = [
+    "CORS_ALLOWED_ORIGINS",
+    "SECRET_KEY",
+    "MAILJET_API_KEY",
+    "MAILJET_SECRET_KEY",
+    "DEFAULT_FROM_EMAIL",
+    "SERVER_EMAIL",
+    "APP_BASE_URL",
+    "INGESTION_DATABASE_URL",
+    "ALLOWED_HOSTS",
+    "IS_HEROKU",
+    "IS_PRODUCTION",
+    "LOG_LEVEL",
+    "DJANGO_LOG_LEVEL",
+    "APP_VERSION",
+    "ENABLE_REGISTRATION",
+    "CSRF_COOKIE_DOMAIN",
+    "DISABLE_ALLAUTH_RATE_LIMITS",
+]
+
+# Minimal valid production environment; tests remove or override entries to
+# exercise each guard.
+PROD_ENV = {
+    "IS_PRODUCTION": "True",
+    "APP_BASE_URL": "https://next.math3d.org",
+    "CSRF_COOKIE_DOMAIN": ".math3d.org",
+}
+
+
+def load_settings(monkeypatch, **env_vars):
+    """
+    Execute settings.py fresh under a fully controlled environment and return
+    the resulting module. Guards raising at import time surface as exceptions.
+    """
+    for var in SETTINGS_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    for key, value in env_vars.items():
+        monkeypatch.setenv(key, value)
+    spec = importlib.util.spec_from_file_location(
+        "main_settings_under_test", SETTINGS_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_production_hardening_driven_by_is_production(monkeypatch):
+    loaded = load_settings(monkeypatch, **PROD_ENV)
+    assert loaded.SECURE_SSL_REDIRECT is True
+    assert loaded.SECURE_HSTS_SECONDS > 0
+    assert loaded.SESSION_COOKIE_SECURE is True
+    assert loaded.CSRF_COOKIE_SECURE is True
+
+
+def test_local_dev_relaxes_cookie_security(monkeypatch):
+    loaded = load_settings(monkeypatch)
+    assert loaded.SESSION_COOKIE_SECURE is False
+    assert loaded.CSRF_COOKIE_SECURE is False
+    assert not getattr(loaded, "SECURE_SSL_REDIRECT", False)
+
+
+def test_is_heroku_without_is_production_fails_loudly(monkeypatch):
+    """
+    A deploy still configured with the legacy IS_HEROKU flag must crash at
+    boot rather than silently start with dev-grade security (issue #1130).
+    """
+    env = {**PROD_ENV, "IS_HEROKU": "True"}
+    del env["IS_PRODUCTION"]
+    with pytest.raises(ImproperlyConfigured, match="IS_PRODUCTION"):
+        load_settings(monkeypatch, **env)
+
+
+def test_is_heroku_alongside_is_production_is_tolerated(monkeypatch):
+    """
+    During the config-var migration both flags coexist (the deploy sets
+    IS_PRODUCTION before IS_HEROKU is deleted); that must not break boot.
+    """
+    loaded = load_settings(monkeypatch, **PROD_ENV, IS_HEROKU="True")
+    assert loaded.SECURE_SSL_REDIRECT is True
+
+
+def test_production_requires_app_base_url(monkeypatch):
+    env = {**PROD_ENV}
+    del env["APP_BASE_URL"]
+    with pytest.raises(ImproperlyConfigured, match="APP_BASE_URL"):
+        load_settings(monkeypatch, **env)
+
+
+def test_production_requires_csrf_cookie_domain(monkeypatch):
+    """
+    Without CSRF_COOKIE_DOMAIN the SPA cannot read the CSRF token and all
+    authed mutations fail closed (issue #1130).
+    """
+    env = {**PROD_ENV}
+    del env["CSRF_COOKIE_DOMAIN"]
+    with pytest.raises(ImproperlyConfigured, match="CSRF_COOKIE_DOMAIN"):
+        load_settings(monkeypatch, **env)
+
+
+def test_csrf_cookie_domain_must_cover_spa_host(monkeypatch):
+    """
+    Cookie auth only works because the SPA and API share a registrable
+    domain; a CSRF_COOKIE_DOMAIN that doesn't cover the SPA host means the
+    SPA can never read the CSRF token.
+    """
+    with pytest.raises(ImproperlyConfigured, match="CSRF_COOKIE_DOMAIN"):
+        load_settings(monkeypatch, **{**PROD_ENV, "CSRF_COOKIE_DOMAIN": ".example.org"})
+
+
+def test_rate_limit_disable_rejected_when_cookies_secure(monkeypatch):
+    """
+    DISABLE_ALLAUTH_RATE_LIMITS must be rejected on any secure-cookie (TLS)
+    deploy, not just under a particular hosting flag (issue #1130).
+    """
+    with pytest.raises(ImproperlyConfigured, match="DISABLE_ALLAUTH_RATE_LIMITS"):
+        load_settings(monkeypatch, **PROD_ENV, DISABLE_ALLAUTH_RATE_LIMITS="True")
+
+
+def test_rate_limit_disable_allowed_in_local_dev(monkeypatch):
+    loaded = load_settings(monkeypatch, DISABLE_ALLAUTH_RATE_LIMITS="True")
+    assert loaded.ACCOUNT_RATE_LIMITS is False
+
+
+def test_local_dev_unions_explicit_cors_origins_with_defaults(monkeypatch):
+    """
+    A local CORS override (e.g. trusting the legacy frontend's dev server)
+    must extend the derived defaults, not replace them — otherwise setting it
+    silently un-trusts the main dev frontend and worktree ports.
+    """
+    loaded = load_settings(
+        monkeypatch,
+        APP_BASE_URL="http://math3d.localdev:3000",
+        CORS_ALLOWED_ORIGINS="http://localhost:3141",
+    )
+    assert "http://localhost:3141" in loaded.CORS_ALLOWED_ORIGINS
+    assert "http://math3d.localdev:3000" in loaded.CORS_ALLOWED_ORIGINS
+
+
+def test_production_cors_origins_are_exactly_the_explicit_config(monkeypatch):
+    loaded = load_settings(
+        monkeypatch, **PROD_ENV, CORS_ALLOWED_ORIGINS="https://next.math3d.org"
+    )
+    assert loaded.CORS_ALLOWED_ORIGINS == ["https://next.math3d.org"]
+
+
+def test_app_base_url_trailing_slash_is_normalized(monkeypatch):
+    """
+    A trailing slash on APP_BASE_URL must not corrupt the auth email links
+    built from it (issue #829).
+    """
+    loaded = load_settings(monkeypatch, APP_BASE_URL="http://math3d.localdev:3000/")
+    assert loaded.APP_BASE_URL == "http://math3d.localdev:3000"
+    assert (
+        loaded.HEADLESS_FRONTEND_URLS["account_confirm_email"]
+        == "http://math3d.localdev:3000/?overlay=activate&key={key}"
+    )
 
 
 def test_dev_cors_origins_cover_app_and_worktree_ports():
@@ -15,7 +182,7 @@ def test_dev_cors_origins_cover_app_and_worktree_ports():
     CORS-trusted.
     """
     origins = dev_cors_allowed_origins(
-        is_heroku=False,
+        is_production=False,
         app_base_url="http://math3d.localdev:3000",
     )
     worktree_origins = [f"http://math3d.localdev:{port}" for port in WORKTREE_PORTS]
@@ -26,14 +193,14 @@ def test_dev_cors_origins_cover_app_and_worktree_ports():
 def test_dev_cors_origins_empty_in_prod():
     """Production must configure CORS origins explicitly."""
     origins = dev_cors_allowed_origins(
-        is_heroku=True,
+        is_production=True,
         app_base_url="https://next.math3d.org",
     )
     assert origins == []
 
 
 def test_dev_cors_origins_empty_without_app_base_url():
-    origins = dev_cors_allowed_origins(is_heroku=False, app_base_url="")
+    origins = dev_cors_allowed_origins(is_production=False, app_base_url="")
     assert origins == []
 
 
@@ -68,7 +235,7 @@ def test_prod_csrf_trust_ignores_cors_origins():
     CSRF-trusted write access.
     """
     origins = csrf_trusted_origins(
-        is_heroku=True,
+        is_production=True,
         app_base_url="https://next.math3d.org",
         cors_allowed_origins=["https://next.math3d.org", "https://partner.example"],
     )
@@ -81,7 +248,7 @@ def test_local_csrf_trust_covers_cors_origins():
     every CORS origin must also pass Django's CSRF origin check.
     """
     origins = csrf_trusted_origins(
-        is_heroku=False,
+        is_production=False,
         app_base_url="http://math3d.localdev:3000",
         cors_allowed_origins=[
             "http://math3d.localdev:3000",
@@ -96,7 +263,7 @@ def test_local_csrf_trust_covers_cors_origins():
 
 def test_local_csrf_trust_handles_unset_app_base_url():
     origins = csrf_trusted_origins(
-        is_heroku=False,
+        is_production=False,
         app_base_url="",
         cors_allowed_origins=["http://math3d.localdev:3000"],
     )

--- a/webserver/main/settings_test.py
+++ b/webserver/main/settings_test.py
@@ -36,12 +36,11 @@ SETTINGS_ENV_VARS = [
     "DISABLE_ALLAUTH_RATE_LIMITS",
 ]
 
-# Minimal valid production environment; tests remove or override entries to
-# exercise each guard.
+# Minimal valid production environment — production is the DEFAULT posture, so
+# no flag is needed; tests remove or override entries to exercise each guard.
 PROD_ENV = {
-    "IS_PRODUCTION": "True",
-    "APP_BASE_URL": "https://next.math3d.org",
-    "CSRF_COOKIE_DOMAIN": ".math3d.org",
+    "APP_BASE_URL": "https://app.example.org",
+    "CSRF_COOKIE_DOMAIN": ".example.org",
 }
 
 
@@ -63,7 +62,8 @@ def load_settings(monkeypatch, **env_vars):
     return module
 
 
-def test_production_hardening_driven_by_is_production(monkeypatch):
+def test_production_hardening_is_the_default(monkeypatch):
+    """Secure by default: hardening applies unless a deploy explicitly opts out."""
     loaded = load_settings(monkeypatch, **PROD_ENV)
     assert loaded.SECURE_SSL_REDIRECT is True
     assert loaded.SECURE_HSTS_SECONDS > 0
@@ -71,28 +71,36 @@ def test_production_hardening_driven_by_is_production(monkeypatch):
     assert loaded.CSRF_COOKIE_SECURE is True
 
 
-def test_local_dev_relaxes_cookie_security(monkeypatch):
-    loaded = load_settings(monkeypatch)
+def test_bare_environment_fails_closed(monkeypatch):
+    """
+    An entirely unconfigured environment must refuse to boot (it defaults to
+    production and trips the required-config guards) rather than silently
+    start with dev-grade security (issue #1130).
+    """
+    with pytest.raises(ImproperlyConfigured):
+        load_settings(monkeypatch)
+
+
+def test_local_dev_opt_out_relaxes_cookie_security(monkeypatch):
+    loaded = load_settings(monkeypatch, IS_PRODUCTION="False")
     assert loaded.SESSION_COOKIE_SECURE is False
     assert loaded.CSRF_COOKIE_SECURE is False
     assert not getattr(loaded, "SECURE_SSL_REDIRECT", False)
 
 
-def test_is_heroku_without_is_production_fails_loudly(monkeypatch):
+def test_is_heroku_with_production_opt_out_is_contradictory(monkeypatch):
     """
-    A deploy still configured with the legacy IS_HEROKU flag must crash at
-    boot rather than silently start with dev-grade security (issue #1130).
+    IS_HEROKU (the legacy prod flag) combined with an explicit IS_PRODUCTION
+    opt-out is contradictory config — refuse to guess which one is stale.
     """
-    env = {**PROD_ENV, "IS_HEROKU": "True"}
-    del env["IS_PRODUCTION"]
     with pytest.raises(ImproperlyConfigured, match="IS_PRODUCTION"):
-        load_settings(monkeypatch, **env)
+        load_settings(monkeypatch, **PROD_ENV, IS_HEROKU="True", IS_PRODUCTION="False")
 
 
-def test_is_heroku_alongside_is_production_is_tolerated(monkeypatch):
+def test_legacy_is_heroku_alone_still_gets_hardened(monkeypatch):
     """
-    During the config-var migration both flags coexist (the deploy sets
-    IS_PRODUCTION before IS_HEROKU is deleted); that must not break boot.
+    An app still carrying the legacy IS_HEROKU config var (and nothing else
+    new) lands on the production default — the migration cannot degrade it.
     """
     loaded = load_settings(monkeypatch, **PROD_ENV, IS_HEROKU="True")
     assert loaded.SECURE_SSL_REDIRECT is True
@@ -123,7 +131,9 @@ def test_csrf_cookie_domain_must_cover_spa_host(monkeypatch):
     SPA can never read the CSRF token.
     """
     with pytest.raises(ImproperlyConfigured, match="CSRF_COOKIE_DOMAIN"):
-        load_settings(monkeypatch, **{**PROD_ENV, "CSRF_COOKIE_DOMAIN": ".example.org"})
+        load_settings(
+            monkeypatch, **{**PROD_ENV, "CSRF_COOKIE_DOMAIN": ".unrelated.example"}
+        )
 
 
 def test_rate_limit_disable_rejected_when_cookies_secure(monkeypatch):
@@ -136,7 +146,9 @@ def test_rate_limit_disable_rejected_when_cookies_secure(monkeypatch):
 
 
 def test_rate_limit_disable_allowed_in_local_dev(monkeypatch):
-    loaded = load_settings(monkeypatch, DISABLE_ALLAUTH_RATE_LIMITS="True")
+    loaded = load_settings(
+        monkeypatch, IS_PRODUCTION="False", DISABLE_ALLAUTH_RATE_LIMITS="True"
+    )
     assert loaded.ACCOUNT_RATE_LIMITS is False
 
 
@@ -148,6 +160,7 @@ def test_local_dev_unions_explicit_cors_origins_with_defaults(monkeypatch):
     """
     loaded = load_settings(
         monkeypatch,
+        IS_PRODUCTION="False",
         APP_BASE_URL="http://math3d.localdev:3000",
         CORS_ALLOWED_ORIGINS="http://localhost:3141",
     )
@@ -157,9 +170,9 @@ def test_local_dev_unions_explicit_cors_origins_with_defaults(monkeypatch):
 
 def test_production_cors_origins_are_exactly_the_explicit_config(monkeypatch):
     loaded = load_settings(
-        monkeypatch, **PROD_ENV, CORS_ALLOWED_ORIGINS="https://next.math3d.org"
+        monkeypatch, **PROD_ENV, CORS_ALLOWED_ORIGINS="https://app.example.org"
     )
-    assert loaded.CORS_ALLOWED_ORIGINS == ["https://next.math3d.org"]
+    assert loaded.CORS_ALLOWED_ORIGINS == ["https://app.example.org"]
 
 
 def test_app_base_url_trailing_slash_is_normalized(monkeypatch):
@@ -167,7 +180,9 @@ def test_app_base_url_trailing_slash_is_normalized(monkeypatch):
     A trailing slash on APP_BASE_URL must not corrupt the auth email links
     built from it (issue #829).
     """
-    loaded = load_settings(monkeypatch, APP_BASE_URL="http://math3d.localdev:3000/")
+    loaded = load_settings(
+        monkeypatch, IS_PRODUCTION="False", APP_BASE_URL="http://math3d.localdev:3000/"
+    )
     assert loaded.APP_BASE_URL == "http://math3d.localdev:3000"
     assert (
         loaded.HEADLESS_FRONTEND_URLS["account_confirm_email"]
@@ -194,7 +209,7 @@ def test_dev_cors_origins_empty_in_prod():
     """Production must configure CORS origins explicitly."""
     origins = dev_cors_allowed_origins(
         is_production=True,
-        app_base_url="https://next.math3d.org",
+        app_base_url="https://app.example.org",
     )
     assert origins == []
 
@@ -236,10 +251,10 @@ def test_prod_csrf_trust_ignores_cors_origins():
     """
     origins = csrf_trusted_origins(
         is_production=True,
-        app_base_url="https://next.math3d.org",
-        cors_allowed_origins=["https://next.math3d.org", "https://partner.example"],
+        app_base_url="https://app.example.org",
+        cors_allowed_origins=["https://app.example.org", "https://partner.example"],
     )
-    assert origins == ["https://next.math3d.org"]
+    assert origins == ["https://app.example.org"]
 
 
 def test_local_csrf_trust_covers_cors_origins():

--- a/webserver/main/settings_test.py
+++ b/webserver/main/settings_test.py
@@ -5,6 +5,7 @@ import pytest
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
+from main.env import EnvConfig
 from main.origins import (
     WORKTREE_PORTS,
     cors_allowed_origins,
@@ -14,27 +15,10 @@ from main.origins import (
 
 SETTINGS_PATH = Path(__file__).parent / "settings.py"
 
-# Every env var settings.py reads; cleared before each load so ambient values
-# (docker-compose env, developer shells) can't leak into the scenario under test.
-SETTINGS_ENV_VARS = [
-    "CORS_ALLOWED_ORIGINS",
-    "SECRET_KEY",
-    "MAILJET_API_KEY",
-    "MAILJET_SECRET_KEY",
-    "DEFAULT_FROM_EMAIL",
-    "SERVER_EMAIL",
-    "APP_BASE_URL",
-    "INGESTION_DATABASE_URL",
-    "ALLOWED_HOSTS",
-    "IS_HEROKU",
-    "IS_PRODUCTION",
-    "LOG_LEVEL",
-    "DJANGO_LOG_LEVEL",
-    "APP_VERSION",
-    "ENABLE_REGISTRATION",
-    "CSRF_COOKIE_DOMAIN",
-    "DISABLE_ALLAUTH_RATE_LIMITS",
-]
+# Every env var settings.py reads — derived from the EnvConfig schema so it
+# cannot drift — cleared before each load so ambient values (docker-compose
+# env, developer shells) can't leak into the scenario under test.
+SETTINGS_ENV_VARS = list(EnvConfig.model_fields)
 
 # Minimal valid production environment — production is the DEFAULT posture, so
 # no flag is needed; tests remove or override entries to exercise each guard.
@@ -173,6 +157,36 @@ def test_production_cors_origins_are_exactly_the_explicit_config(monkeypatch):
         monkeypatch, **PROD_ENV, CORS_ALLOWED_ORIGINS="https://app.example.org"
     )
     assert loaded.CORS_ALLOWED_ORIGINS == ["https://app.example.org"]
+
+
+def test_app_base_url_must_be_a_bare_origin(monkeypatch):
+    """
+    APP_BASE_URL is used verbatim as a CORS/CSRF origin, and a browser's
+    Origin header never carries a path — a path-bearing or scheme-less value
+    would boot fine and then silently fail every credentialed request.
+    """
+    for bad in ["https://app.example.org/app", "app.example.org"]:
+        with pytest.raises(ImproperlyConfigured, match="APP_BASE_URL"):
+            load_settings(monkeypatch, IS_PRODUCTION="False", APP_BASE_URL=bad)
+
+
+def test_csrf_cookie_domain_coverage_is_case_insensitive(monkeypatch):
+    """Domain matching is case-insensitive; unusual casing must not fail boot."""
+    loaded = load_settings(
+        monkeypatch, **{**PROD_ENV, "CSRF_COOKIE_DOMAIN": ".Example.org"}
+    )
+    assert loaded.CSRF_COOKIE_DOMAIN == ".Example.org"
+
+
+def test_csrf_cookie_domain_covers_subdomains_without_leading_dot(monkeypatch):
+    """
+    Browsers ignore a leading dot on the cookie Domain attribute (RFC 6265):
+    'example.org' covers app.example.org just like '.example.org' does.
+    """
+    loaded = load_settings(
+        monkeypatch, **{**PROD_ENV, "CSRF_COOKIE_DOMAIN": "example.org"}
+    )
+    assert loaded.CSRF_COOKIE_DOMAIN == "example.org"
 
 
 def test_app_base_url_trailing_slash_is_normalized(monkeypatch):

--- a/webserver/main/urls.py
+++ b/webserver/main/urls.py
@@ -19,9 +19,11 @@ from django.http import HttpResponseRedirect
 from django.urls import include, path
 
 from main.api import api
+from main.views import health
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("health", health),
     path("v1/", api.urls),
     path("_allauth/", include("allauth.headless.urls")),
     path("", lambda request: HttpResponseRedirect("/v1/docs")),

--- a/webserver/main/views.py
+++ b/webserver/main/views.py
@@ -1,7 +1,9 @@
 from django.conf import settings
 from django.http import HttpRequest, JsonResponse
+from django.views.decorators.http import require_safe
 
 
+@require_safe
 def health(request: HttpRequest) -> JsonResponse:
     """Unversioned healthcheck for uptime monitors and post-deploy smoke checks.
 

--- a/webserver/main/views.py
+++ b/webserver/main/views.py
@@ -1,0 +1,12 @@
+from django.conf import settings
+from django.http import HttpRequest, JsonResponse
+
+
+def health(request: HttpRequest) -> JsonResponse:
+    """Unversioned healthcheck for uptime monitors and post-deploy smoke checks.
+
+    Deliberately a plain Django view rather than a ninja route: it is operational
+    surface, not product API, so it stays out of openapi.v1.yaml and the generated
+    clients, and its URL is stable across API versions.
+    """
+    return JsonResponse({"status": "ok", "version": settings.APP_VERSION})

--- a/webserver/main/views_test.py
+++ b/webserver/main/views_test.py
@@ -1,0 +1,8 @@
+from django.test import Client, override_settings
+
+
+@override_settings(APP_VERSION="2026.07.03.1")
+def test_health_endpoint_reports_ok_and_version():
+    response = Client().get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "version": "2026.07.03.1"}

--- a/webserver/main/views_test.py
+++ b/webserver/main/views_test.py
@@ -6,3 +6,13 @@ def test_health_endpoint_reports_ok_and_version():
     response = Client().get("/health")
     assert response.status_code == 200
     assert response.json() == {"status": "ok", "version": "2026.07.03.1"}
+
+
+def test_health_endpoint_allows_head():
+    """Uptime monitors commonly probe with HEAD; require_safe (not require_GET)
+    was chosen deliberately to allow it."""
+    assert Client().head("/health").status_code == 200
+
+
+def test_health_endpoint_rejects_unsafe_methods():
+    assert Client().post("/health").status_code == 405

--- a/webserver/pyproject.toml
+++ b/webserver/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
 	"whitenoise>=6.11.0",
 	"django-allauth>=65.0,<66.0",
 	"django-ninja>=1.6,<2.0",
-	"pydantic-settings>=2.0,<3.0",
+	"pydantic-settings>=2.7,<3.0",
 ]
 
 [dependency-groups]

--- a/webserver/pyproject.toml
+++ b/webserver/pyproject.toml
@@ -11,13 +11,13 @@ dependencies = [
 	"pyyaml>=6.0,<7.0",
 	"gunicorn>=23.0.0,<24.0.0",
 	"django-cors-headers>=4.1.0,<5.0.0",
-	"django-environ>=0.12.0,<0.13.0",
 	"faker>=24.0.0,<25.0.0",
 	"django-anymail[mailjet]>=10.2,<11.0",
 	"psycopg>=3.2.10",
 	"whitenoise>=6.11.0",
 	"django-allauth>=65.0,<66.0",
 	"django-ninja>=1.6,<2.0",
+	"pydantic-settings>=2.0,<3.0",
 ]
 
 [dependency-groups]
@@ -44,10 +44,6 @@ packages = ["main"]
 
 [tool.mypy]
 plugins = ["mypy_django_plugin.main"]
-
-[[tool.mypy.overrides]]
-module = "environ.*"
-ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "allauth.*"

--- a/webserver/uv.lock
+++ b/webserver/uv.lock
@@ -135,15 +135,6 @@ wheels = [
 ]
 
 [[package]]
-name = "django-environ"
-version = "0.12.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d6/04/65d2521842c42f4716225f20d8443a50804920606aec018188bbee30a6b0/django_environ-0.12.0.tar.gz", hash = "sha256:227dc891453dd5bde769c3449cf4a74b6f2ee8f7ab2361c93a07068f4179041a", size = 56804, upload-time = "2025-01-13T17:03:37.74Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/b3/0a3bec4ecbfee960f39b1842c2f91e4754251e0a6ed443db9fe3f666ba8f/django_environ-0.12.0-py2.py3-none-any.whl", hash = "sha256:92fb346a158abda07ffe6eb23135ce92843af06ecf8753f43adf9d2366dcc0ca", size = 19957, upload-time = "2025-01-13T17:03:32.918Z" },
-]
-
-[[package]]
 name = "django-ninja"
 version = "1.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -282,11 +273,11 @@ dependencies = [
     { name = "django-allauth" },
     { name = "django-anymail" },
     { name = "django-cors-headers" },
-    { name = "django-environ" },
     { name = "django-ninja" },
     { name = "faker" },
     { name = "gunicorn" },
     { name = "psycopg" },
+    { name = "pydantic-settings" },
     { name = "pyyaml" },
     { name = "tqdm" },
     { name = "whitenoise" },
@@ -314,11 +305,11 @@ requires-dist = [
     { name = "django-allauth", specifier = ">=65.0,<66.0" },
     { name = "django-anymail", extras = ["mailjet"], specifier = ">=10.2,<11.0" },
     { name = "django-cors-headers", specifier = ">=4.1.0,<5.0.0" },
-    { name = "django-environ", specifier = ">=0.12.0,<0.13.0" },
     { name = "django-ninja", specifier = ">=1.6,<2.0" },
     { name = "faker", specifier = ">=24.0.0,<25.0.0" },
     { name = "gunicorn", specifier = ">=23.0.0,<24.0.0" },
     { name = "psycopg", specifier = ">=3.2.10" },
+    { name = "pydantic-settings", specifier = ">=2.0,<3.0" },
     { name = "pyyaml", specifier = ">=6.0,<7.0" },
     { name = "tqdm", specifier = ">=4.64.1,<5.0.0" },
     { name = "whitenoise", specifier = ">=6.11.0" },
@@ -454,6 +445,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -500,6 +505,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]

--- a/webserver/uv.lock
+++ b/webserver/uv.lock
@@ -309,7 +309,7 @@ requires-dist = [
     { name = "faker", specifier = ">=24.0.0,<25.0.0" },
     { name = "gunicorn", specifier = ">=23.0.0,<24.0.0" },
     { name = "psycopg", specifier = ">=3.2.10" },
-    { name = "pydantic-settings", specifier = ">=2.0,<3.0" },
+    { name = "pydantic-settings", specifier = ">=2.7,<3.0" },
     { name = "pyyaml", specifier = ">=6.0,<7.0" },
     { name = "tqdm", specifier = ">=4.64.1,<5.0.0" },
     { name = "whitenoise", specifier = ">=6.11.0" },


### PR DESCRIPTION
### What are the relevant issues?

- Closes https://github.com/ChristopherChudzicki/math3d-next/issues/1130
- Closes https://github.com/ChristopherChudzicki/math3d-next/issues/829

### Description

Four related backend-config changes:

**1. Production hardening is now the default; dev opts out via `IS_DEVELOPMENT=True`.**
All production security (secure cookies, SSL redirect, HSTS, prod `ALLOWED_HOSTS`) keys off a single `IS_DEVELOPMENT` setting that **defaults to false**. An unconfigured deployment boots hardened or fails loudly on the required-config guards — it can never silently come up with dev-grade security. The flag is named for the environments that actually assert it: only dev environments set it, about themselves, so production-like deploys (prod, a future rc) all leave it unset and never have to claim to be "production":

- `.env.development` sets `IS_DEVELOPMENT=True` (covers local docker, worktrees, and e2e via the existing env-file loading)
- CI's `webserver-tests` job sets it at job level (it runs on the bare runner with no env files)
- Heroku needs **no flag at all**; `IS_HEROKU` is retained only to reject contradictory config (legacy prod flag + explicit dev opt-out)

Boot-time guards in the hardened (non-dev) posture: `APP_BASE_URL` (pre-existing) and `CSRF_COOKIE_DOMAIN` are required, and `CSRF_COOKIE_DOMAIN` must cover the SPA host — making the shared-registrable-domain constraint of cookie auth explicit. `DISABLE_ALLAUTH_RATE_LIMITS` is now rejected on any secure-cookie deploy rather than only under the old Heroku flag.

**2. Typed env-var schema (`pydantic-settings`); django-environ removed.**
Every env var the webserver reads — including `DATABASE_URL`, which previously bypassed the env scheme via `os.environ.get` — is declared once in `EnvConfig(BaseSettings)` (`main/env.py`) with types and defaults. The cross-variable boot guards live there as model validators, so they're unit-testable by constructing the model directly; `settings.py` wraps `ValidationError` in `ImproperlyConfigured` so a misconfigured deploy still fails loudly and Django-idiomatically at import. The cookie-domain coverage check uses Django's `is_same_domain` (case-insensitive, unlike a naive string comparison), normalized to the dotted pattern since browsers ignore a leading dot on cookie domains (RFC 6265).

**3. `APP_BASE_URL` normalization and origin validation (#829).**
The base URL is read once, trailing-slash-stripped, and validated as a bare origin (scheme + host, no path/query) before it's used in `HEADLESS_FRONTEND_URLS` email links and origin trust. A trailing slash can no longer corrupt activation/password-reset links, and a path-bearing or scheme-less value fails at boot instead of booting fine and then silently failing every credentialed request (browser `Origin` headers never carry paths).

**4. Unversioned `/health` endpoint** returning `{"status": "ok", "version": <APP_VERSION>}`. Safe methods only (`@require_safe`: GET and HEAD — uptime monitors commonly probe with HEAD; anything else is 405). Deliberately a plain Django view rather than a ninja route: it's operational surface (uptime monitors, post-deploy checks), so it stays out of `openapi.v1.yaml`/generated clients and its URL is stable across API versions. This gives the previously-unread `APP_VERSION` setting (already populated on every deploy via `HD_APP_VERSION`) its first consumer.

Also swept along (env hygiene): explicit `CORS_ALLOWED_ORIGINS` now **union** with the derived dev defaults instead of replacing them. A local `.env` override for the legacy frontend was silently un-trusting the SPA origin, CORS-blocking every credentialed browser request in local e2e runs — the union matches the behavior the `.env` comment always claimed.

### How can this be tested?

- `main/settings_test.py` has a `load_settings` harness that execs `settings.py` under a fully controlled environment (the env clear-list is derived from `EnvConfig.model_fields`, so it can't drift from the schema). It pins each boot-time guard: bare env fails closed, missing `APP_BASE_URL`/`CSRF_COOKIE_DOMAIN` raise, cookie-domain coverage (including case-insensitivity and no-leading-dot subdomain coverage), bare-origin validation, rate-limit rejection, CORS union vs prod-exact, trailing-slash normalization.
- `curl http://api.math3d.localdev:8000/health` against the dev backend → `{"status": "ok", "version": "dev"}`.
- Full Playwright e2e suite passes locally against these settings (46/46), including the auth email-link flows built from `APP_BASE_URL`.

### Additional context

**Deviations from the issues as written:**

- #829 names the djoser-era `ACTIVATION_URL`/`PASSWORD_RESET_CONFIRM_URL` settings, which were removed in the allauth migration (#1129). The fragile f-string joining it actually complains about survived in `HEADLESS_FRONTEND_URLS`; that's what this fixes.
- #1130 asks to "introduce an explicit `IS_PRODUCTION`/`DJANGO_ENV` and drive all hardening off it." This PR goes one step further: rather than an opt-in production flag (which recreates the original failure mode — forget the flag, silently degrade), hardening is the *default* and dev opts out with `IS_DEVELOPMENT=True`. The unconfigured state is now the safe state, and the flag's name matches who asserts it — under the issue's `IS_PRODUCTION`, an rc/staging deploy would have to either claim to be production or silently degrade. The issue's remaining bullets (rate-limit rejection beyond `IS_HEROKU`, `CSRF_COOKIE_DOMAIN` prod guard, making the SameSite/shared-domain assumption explicit, general env hygiene) are implemented as written.

**Env-format compatibility:** `ALLOWED_HOSTS` and `CORS_ALLOWED_ORIGINS` keep their comma-separated format (pydantic-settings expects JSON for list fields by default; `NoDecode` + a splitting validator preserves the existing format), so no deployed config vars change shape.

**Deploy behavior:** existing Heroku apps need no config change — *provided* `CSRF_COOKIE_DOMAIN` is already set (cookie auth has required it to function since #1129, but it was previously unguarded). It's now required at boot, so the release phase fails if it's missing — see checklist.

**Local dev after pulling this:** recreate the backend container (`docker compose up -d`) so it picks up the new `.env.development`. A running container still carries the old env baked in at creation, so it boots in the hardened posture and fails loudly on the rate-limit guard — loud, but easy to misread as a broken branch.

### Checklist:

- [ ] Pre-deploy: confirm `heroku config:get CSRF_COOKIE_DOMAIN` is set on the rc and production apps (newly required at boot)
- [ ] Post-deploy cleanup (optional, any time): `heroku config:unset IS_HEROKU` on the rc and production apps
