### PR TITLE
chore(deps): upgrade Django to 6.0

### DIFF
--- a/webserver/main/settings.py
+++ b/webserver/main/settings.py
@@ -145,6 +145,8 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django.contrib.sites",  # Required by allauth
+    # Django 6.0 requires this app be installed to use GinIndex (see scenes.Scene).
+    "django.contrib.postgres",
     "authentication",  # custom app
     "allauth",
     "allauth.account",

--- a/webserver/pyproject.toml
+++ b/webserver/pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 authors = [ { name = "Chris Chudzicki" } ]
 requires-python = ">=3.12,<3.13"
 dependencies = [
-	"Django>=5.2.16,<6.0.0",
+	"Django>=6.0.7,<7.0.0",
 	"dj-database-url>=2.3.0,<3.0.0",
 	"tqdm>=4.64.1,<5.0.0",
 	"pyyaml>=6.0,<7.0",
@@ -23,7 +23,7 @@ dependencies = [
 [dependency-groups]
 dev = [
 	"mypy>=1.0.0,<2.0.0",
-	"django-stubs>=5.2.9,<6.0.0",
+	"django-stubs>=6.0.6,<7.0.0",
 	"types-tqdm>=4.64.7.15,<5.0.0",
 	"pytest>=9.0.3,<9.1.0",
 	"pytest-django>=4.5.2,<5.0.0",

--- a/webserver/uv.lock
+++ b/webserver/uv.lock
@@ -82,16 +82,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "5.2.16"
+version = "6.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/26/889449d521ae508b26de715954faecd8bcf3f740affb81b2d146a83b42a5/django-5.2.16.tar.gz", hash = "sha256:59ea02020c3136fce14bef0bbece21a10a4febef5eed1c51c22ae468efa22200", size = 10890894, upload-time = "2026-07-07T13:52:17.005Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/55/664f24ff81c9ea19cb7dfc851afeae1f3c2390c7aee01d4ded68b5c1580d/django-6.0.7.tar.gz", hash = "sha256:2998503fc083124fb58037084bfa00de323c7c743f05f1b4284e77bff0ab8890", size = 10921299, upload-time = "2026-07-07T13:51:26.485Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/13/1e5e3e4c15dcecb04281b3cb2a46a4670e1cef131068e202f6040df19224/django-5.2.16-py3-none-any.whl", hash = "sha256:04f354bf9d807a86ad1a8392fe3808d362358a8eafc322848e0e43e59b24371d", size = 8311943, upload-time = "2026-07-07T13:52:11.223Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/ec/1ce5334b6a2c52ce619c23a0be8d366a57a0e080ebb2d88266e5c849157c/django-6.0.7-py3-none-any.whl", hash = "sha256:a037427c2288443a8c02a1b02295a31c239663aa682bc50b1976afb7cf6a769e", size = 8373344, upload-time = "2026-07-07T13:51:20.007Z" },
 ]
 
 [[package]]
@@ -149,7 +149,7 @@ wheels = [
 
 [[package]]
 name = "django-stubs"
-version = "5.2.9"
+version = "6.0.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
@@ -157,9 +157,9 @@ dependencies = [
     { name = "types-pyyaml" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/01/86c921e0e19c9fa7e705bf795998dbf55eb183e7be0342a3027dc1bcbc9f/django_stubs-5.2.9.tar.gz", hash = "sha256:c192257120b08785cfe6f2f1c91f1797aceae8e9daa689c336e52c91e8f6a493", size = 257970, upload-time = "2026-01-20T23:59:27.018Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/de/1b8ccb0909970fb4a8b48426f67132164110304875abdb4e4912c55480f4/django_stubs-6.0.6.tar.gz", hash = "sha256:dfc01e052e33c7f8f0c30c3ff8eda0903ee29ac710d1e46d9effd773744a69b0", size = 281381, upload-time = "2026-06-23T08:22:54.098Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/05/4c9c419b7051eb4b350100b086be6df487f968ab672d3d370f8ccf7c3746/django_stubs-5.2.9-py3-none-any.whl", hash = "sha256:2317a7130afdaa76f6ff7f623650d7f3bf1b6c86a60f95840e14e6ec6de1a7cd", size = 508656, upload-time = "2026-01-20T23:59:25.12Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/b0/b73855fb9cf381fa1d754ea33c25f14f5b11c297f48dc3a4e0359dc3adc2/django_stubs-6.0.6-py3-none-any.whl", hash = "sha256:c488fea05a9eac40ddbdc69887f63a5c0922cb13df285291ee99c9bbc89bc4f1", size = 546491, upload-time = "2026-06-23T08:22:52.466Z" },
 ]
 
 [[package]]
@@ -301,7 +301,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "dj-database-url", specifier = ">=2.3.0,<3.0.0" },
-    { name = "django", specifier = ">=5.2.16,<6.0.0" },
+    { name = "django", specifier = ">=6.0.7,<7.0.0" },
     { name = "django-allauth", specifier = ">=65.0,<66.0" },
     { name = "django-anymail", extras = ["mailjet"], specifier = ">=10.3,<11.0" },
     { name = "django-cors-headers", specifier = ">=4.1.0,<5.0.0" },
@@ -318,7 +318,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "cssselect", specifier = ">=1.2.0,<2.0.0" },
-    { name = "django-stubs", specifier = ">=5.2.9,<6.0.0" },
+    { name = "django-stubs", specifier = ">=6.0.6,<7.0.0" },
     { name = "factory-boy", specifier = ">=3.3.3,<4.0.0" },
     { name = "lxml", specifier = ">=5.4.0,<6.0.0" },
     { name = "lxml-stubs", specifier = ">=0.5.0,<0.6.0" },


### PR DESCRIPTION
### What are the relevant issues?

N/A

### Description

Upgrades Django to its latest release.

- **Django** `5.2.16` → `6.0.7`
- **django-stubs** `5.2.9` → `6.0.6` (django-stubs now version-tracks Django, so 6.0.x matches Django 6.0)

All other backend dependencies (django-ninja, django-allauth, django-anymail, django-cors-headers, whitenoise, dj-database-url) already declare Django 6.0 support, so nothing had to be held back.

**One Django 6.0 breaking change fixed:** Django 6.0 enforces system check `postgres.E005` — `django.contrib.postgres` must be in `INSTALLED_APPS` to use `GinIndex`, which `scenes.Scene` relies on (`title_gin_trgm_index`). This is a database-tagged check, so it surfaces on `migrate` (run by the dev server on startup) rather than on a plain `manage.py check`. The fix adds `django.contrib.postgres` to `INSTALLED_APPS`; no new migration is needed since the app has no models (`makemigrations --check` confirms no drift).

### Screenshots (if appropriate)

N/A

### How can this be tested?

All run against Django 6.0.7:

- `just be test` — 139 passed (the suite promotes `DeprecationWarning` to errors, so no deprecated APIs are in use)
- `just be typecheck` — mypy clean, no issues in 92 files (with django-stubs 6.0.6)
- `manage.py migrate` and `manage.py check --database default` — no issues
- OpenAPI v1 + allauth specs regenerate with no diff, so the FE clients need no regeneration
- `yarn test-e2e` — 46 passed, exercising the auth/session/CSRF flows most likely to be affected by a Django major bump

### Additional context

N/A

### Checklist:

- [ ] N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
