### PR TITLE
ci: fail the release when the Cloudflare Workers deploy fails

### DIFF
--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -100,10 +100,6 @@ jobs:
         env:
           HD_APP_VERSION: ${{ inputs.version }}
 
-  # Cloudflare Workers is the live origin (DNS serves Cloudflare), so a failure here
-  # fails the release. The AWS/Heroku deploy above still runs in parallel as a legacy
-  # dual-publish target until it is removed. Production-only — rc builds are dry runs
-  # (see release-rc.yml).
   deploy-cloudflare:
     needs: build
     if: ${{ !inputs.dry_run && inputs.environment == 'production' }}

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -100,19 +100,15 @@ jobs:
         env:
           HD_APP_VERSION: ${{ inputs.version }}
 
-  # Dual-publish: deploy the same build artifact to Cloudflare Workers in parallel
-  # with the AWS/Heroku deploy above. Production-only for now — rc builds are dry runs
-  # (see release-rc.yml) and stay on AWS. Independent job so a Cloudflare failure never
-  # blocks the proven AWS/Heroku path (and vice versa) during the bake period.
+  # Cloudflare Workers is the live origin (DNS serves Cloudflare), so a failure here
+  # fails the release. The AWS/Heroku deploy above still runs in parallel as a legacy
+  # dual-publish target until it is removed. Production-only — rc builds are dry runs
+  # (see release-rc.yml).
   deploy-cloudflare:
     needs: build
     if: ${{ !inputs.dry_run && inputs.environment == 'production' }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
-    # During the dual-publish bake, AWS/CloudFront is the authoritative live origin.
-    # A Cloudflare deploy failure should surface as a red check on THIS job but must
-    # not fail the overall release (which already succeeded on AWS/Heroku).
-    continue-on-error: true
     env:
       SKIP_YARN_COREPACK_CHECK: true
     steps:


### PR DESCRIPTION
### What are the relevant tickets?

- https://github.com/ChristopherChudzicki/math3d-next/issues/1176

### Description (What does it do?)

Removes `continue-on-error: true` from the `deploy-cloudflare` job in the reusable deploy workflow (along with the comment block explaining it).

That flag was deliberate during the dual-publish bake period, when AWS/CloudFront was the authoritative live origin and a Cloudflare deploy failure was only supposed to show as a red check on its own job. DNS now serves Cloudflare, so Cloudflare Workers is the main deployment — a failed Cloudflare deploy must fail the release.

The AWS/Heroku deploy job is unchanged: it still runs in parallel and still hard-fails the workflow, as a legacy dual-publish target until it's removed in a few weeks.

### How can this be tested?

Workflow-only change, so it's exercised by the next production release. To review: confirm `deploy-cloudflare` no longer has `continue-on-error`, and that both deploy jobs (`deploy` and `deploy-cloudflare`) independently gate the workflow result.

### Additional Context

Follow-up work: remove the AWS/CloudFront + S3 deploy path entirely once the Cloudflare setup has baked (part of #1176).

🤖 Generated with [Claude Code](https://claude.com/claude-code)