### PR TITLE
fix(ci): deploy Cloudflare Worker via yarn, not wrangler-action npm install

### DIFF
--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -113,8 +113,25 @@ jobs:
     # A Cloudflare deploy failure should surface as a red check on THIS job but must
     # not fail the overall release (which already succeeded on AWS/Heroku).
     continue-on-error: true
+    env:
+      SKIP_YARN_COREPACK_CHECK: true
     steps:
       - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: "yarn"
+
+      # Install with yarn, not npm: this is a Yarn-workspaces monorepo whose
+      # package.json files use the `workspace:` protocol, which npm can't parse
+      # (cloudflare/wrangler-action's own `npm i wrangler` fails with
+      # EUNSUPPORTEDPROTOCOL here). Running the workspace-pinned wrangler is also
+      # the single source of truth for the version — no duplicated version string.
+      - name: Install dependencies
+        run: |
+          corepack enable
+          yarn install --immutable
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4
@@ -123,11 +140,8 @@ jobs:
           path: packages/app/dist/
 
       - name: Deploy to Cloudflare Workers
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: packages/app
-          command: deploy
-          # Keep in sync with wrangler in packages/app/package.json for local/CI parity.
-          wranglerVersion: "4.107.0"
+        working-directory: packages/app
+        run: yarn wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
### What are the relevant issues?

- https://github.com/ChristopherChudzicki/math3d-next/issues/1176

Follow-up fix to the merged dual-publish PR (#1181): the new `deploy-cloudflare` job failed on the first production release.

### Description

The `deploy-cloudflare` job used `cloudflare/wrangler-action@v3`, which installs wrangler by running `npm i wrangler@<version>` in `packages/app`. In this Yarn-workspaces monorepo the package manifests use the `workspace:` protocol, which **npm cannot parse**, so the action failed before deploying:

```
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "workspace:": workspace:^
```

Fix: install with **yarn** and run the workspace-pinned wrangler directly (`yarn wrangler deploy`), authenticating via `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` env vars. This also makes `packages/app/package.json` the single source of the wrangler version (drops the duplicated `wranglerVersion` string).

Note: because the job is `continue-on-error`, this failure did **not** break the release — AWS S3/CloudFront + Heroku deployed normally, and the Worker (still on `*.workers.dev`, no custom domain) serves no users, so there was no impact.

### How can this be tested?

- Locally verified: `cd packages/app && yarn wrangler deploy --dry-run` runs wrangler 4.107.0, reads the 27 files from `dist`, and bundles cleanly.
- Real path: on the next production release the `deploy / deploy-cloudflare` job should go **green** and publish the Worker with the CI-built (correct prod `VITE_*`) artifact.

### Additional Context

No changes to the AWS/Heroku path or to `wrangler.jsonc`/`_headers`. `yarn install --immutable` mirrors the existing `build` job.