### PR TITLE
chore(ci): align CI runners with Heroku-26 stack

### DIFF
--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     environment: ${{ inputs.environment }}
     env:
       SKIP_YARN_COREPACK_CHECK: true
@@ -65,7 +65,7 @@ jobs:
   deploy:
     needs: build
     if: ${{ !inputs.dry_run }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     environment: ${{ inputs.environment }}
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -103,7 +103,7 @@ jobs:
   deploy-cloudflare:
     needs: build
     if: ${{ !inputs.dry_run && inputs.environment == 'production' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     environment: ${{ inputs.environment }}
     env:
       SKIP_YARN_COREPACK_CHECK: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,7 +12,11 @@ env:
 jobs:
   e2e-tests:
     timeout-minutes: 60
-    runs-on: ubuntu-26.04
+    # Pinned to 24.04 (not 26.04 like the other jobs) because Playwright 1.57
+    # can't install browser deps on ubuntu-26.04-x64 yet. The backend under test
+    # runs in Docker, so this runner's OS has no Heroku-parity relevance. Bump to
+    # ubuntu-26.04 once a Playwright release supports it.
+    runs-on: ubuntu-24.04
     environment: "ci"
     env:
       SKIP_YARN_COREPACK_CHECK: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   e2e-tests:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     environment: "ci"
     env:
       SKIP_YARN_COREPACK_CHECK: true

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   main:
     name: Validate PR title
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
         id: lint_pr_title

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   validate-rc:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     outputs:
       rc_tag: ${{ steps.find_latest_rc.outputs.rc_tag }}
       version: ${{ steps.extract_version.outputs.version }}
@@ -79,7 +79,7 @@ jobs:
 
   create-prod-tag:
     needs: validate-rc
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   create-rc:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     environment: rc
     outputs:
       version: ${{ steps.generate_version.outputs.version }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   frontend-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     environment: "ci"
     env:
       SKIP_YARN_COREPACK_CHECK: true
@@ -33,7 +33,7 @@ jobs:
       - run: yarn test -- --test-timeout=10000
 
   webserver-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     env:
       # CI is a dev environment: the tests speak plain http (production
       # posture would 301 everything), and production behavior is pinned
@@ -47,7 +47,10 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.12.5
+          # Single source of truth, shared with local dev and the Heroku build,
+          # which both read webserver/.python-version. `3.12` resolves to the
+          # latest available 3.12 patch, matching Heroku's runtime selection.
+          python-version-file: webserver/.python-version
       - name: Install just
         uses: extractions/setup-just@v3
       - name: Install python dependencies
@@ -67,7 +70,7 @@ jobs:
     # index.ts each, regenerated, prettier-formatted, and diffed directly.
     env:
       SKIP_YARN_COREPACK_CHECK: true # https://github.com/actions/setup-node/issues/531#issuecomment-1819151412
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v6


### PR DESCRIPTION
### What are the relevant issues?

N/A — prep for moving the backend to the Heroku-26 stack (`heroku stack:set heroku-26`).

### Description

Aligns GitHub Actions CI with the Heroku-26 stack (Ubuntu 26.04) the app is moving to:

- **10 of the 11 jobs** across the 6 workflows move from `ubuntu-latest` to `ubuntu-26.04`, so CI runs on the same OS as the Heroku build. This includes the release/deploy jobs — kept consistent with the rest of the fleet by choice; they get no OS-parity benefit (they only run deploy CLIs), so if the preview image ever causes queueing there, retry or scope those back to `ubuntu-latest`.
- **The `e2e-tests` job stays on `ubuntu-24.04`** — Playwright 1.57 can't install browser deps on `ubuntu-26.04-x64` yet. That job runs the backend in Docker, so its runner OS carries no Heroku-parity relevance; the parity that matters (pytest on the host) lives in `webserver-tests`, which is on 26.04. Bump the e2e runner to 26.04 once a Playwright release supports it.
- **`webserver-tests` Python** now comes from `webserver/.python-version` (`python-version-file:`) instead of a hardcoded `3.12.5`. Heroku selects the Python version from `.python-version`, so CI now reads the exact same file Heroku does — one source of truth for local dev, CI, and the Heroku build, tracking the latest 3.12 patch.

### How can this be tested?

This PR's own CI run is the test — the `CI/ Tests` and `CI/ End-to-end Tests` workflows now execute on the new runners and against the `.python-version`-selected interpreter. Green CI here confirms the suite passes on the new setup.

### Additional context

- `ubuntu-26.04` is currently a **public preview** GitHub-hosted runner (GA pending). `ubuntu-latest` will roll to 26.04 on its own at GA, so this is the "sooner + explicit" move, not a permanent divergence. Preview images can occasionally queue or be less stable — acceptable for CI (cheap retries).
- `pyproject.toml`'s `requires-python = ">=3.12,<3.13"` is intentionally left as-is: it's a compatibility *range*, semantically distinct from the run-pin in `.python-version` that Heroku (and now CI) actually selects from.
- The actual `heroku stack:set heroku-26` is a separate infra step on the Heroku app, not part of this PR. No `app.json` exists, so there's no Review-Apps stack field to update.