### PR TITLE
feat(scene): decouple scene-loading from chrome; add /app/frame render page

### DIFF
--- a/docs/superpowers/specs/2026-07-11-og-metadata-worker-design.md
+++ b/docs/superpowers/specs/2026-07-11-og-metadata-worker-design.md
@@ -1,0 +1,468 @@
+# OG Sharing Metadata via Cloudflare Worker — Design
+
+**Date:** 2026-07-11
+**Status:** Approved design, pre-implementation
+
+## Problem
+
+Math3d is a client-rendered SPA served from Cloudflare Workers Static Assets. Social
+scrapers (Facebook, X/Twitter, Slack, Discord, LinkedIn) do not execute JavaScript, so a
+shared scene link currently unfurls with whatever static `<head>` ships in `index.html` —
+today that's a placeholder (`<title>Vite + React + TS</title>`, no OG tags at all). Every
+shared scene looks identical and broken.
+
+We want per-scene Open Graph metadata (starting with the scene **title**) injected at the
+edge, without server-side rendering the app.
+
+## Goals (v1)
+
+- A shared scene URL unfurls with that scene's **title**.
+- Home page and all non-scene routes unfurl with sensible **site-level defaults**.
+- A single **static, branded default `og:image`** on every card (per-scene screenshots are
+  a deferred fast-follow — see below).
+- Everything config-as-code, deployed by the existing `wrangler deploy` CI step.
+
+## Non-goals (v1)
+
+- Per-scene screenshot images (deferred — see "Images: deferred fast-follow").
+- Per-scene `og:description` (a static site-tagline default covers every card — this default
+  is load-bearing, see Tag set, and must not be dropped).
+- Instant cache invalidation on scene edits — v1 relies on TTL; edits are admin-only and rare,
+  so ≤ TTL staleness is acceptable. A push-invalidation design is sketched for later.
+
+## Canonical origin & the domain migration
+
+The new app (this repo) is currently served at **`https://next.math3d.org`**. Apex
+`math3d.org` presently 301-redirects to `www.math3d.org`, which is the **legacy** site — so the
+canonical origin for the new app is `next.math3d.org` **for now**, not apex.
+
+The intended end state is apex-as-canonical. The origin is consumed in two places — the static
+`index.html` defaults (as `%VITE_SITE_ORIGIN%`, substituted at build time; Vite already does this
+for `%VITE_APP_VERSION%`) and the Worker's per-scene `og:url` (a `SITE_ORIGIN` `var` in
+`wrangler.jsonc`). **To avoid the two drifting, source them from one value in CI**: `vite build`
+reads `VITE_SITE_ORIGIN`, and `wrangler deploy --var SITE_ORIGIN:$SITE_ORIGIN` injects the same
+value. Both are `https://next.math3d.org` now. (Do **not** bake apex into `og:url` yet: a scraper
+hitting `math3d.org/<key>` today is redirected to the legacy site and would unfurl the wrong page.)
+
+The apex cutover is **not** a one-line flip — two constraints:
+
+- **`next.math3d.org` must keep resolving indefinitely** (ideally a path-preserving
+  `301 → apex`). Shares already posted are cached under `next.math3d.org/<key>`; if `next` goes
+  dark, those links 404 on click. A 301 also lets re-scrapes converge on the pinned apex `og:url`.
+- **Engagement counts don't migrate.** FB/LinkedIn aggregate by `og:url`, so pre-flip shares
+  (keyed to `next`) and post-flip shares (keyed to apex) are distinct identities — likes/shares
+  won't merge. Acceptable, but know it before flipping.
+
+## Build sequencing
+
+Decided 2026-07-12: build the **render-mode route first**, _before_ the metadata Worker.
+Rationale — it's a self-contained app feature, it's the hard prerequisite for per-scene images,
+and it doubles as the tool for authoring the static default `og:image` (screenshot a nice scene
+in render mode rather than hand-designing a card). Order:
+
+1. **Render-mode route** (app) — the "App-side prerequisite" section under Images below; gets its
+   own plan. Built next.
+2. **v1 metadata Worker** (the main design in this doc) — ships with the static default image,
+   which step 1 helps produce.
+3. **Per-scene image generation** (fast-follow) — pick a compute path; SwiftShader fidelity is
+   already cleared (see Images below).
+
+## Key facts established during design
+
+- **Scene URL shape:** `/:sceneKey?` at the root (`packages/app/src/routes.tsx:39`). A scene
+  is a single path segment: `<origin>/<key>`. The only other routes are `/app/*` and a
+  multi-segment catch-all — no other single-segment routes exist, so "single non-asset segment =
+  candidate scene key" is sound.
+- **Key charset:** generated keys use `KEY_ALPHABET` (alphanumeric, no `0OlI`-type ambiguities),
+  length 10; the backend reserves only `app` and keys < 2 chars
+  (`webserver/scenes/models.py`). Keys never contain `.` or `/`. Legacy scene keys also fit
+  `[A-Za-z0-9_-]` (confirmed), so the Worker's validation regex covers them too.
+- **Metadata source:** `GET /scenes/{key}/`, `auth=None` (public) — returns the scene incl.
+  `title` (`webserver/scenes/api.py:60`). Despite `by_alias=True`, `title` has **no alias**
+  (verified in `webserver/openapi.v1.yaml`), so the Worker reads the JSON field `title`
+  directly. Production host: **`https://api.math3d.org`**.
+- **Title default:** `title` is `TextField(blank=True, default="Untitled")`
+  (`webserver/scenes/models.py:108`) — the API effectively always returns a non-empty title,
+  often the literal `"Untitled"`.
+- **Static Assets + Worker routing (IMPORTANT):** with our `compatibility_date` (≥ 2025-04-01),
+  the `assets_navigation_prefers_asset_serving` flag is **on by default**. That means a
+  **navigation request** (`Sec-Fetch-Mode: navigate` — every real browser, and any
+  headless-browser-based scraper) to a path with no matching asset is served the SPA fallback
+  `index.html` **without invoking the Worker**. So the Worker will **not** run for scene
+  navigations unless we force it. **`run_worker_first` (a glob-pattern array) is required** — see
+  Config. Requests that match a real static asset (`/assets/*`, `/og/*`, `/favicon.*`) should be
+  excluded so they keep bypassing the Worker (zero invocations for assets).
+- **Social caches** are URL-keyed; lifetimes vary (Facebook/LinkedIn effectively cache by URL
+  for days-to-indefinite; Slack re-scrapes ~every 30 min; Discord is short). Facebook (and
+  others) canonicalize on `og:url`, so pinning `og:url` to a fixed canonical consolidates
+  cache/engagement identity — verified against FB docs ("Likes and Shares for this URL will
+  aggregate at this URL").
+- **No head-manager in the app:** `packages/app` has no react-helmet/unhead; the only runtime
+  `<head>` write is `document.title` in `SceneControls`. So the Worker-injected meta tags are
+  never clobbered or duplicated for real users. (Moot for scrapers, but confirms correctness.)
+
+## Architecture
+
+Convert `packages/app/wrangler.jsonc` from Static-Assets-only to Static-Assets + a Worker.
+The Worker's sole job: for a scene-key navigation, look up the title and rewrite a small,
+fixed set of `<meta>`/`<title>` elements in the SPA shell via `HTMLRewriter`. Everything else
+passes through to `env.ASSETS` untouched.
+
+### Tag set — defaults live in `index.html`, per-scene values rewritten by the Worker
+
+`packages/app/index.html` ships baked-in defaults (also fixes the placeholder `<title>`).
+`%VITE_SITE_ORIGIN%` is substituted at build time (`https://next.math3d.org` now):
+
+```html
+<title>Math3d — Interactive 3D Math Visualization</title>
+<meta property="og:site_name" content="Math3d" />
+<meta property="og:type" content="website" />
+<meta
+  property="og:title"
+  content="Math3d — Interactive 3D Math Visualization"
+/>
+<meta property="og:description" content="Interactive 3D math visualization." />
+<meta property="og:url" content="%VITE_SITE_ORIGIN%/" />
+<meta property="og:image" content="%VITE_SITE_ORIGIN%/og/default.png" />
+<meta property="og:image:type" content="image/png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="Math3d — 3D math visualization" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta
+  name="twitter:title"
+  content="Math3d — Interactive 3D Math Visualization"
+/>
+<meta name="twitter:image" content="%VITE_SITE_ORIGIN%/og/default.png" />
+<meta name="twitter:image:alt" content="Math3d — 3D math visualization" />
+```
+
+Notes:
+
+- **`og:image:width`/`height`/`type`** matter: without them the _first_ share of a URL (before
+  any scraper has fetched+measured the PNG) can render blank/mis-cropped, fixed only on a later
+  re-scrape. The default image is a known 1200×630 PNG, so these are free to state.
+- **Keep the static `og:description`** — Discord/LinkedIn need a non-empty description to render
+  an embed at all. v1 doesn't vary it per scene; every card shares this text, which is fine.
+- **No `twitter:site`/`twitter:creator`** — Math3d has no X handle. (X inherits `og:*` via its
+  fallback chain, so `twitter:description` is unnecessary.)
+- Home page and non-scene routes are covered by these defaults: the Worker either isn't invoked
+  (a matched asset bypasses it) or runs and passes the request straight through (e.g. `/`, whose
+  step-1 filter rejects the empty segment → `env.ASSETS.fetch` serves `index.html`).
+
+The Worker, on a scene page, **overwrites the `content` attribute** of `og:title`,
+`twitter:title`, and `og:url`, and rewrites the **`<title>` element** text. It leaves
+`og:image*`/`og:site_name`/`og:description` at their defaults in v1. (The images fast-follow
+adds `og:image`/`twitter:image` rewrites.) HTMLRewriter mutates existing elements — no
+duplicate tags.
+
+> The static default `og:image` asset (`/og/default.png`, 1200×630, branded) must be
+> produced and committed to `packages/app/public/og/` before launch. **TODO: source/design
+> this image** (the render-mode route is the intended tool for this) — a launch prerequisite,
+> not a blocker for building the Worker.
+
+### Request flow (Worker `fetch` handler)
+
+1. Parse `url.pathname`. **Passthrough** (`env.ASSETS.fetch(request)`, unchanged) unless the path
+   is a single non-asset segment: reject `/app` or `/app/*`, empty/`/`, multi-segment (interior
+   `/`), and dotted (contains `.`). Otherwise it's a **candidate scene key**.
+2. **Validate the key** against `^[A-Za-z0-9_-]{2,80}$` (a superset of the real key charset). On
+   failure → passthrough defaults with **zero KV/Heroku cost**. (Cheap defense-in-depth: caps the
+   junk-path amplification surface before any backend touch.)
+3. Read the title from KV (`OG_CACHE`, key `title:<key>`):
+   - **Hit** → use the cached title.
+   - **Miss** → `fetch(`${API_BASE}/scenes/${key}/`)` with `AbortSignal.timeout(~1000ms)`. The
+     fetch uses a **bare URL string, not the incoming `request`** — no cookies/headers are
+     forwarded (the endpoint is public `auth=None`; this also rules out any header-based
+     cache-poisoning). On `200`, parse the body **defensively**: wrap `response.json()` and a
+     `typeof body.title === "string"` check in the same try/catch as the failure paths.
+     - Valid `200` → extract `title`, write it to KV behind
+       `ctx.waitUntil(put(...).catch(log))` with an `expirationTtl` (see Caching), and use it.
+     - `404` / non-2xx / **malformed or missing-title 200** / timeout / network error →
+       passthrough defaults, **no KV write** (see Caching rationale). **The page must never block
+       or error on the lookup.**
+4. Fetch the SPA shell (`env.ASSETS.fetch`) and pipe it through `HTMLRewriter`, rewriting:
+   `meta[property="og:title"]` / `meta[name="twitter:title"]` `content` (the title), the
+   `<title>` element text, and `meta[property="og:url"]` `content` (= `${SITE_ORIGIN}/<key>`).
+   Return the transformed response, setting an explicit **short/`private` `Cache-Control`** rather
+   than inheriting `index.html`'s (so no intermediary over-caches per-scene HTML). HTMLRewriter
+   preserves status/headers otherwise.
+
+**Security notes (hard constraints):**
+
+- The title is user-controlled — inject it **only** via HTMLRewriter's
+  `element.setAttribute("content", …)` / `element.setInnerContent(…, {html:false})`, which
+  HTML-escape the value. Never string-concatenate the title into raw HTML. A hostile-title unit
+  test guards this.
+- Keep `key`/`title` strictly **request-local** — no module-global mutable state in the Worker, or
+  a concurrent request on the same isolate could cross-write.
+
+### Title handling
+
+- Trim the fetched title, then **clamp to ~200 chars** (`Scene.title` is an uncapped `TextField`;
+  cards truncate ~60–90 anyway, and the clamp bounds the HTML/KV value). If empty or the literal
+  `"Untitled"` → `"Untitled scene — Math3d"`. (A user who deliberately names a scene `"Untitled"`
+  gets the generic card — acceptable.)
+- `og:url` = `${SITE_ORIGIN}/<key>` (fixed canonical, regardless of the requested host).
+
+### URL classification (why it's safe)
+
+Malformed keys are rejected by the regex (step 2). Well-formed-but-nonexistent keys (e.g.
+`/help`, `/about`, a deleted scene) 404 at the API → passthrough defaults. Reserved routes
+(`/app/*`), asset-like, and multi-segment paths are filtered before any fetch. So the common
+cases never touch KV or Heroku.
+
+## Caching rationale
+
+With `run_worker_first`, the Worker runs for **all** scene navigations (humans + scrapers), so
+the KV cache keeps human scene-loads on a ~single-ms edge read instead of a synchronous Heroku
+round-trip, and bounds Heroku load to one fetch per scene per TTL window.
+
+**Positive-cache only — no negative sentinels.** KV's free tier allows only ~1,000 writes/day.
+Writing a sentinel per 404 would let junk/crawler traffic exhaust that budget (a cheap
+amplification). Instead we only write KV on a `200`, so misses cost at most a fast Heroku 404.
+
+**The trade this makes — and its mitigation.** Positive-only means many _distinct_ junk
+single-segment paths (`/aaaa`, `/aaab`, …) are each an uncacheable Heroku 404. The key-regex
+rejects malformed junk, but valid-charset junk still reaches the origin — a new amplification
+surface that didn't exist when Static Assets served every unmatched path at zero origin cost.
+Heroku's 404 is a single indexed-key miss (cheap), so this is acceptable at our scale, but the
+right place to bound abusive volume is **a Cloudflare Rate-Limiting/WAF rule on the scene route**,
+not the cache. (Add such a rule — see Launch prerequisites.)
+
+**TTL.** Since edits are admin-only and rare, a longer TTL is fine and cuts origin load; start
+around **1 hour**, tunable. Keep it bounded even after push-invalidation ships — it's the backstop
+that self-heals the read/write race noted in Cache invalidation, so don't raise it toward infinity.
+
+## Cache invalidation (future — not in v1)
+
+v1 accepts ≤ TTL title staleness. When instant edits are wanted, use **push invalidation from
+the backend** (no polling, no separate infra):
+
+- On scene `PATCH` (`webserver/scenes/api.py:78`), after saving, the Django handler **DELETEs**
+  the key via the KV REST API (`DELETE …/storage/kv/namespaces/{ns}/values/title:<key>`). DELETE
+  (not overwrite) keeps the **Worker the sole formatter** of the KV value — the backend needn't
+  replicate the Worker's trim/`"Untitled"`-normalization; the next read repopulates from Heroku
+  (one cheap re-fetch, negligible for rare admin edits).
+- **Token:** Cloudflare KV write tokens are **account-scoped, not per-namespace** (the
+  `Workers KV Storage Write` permission group is account-wide). So the Heroku token is a single
+  account-scoped, write-only secret — acceptable, but it can write _any_ KV namespace in the
+  account. Endpoint verified: `PUT/DELETE /accounts/{account_id}/storage/kv/namespaces/{ns}/values/{key}`,
+  Bearer auth.
+- **Call it best-effort, in-request, with a strict ~1–2 s timeout**, swallowing all
+  errors/timeouts (there's no task queue — a save must never fail on a Cloudflare hiccup, and a
+  _slow_ Cloudflare must not tie up the WSGI worker for long). Don't reuse this synchronous path
+  for a high-volume write endpoint without revisiting.
+- **Residual race (document, don't over-engineer):** a Worker KV miss reads the old title from
+  Heroku and writes it via `ctx.waitUntil`; if a `PATCH` DELETE lands _between_ that read and the
+  deferred write, the stale value is repopulated and persists until TTL. DELETE doesn't eliminate
+  this. It self-heals at the TTL backstop — so **keep a bounded TTL (~1 h)** rather than raising it
+  toward infinity while this race exists. A true fix (locks/timestamps) is overkill for admin-only
+  rare edits.
+- This same PATCH hook is where the **images fast-follow** bumps `graphicsVersion` / enqueues a
+  re-render — so it's worth building once, for both.
+
+## Config-as-code changes
+
+`packages/app/wrangler.jsonc`:
+
+```jsonc
+{
+  "$schema": "../../node_modules/wrangler/config-schema.json",
+  "name": "math3d-next",
+  "compatibility_date": "2026-07-04",
+  "main": "./src/worker/index.ts",
+  "assets": {
+    "directory": "./dist",
+    "not_found_handling": "single-page-application",
+    "binding": "ASSETS",
+    // Force the Worker to run for scene navigations; keep real assets bypassing it.
+    // Exact globs to be validated with `wrangler dev` (multi-segment matching of `/*`).
+    "run_worker_first": [
+      "/*",
+      "!/assets/*",
+      "!/og/*",
+      "!/favicon.ico",
+      "!/favicon.svg",
+      "!/apple-touch-icon.png",
+      "!/index.html"
+    ]
+  },
+  "kv_namespaces": [
+    { "binding": "OG_CACHE", "id": "<prod-id>", "preview_id": "<preview-id>" }
+  ],
+  "vars": {
+    "API_BASE": "https://api.math3d.org",
+    // Committed default; overridden at deploy via `--var SITE_ORIGIN:$SITE_ORIGIN`, sourced from
+    // the same CI value as VITE_SITE_ORIGIN (see Canonical origin & the domain migration).
+    "SITE_ORIGIN": "https://next.math3d.org"
+  }
+}
+```
+
+One-time setup (documented in the plan, run once):
+
+```bash
+yarn wrangler kv namespace create OG_CACHE
+yarn wrangler kv namespace create OG_CACHE --preview
+```
+
+New/changed files:
+
+- `packages/app/src/worker/index.ts` — the Worker + `HTMLRewriter` handlers.
+- `packages/app/src/worker/*.test.ts` — Worker unit tests (workers pool — see Testing).
+- `packages/app/index.html` — real `<title>` + default OG/Twitter tags (with `%VITE_SITE_ORIGIN%`).
+- `packages/app/public/og/default.png` — static branded default card (launch prerequisite).
+- `.env.development` (+ build env) — add `VITE_SITE_ORIGIN`.
+
+No CI pipeline change: `deploy-reusable.yml` already runs `yarn wrangler deploy` after
+`yarn build` produces `./dist`.
+
+## Testing
+
+Worker unit tests via `@cloudflare/vitest-pool-workers` (runs in workerd — `HTMLRewriter` doesn't
+exist under jsdom).
+
+**Config split (required).** `packages/app` currently has one Vitest config
+(`vite.config.ts`, `environment: "jsdom"`, `include: ./src/**/*.{test,spec}.{ts,tsx}`) — which
+_matches_ `src/worker/*.test.ts`. Introduce a Vitest **`projects`** split:
+
+- **jsdom project** — the existing app tests. Move the current root `test` options
+  (`globals`, `clearMocks`, `setupFiles: ["./src/setupTests.ts"]`, `env`, `css.modules`,
+  `include`) _into_ this project, and add `exclude: ["./src/worker/**"]`.
+- **workers project** — scoped to `src/worker/**`, using the **`cloudflareTest()` Vite plugin**
+  from `@cloudflare/vitest-pool-workers` (options — e.g. `{ wrangler: { configPath: "./wrangler.jsonc" } }`
+  — passed to the plugin). **Do not** load `setupTests.ts` here (it pulls in jsdom/Testing-Library
+  globals absent under workerd, and the pool disallows a custom `environment`/`runner`).
+
+Versions: `@cloudflare/vitest-pool-workers` **≥ 0.13** (the Vitest-4 line; the older
+`defineWorkersProject`/`test.poolOptions.workers` API is **removed**) and **Vitest ≥ 4.1** (the app
+pins `^4.0.18` — raise the floor). `yarn test`/Turbo run `vitest --run`, which executes both
+projects in one invocation.
+
+Test shell: worker tests run without a build, so `./dist` (the `ASSETS` directory) may be absent —
+provide the HTML shell explicitly (a fixture string fed through `HTMLRewriter`, or a mocked
+`env.ASSETS.fetch`) rather than relying on the real asset binding.
+
+Cases:
+
+- scene key, API `200` → `og:title`/`twitter:title`/`<title>`/`og:url` all rewritten correctly;
+- empty / whitespace / `"Untitled"` title → `"Untitled scene — Math3d"` fallback;
+- over-long title → clamped to ~200 chars;
+- **hostile title** (`"><img src=x onerror=alert(1)>` and `&"<>`) → escaped, no attribute
+  breakout (round-trips JSON-decode → HTML-escape);
+- invalid key (bad charset, too long, `%2F`, CRLF) → passthrough, **no** KV/Heroku touch;
+- API `404` / timeout / 500 → shell served with default tags (no error, no KV write);
+- **malformed 200** (non-JSON body, or JSON missing a string `title`) → default tags, no KV write;
+- `/app/x`, multi-segment, dotted paths → passthrough, no fetch;
+- KV hit path → no Heroku fetch;
+- no incoming request header/cookie is forwarded to the API fetch.
+
+Notes:
+
+- `yarn start` (Vite dev) is unaffected — OG injection exists only in the built Worker; verify
+  manually with `wrangler dev` against `./dist` (also the place to validate the `run_worker_first`
+  globs).
+- The Playwright e2e suite does not exercise the Worker.
+
+## Images: deferred fast-follow (not in v1)
+
+v1 ships the static default `og:image`. Per-scene screenshots of the MathBox scene are a
+separate effort.
+
+**Fidelity spike — PASSED (2026-07-12).** The open question was whether GPU-less SwiftShader
+(Cloudflare Browser Rendering's environment) renders MathBox scenes acceptably. Tested locally
+by rendering a production scene (a translucent surface-of-revolution over a solid washer — the
+stress case for software rendering) under forced SwiftShader
+(`--use-angle=swiftshader --enable-unsafe-swiftshader`), confirming the active backend via
+`UNMASKED_RENDERER_WEBGL` = `"ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device...), SwiftShader
+driver)"` so it couldn't be a Mac-GPU false pass. Result: faithful — correct order-dependent
+alpha blending on the translucent surface, correct solid shading/occlusion, crisp
+anti-aliased axes/gridlines/labels, correct colors. Since Browser Rendering uses the same
+ANGLE+SwiftShader path, the server-side image approach is viable with **no GPU infra**. (Spike
+covered fidelity, not render-time/quota; a confirmation run on actual Browser Rendering is
+cheap but not gating.)
+
+Three viable compute paths, all storing the PNG blob in a bucket (R2 or S3) with only the URL
+
+- a `graphicsVersion` in Postgres (never blobs in the DB):
+
+1. **Cloudflare Browser Rendering + R2** — on-demand generate + cache, keyed by
+   `sceneKey + graphicsVersion`. Runs on the current **Free** plan (Browser Rendering free
+   tier: ~10 browser-min/day ≈ ~60 fresh renders/day; caching means only new/changed scenes
+   cost anything). Zero runtime to own. Daily cap is the only constraint; $5/mo Workers Paid
+   (10 browser-hr/mo ≈ ~3,600 renders) is the graceful upgrade.
+2. **Self-hosted headless Chromium on the Heroku worker** (Celery/RQ/dramatiq + Playwright) —
+   keeps data fully in-stack and reuses paid Heroku capacity; the durable cost is _owning the
+   Chromium runtime_ (buildpack, ~300–700MB RAM/render, version upgrades). Same SwiftShader
+   fidelity as option 1 (Heroku dynos have no GPU).
+3. **Hybrid** — Heroku worker calls Cloudflare Browser Rendering's REST API, stores the PNG in
+   your own S3 + Postgres URL. Your queue/triggers/storage, no Chromium runtime to own.
+
+Client-side capture (screenshot in the sharer's browser) was **rejected**: nondeterministic
+framing, attacker-controlled uploaded bytes served as public previews, can't regenerate on
+graphics changes, and only covers scenes someone actually shares.
+
+### App-side prerequisite — a deterministic "render mode"
+
+_(Being pulled forward — see Build sequencing: the next thing we build, ahead of the metadata
+Worker, and the tool for authoring the static default `og:image`.)_
+
+A headless screenshot of the app as-is has three problems — the first two confirmed by the
+fidelity spike, the third about the screenshot-taker's resource use:
+
+1. **UI chrome.** The controls sidebar/header/toolbar occupy the left third of the frame and
+   shove the scene off-center — not a clean scene image. (Also the stats.js FPS overlay:
+   `mathboxOptions.plugins` includes `"stats"` in `Scene.tsx:28`.)
+2. **Animation.** Sliders can be auto-playing on load. Slider playback is a `useInterval` in the
+   **sidebar** (`.../VariableSlider/index.tsx:116`) that advances the value into Redux — it is
+   **not** part of the Three.js render loop, and there is **no** global clock/`t` parameter.
+3. **Continuous rendering.** MathBox/Three.js runs a ~60 fps render loop. A static screenshot
+   needs exactly one settled frame; the loop is otherwise pure wasted CPU on whatever takes the
+   shot (a Browser Rendering session, a Heroku dyno). This is the main motivation.
+
+The app needs a **render mode**, toggled by a query param (name TBD — need not contain "og";
+candidates `?render` / `?screenshot` / `?still`), that:
+
+- **hides all UI chrome** by **not mounting** `Header` / `Sidebar`+`SceneControls` /
+  `ToggleKeyboardButton` (`MainPage.tsx:86–105`), and drops the stats overlay. Note the existing
+  `?controls=0` param only **CSS-hides** the sidebar while leaving it mounted
+  (`Sidebar.tsx:43,74`) — so it does **not** stop slider timers and can't be reused for this.
+  **Blocking dependency:** scene _data-loading_ currently lives inside `SceneControls`
+  (`useLoadSceneIntoRedux` — the sole `setScene` dispatcher), so not-mounting it would render a
+  _blank_ scene. Decoupling that is a precursor refactor tracked separately —
+  see `2026-07-12-scene-render-mode-decoupling-handoff.md`;
+- **stops the render loop** after the scene settles. MathBox exposes `mathbox.stop()`/`start()`
+  (→ `three.Loop.stop()`); `window.mathbox` is already wired (`Scene.tsx:37`), so it's a one-liner.
+- **freezes animation** — achieved for free by not mounting the sliders (removes the `useInterval`),
+  which also freezes each variable at its stored value;
+- does all of the above **without mutating persisted/Redux UI state**.
+
+Likely also wants a canonical default camera framing for scenes the author never re-oriented.
+Feasibility read: **moderate, no blockers.** The one fuzzy piece is **"settled" detection** —
+MathBox exposes no idle event, so render a fixed number of frames past `warmup` (or a short
+timeout) then `stop()`; with sliders unmounted the scene is deterministic, so a fixed warmup is
+likely sufficient.
+
+**Social-cache implications for images:** updating an image later reaches only _future_ shares
+and platforms that re-scrape soon (Slack ~30 min); already-posted links on FB/LinkedIn/X keep
+the old image until they expire or are manually refreshed (FB Sharing Debugger / LinkedIn Post
+Inspector; X has no reliable manual refresh). Version the image URL
+(`/og/<key>-<graphicsVersion>.png`) so re-scrapes cache-bust cleanly — the only reliable
+cross-platform bust. This tempers the "regenerate on graphics change" benefit — worth weighing
+when picking the compute path.
+
+## Launch prerequisites / open items
+
+- [ ] Produce the static branded default `og:image` (1200×630) → `public/og/default.png`.
+- [ ] At apex cutover: flip the single CI origin value to apex, **and** keep `next.math3d.org`
+      resolving (path-preserving `301 → apex`) so already-shared links survive (see Canonical
+      origin & the domain migration).
+- [ ] Create the `OG_CACHE` KV namespace (prod + preview) and paste ids into `wrangler.jsonc`.
+- [ ] Validate the `run_worker_first` globs with `wrangler dev` (confirm `/*` matches
+      single-segment scene keys and the asset exclusions bypass correctly; confirm
+      `env.ASSETS.fetch` doesn't re-enter the Worker — one invocation per scene nav, no loop).
+- [ ] Add a Cloudflare Rate-Limiting/WAF rule on the scene route to bound origin-404 abuse
+      (see Caching rationale).
+- [ ] Wire origin config from a single CI value (`VITE_SITE_ORIGIN` → build; same value →
+      `wrangler deploy --var SITE_ORIGIN:$SITE_ORIGIN`).

--- a/docs/superpowers/specs/2026-07-11-og-metadata-worker-design.md
+++ b/docs/superpowers/specs/2026-07-11-og-metadata-worker-design.md
@@ -403,46 +403,52 @@ Client-side capture (screenshot in the sharer's browser) was **rejected**: nonde
 framing, attacker-controlled uploaded bytes served as public previews, can't regenerate on
 graphics changes, and only covers scenes someone actually shares.
 
-### App-side prerequisite — a deterministic "render mode"
+### App-side prerequisite — a deterministic render mode
 
-_(Being pulled forward — see Build sequencing: the next thing we build, ahead of the metadata
-Worker, and the tool for authoring the static default `og:image`.)_
+_Implemented in PR #1209 (the `/app/frame/:sceneKey` render page). Design:
+`docs/superpowers/specs/2026-07-12-scene-render-mode-decoupling-design.md`. Summarized here
+as-built; a few details diverged from the original sketch and are noted inline._
 
 A headless screenshot of the app as-is has three problems — the first two confirmed by the
 fidelity spike, the third about the screenshot-taker's resource use:
 
-1. **UI chrome.** The controls sidebar/header/toolbar occupy the left third of the frame and
-   shove the scene off-center — not a clean scene image. (Also the stats.js FPS overlay:
-   `mathboxOptions.plugins` includes `"stats"` in `Scene.tsx:28`.)
+1. **Editor UI.** The controls sidebar/header/toolbar occupy the left third of the frame and
+   shove the scene off-center — not a clean scene image. (The stats.js FPS overlay was in
+   `mathboxOptions.plugins` too; it's now dropped from all scene rendering.)
 2. **Animation.** Sliders can be auto-playing on load. Slider playback is a `useInterval` in the
-   **sidebar** (`.../VariableSlider/index.tsx:116`) that advances the value into Redux — it is
-   **not** part of the Three.js render loop, and there is **no** global clock/`t` parameter.
+   **sidebar** (`VariableSlider`) that advances the value into Redux — it is **not** part of the
+   Three.js render loop, and there is **no** global clock/`t` parameter.
 3. **Continuous rendering.** MathBox/Three.js runs a ~60 fps render loop. A static screenshot
    needs exactly one settled frame; the loop is otherwise pure wasted CPU on whatever takes the
-   shot (a Browser Rendering session, a Heroku dyno). This is the main motivation.
+   shot (a Browser Rendering session, a Heroku dyno). This was the main motivation.
 
-The app needs a **render mode**, toggled by a query param (name TBD — need not contain "og";
-candidates `?render` / `?screenshot` / `?still`), that:
+As built, render mode is a **dedicated route** — `/app/frame/:sceneKey` → `FramePage`, rendering
+`<Scene still>` full-viewport — **not** a query param on the scene URL (a route keeps the
+frame-mode conditionals out of `MainPage`'s Header/Sidebar/banner tree; see the decoupling design
+doc). It:
 
-- **hides all UI chrome** by **not mounting** `Header` / `Sidebar`+`SceneControls` /
-  `ToggleKeyboardButton` (`MainPage.tsx:86–105`), and drops the stats overlay. Note the existing
-  `?controls=0` param only **CSS-hides** the sidebar while leaving it mounted
-  (`Sidebar.tsx:43,74`) — so it does **not** stop slider timers and can't be reused for this.
-  **Blocking dependency:** scene _data-loading_ currently lives inside `SceneControls`
-  (`useLoadSceneIntoRedux` — the sole `setScene` dispatcher), so not-mounting it would render a
-  _blank_ scene. Decoupling that is a precursor refactor tracked separately —
-  see `2026-07-12-scene-render-mode-decoupling-handoff.md`;
-- **stops the render loop** after the scene settles. MathBox exposes `mathbox.stop()`/`start()`
-  (→ `three.Loop.stop()`); `window.mathbox` is already wired (`Scene.tsx:37`), so it's a one-liner.
-- **freezes animation** — achieved for free by not mounting the sliders (removes the `useInterval`),
-  which also freezes each variable at its stored value;
+- **hides the editor UI** by **not mounting** `Header` / `Sidebar`+`SceneControls` /
+  `ToggleKeyboardButton` — `FramePage` mounts only the scene. (The existing `?controls=0` param
+  only **CSS-hides** the sidebar while leaving it mounted, so it does not stop slider timers and
+  couldn't be reused for this.) The **blocking dependency** — scene _data-loading_ used to live
+  inside `SceneControls`, so not-mounting it rendered a _blank_ scene — was removed by extracting
+  a `useSceneLoader` hook that both the editor and the render page call;
+- **stops the render loop** after the scene settles, via `mathbox.stop()` (→ `three.Loop.stop()`),
+  and sets `data-scene-ready` on the container for a screenshotter to wait on;
+- **freezes animation** for free by not mounting the sliders (removes the `useInterval`), which
+  also freezes each variable at its stored value;
 - does all of the above **without mutating persisted/Redux UI state**.
 
-Likely also wants a canonical default camera framing for scenes the author never re-oriented.
-Feasibility read: **moderate, no blockers.** The one fuzzy piece is **"settled" detection** —
-MathBox exposes no idle event, so render a fixed number of frames past `warmup` (or a short
-timeout) then `stop()`; with sliders unmounted the scene is deterministic, so a fixed warmup is
-likely sufficient.
+**"Settled" detection was the one hard part — and the original guess (a fixed frame count past
+`warmup`) proved insufficient.** MathBox exposes no idle event, and mathbox-react built the scene
+tree across more than one React commit, so its warmup queue (`getPending()`) was non-monotonic:
+it could hit 0 _between_ commit bursts before the rest of the scene enqueued, so a fixed
+frame-count settle risked a blank/half-drawn capture. Two fixes shipped — readiness gates on
+**wall-clock queue quiescence** (`STILL_QUIET_MS`) rather than a frame count, and mathbox-react
+was bumped to `1.0.1`, which creates nodes in a `useLayoutEffect` so the tree builds in one
+synchronous commit burst (removing the transient at the source). A committed e2e regression test
+(`frame-render.test.ts`) asserts the capture is content-present, not blank. A canonical default
+camera framing for un-oriented scenes remains a possible follow-up.
 
 **Social-cache implications for images:** updating an image later reaches only _future_ shares
 and platforms that re-scrape soon (Slack ~30 min); already-posted links on FB/LinkedIn/X keep

--- a/docs/superpowers/specs/2026-07-12-scene-render-mode-decoupling-design.md
+++ b/docs/superpowers/specs/2026-07-12-scene-render-mode-decoupling-design.md
@@ -106,15 +106,20 @@ const FramePage: React.FC = () => {
 
 No `Header`, `Sidebar`/`SceneControls`, `ToggleKeyboardButton`, banners, or legacy dialog. `<Scene>` fills the viewport (100% width/height, no sidebar margin).
 
+### Removing the FPS overlay (both modes)
+
+The stats.js FPS overlay (`stats` in `mathboxOptions.plugins`, `Scene.tsx:29`) is dropped from **all** scene rendering — it doesn't fit the rest of the UI and is usually obscured by the controls. `mathboxOptions.plugins` becomes `["core", "controls", "cursor"]` for interactive and frame modes alike. `controls` and `cursor` stay: `<Camera>` applies the scene's stored camera _target_ via MathBox's `<Threestrap.Controls target={controlsTarget}>` (`Camera.tsx:127–134`), which is part of the `controls` plugin — dropping it would break framing (the camera would ignore the stored target and look at the origin). The `up: Vector3(0,0,1)` camera option is retained.
+
+Because the plugin set is now identical in both modes, the `still` seam does **not** touch plugins.
+
 ### A `still` seam on `<Scene>`
 
-Add an optional `still?: boolean` prop to `<Scene>`. (The prop describes the _behavior_ — a frozen, single frame; the route is named `/app/frame/` as a URL choice. They intentionally read slightly differently.) When `still` is set:
+Add an optional `still?: boolean` prop to `<Scene>`. (The prop describes the _behavior_ — a frozen, single frame; the route is named `/app/frame/` as a URL choice. They intentionally read slightly differently.) When `still` is set, it does exactly two things:
 
-1. **Drop the FPS overlay plugin.** Interactive `mathboxOptions.plugins` is `["core", "controls", "cursor", "stats"]`; still mode uses `["core", "controls", "cursor"]` — dropping only `stats` (the stats.js FPS overlay). `controls` is **retained**: `<Camera>` applies the scene's stored camera _target_ via MathBox's `<Threestrap.Controls target={controlsTarget}>` (`Camera.tsx:127–134`), which is part of the `controls` plugin — dropping it would break framing (the camera would ignore the stored target and look at the origin). `cursor` is harmless and kept for simplicity. No user input occurs in a headless capture regardless, so keeping OrbitControls mounted costs nothing; the loop still halts via `mathbox.stop()`. The `up: Vector3(0,0,1)` camera option is retained.
-2. **Halt the render loop once settled.** There is no MathBox idle event, and with sliders unmounted the scene is deterministic, so "settled" is approximated by a **fixed warmup**: after MathBox mounts, allow a small fixed number of post-render frames (a tunable constant), then call `mathbox.stop()` (`window.mathbox` is already assigned in `Scene.tsx:37`). This ends the perpetual loop so the screenshot-taker's CPU isn't pegged.
-3. **Expose a readiness signal.** Once stopped, set `data-scene-ready="true"` on the scene container `<div>`. A headless screenshotter waits on this selector before capturing. (Neutral name — a property of "the static scene is drawn and stopped", independent of the route name.)
+1. **Halt the render loop once settled.** There is no MathBox idle event, and with sliders unmounted the scene is deterministic, so "settled" is approximated by a **fixed warmup**: after MathBox mounts, allow a small fixed number of post-render frames (a tunable constant), then call `mathbox.stop()` (`window.mathbox` is already assigned in `Scene.tsx:37`). This ends the perpetual loop so the screenshot-taker's CPU isn't pegged.
+2. **Expose a readiness signal.** Once stopped, set `data-scene-ready="true"` on the scene container `<div>`. A headless screenshotter waits on this selector before capturing. (Neutral name — a property of "the static scene is drawn and stopped", independent of the route name.)
 
-Interactive `<Scene>` (no `still`) is completely unchanged.
+Interactive `<Scene>` (no `still`) behaves as before, minus the now-removed FPS overlay.
 
 ### Determinism / freeze — verified
 
@@ -123,7 +128,7 @@ The only auto-advancing timer in the app is the slider's `useInterval` (`Variabl
 ## Files touched
 
 - **New:** `features/scene/useSceneLoader.ts`, `pages/FramePage/FramePage.tsx` (+ index), and any `FramePage.module.css` for full-viewport layout.
-- **Edit:** `features/sceneControls/SceneControls.tsx` (remove data hook + `sceneKey` prop; accept `loading`), `features/scene/Scene.tsx` (add `still` prop: plugin set, loop halt, ready attribute), `pages/MainPage/MainPage.tsx` (call `useSceneLoader`, pass `loading`), `routes.tsx` (add `frame/:sceneKey` under the `app` route → `/app/frame/:sceneKey`).
+- **Edit:** `features/sceneControls/SceneControls.tsx` (remove data hook + `sceneKey` prop; accept `loading`), `features/scene/Scene.tsx` (remove `stats` from `mathboxOptions.plugins`; add `still` prop: loop halt + ready attribute), `pages/MainPage/MainPage.tsx` (call `useSceneLoader`, pass `loading`), `routes.tsx` (add `frame/:sceneKey` under the `app` route → `/app/frame/:sceneKey`).
 
 ## Testing
 
@@ -138,3 +143,4 @@ The only auto-advancing timer in the app is the slider's `useInterval` (`Variabl
 - Scene data loads via `useSceneLoader`, independent of `SceneControls`.
 - `/app/frame/:sceneKey` renders a chrome-less, full-viewport scene with real data; the render loop stops after warmup and `data-scene-ready` appears.
 - Normal `MainPage` behavior (loading, 404 redirect, title, default-scene fallback) is unchanged, verified by unit + e2e.
+- The stats.js FPS overlay no longer appears in the interactive scene (`stats` removed from `mathboxOptions.plugins`).

--- a/docs/superpowers/specs/2026-07-12-scene-render-mode-decoupling-design.md
+++ b/docs/superpowers/specs/2026-07-12-scene-render-mode-decoupling-design.md
@@ -1,0 +1,140 @@
+# Design: Decouple scene-loading from chrome + a scene-only `/app/frame/` render page
+
+**Date:** 2026-07-12
+**Branch:** `scene-render-mode-decoupling`
+**Supersedes the investigation in:** `docs/superpowers/specs/2026-07-12-scene-render-mode-decoupling-handoff.md`
+**Unblocks:** `docs/superpowers/specs/2026-07-11-og-metadata-worker-design.md` (per-scene social-share images)
+
+## Problem
+
+`SceneControls` conflates two unrelated responsibilities:
+
+1. **Data** — `useLoadSceneIntoRedux` (`SceneControls.tsx:16`) fetches the scene (React Query), dispatches `setScene` into Redux, sets `document.title`, and handles 404 (notification + redirect).
+2. **Presentation** — renders the editor chrome (`ControlTabs`, `AddObjectButton`, `MathItemsList`).
+
+`<Scene>` renders purely from Redux — it gates on `select.hasItems(REQUIRED_ITEMS)` (`Scene.tsx:106`) and only mounts MathBox once those items exist. So `<Scene>` structurally depends on responsibility #1 having run, but #1 only runs as a side-effect of mounting the chrome for #2. You cannot hide the chrome by unmounting it without also killing scene-loading.
+
+The existing `?controls=0` param does **not** address this: `Sidebar` keeps its children mounted and merely toggles an `inert`/`aria-hidden` CSS state (`Sidebar.tsx:43,74`). `SceneControls` — and any running timer — stays mounted. It hides pixels, not the coupling.
+
+This blocks a **scene-only render page**: a URL a headless browser can load to screenshot just the 3D canvas — no header, sidebar, toolbar, or FPS overlay — for per-scene social-share images.
+
+## Goals
+
+1. Scene data loads via a hook that does **not** require `SceneControls` to be mounted.
+2. A dedicated `/app/frame/:sceneKey` route renders only the 3D scene, full-viewport, with real data.
+3. The frame page halts its render loop once the scene settles (no perpetual ~60fps) and exposes a readiness signal for a headless screenshotter.
+4. The captured frame is deterministic (no auto-advancing animation).
+5. None of this mutates persisted state (there is none) or the normal editor experience.
+
+## Non-goals (deferred)
+
+- The OG-metadata Worker and the actual screenshot/capture pipeline (separate downstream effort; this only provides the clean URL).
+- A canonical default camera framing for scenes the author never re-oriented — the frame page uses the scene's **stored** camera. Framing heuristics are a later, separate design question.
+- Any change to how the normal editor loads, redirects, titles, or falls back to the default scene.
+- **A headless animation controller** (deliberately out of scope, documented seam). The slider animation loop — `useInterval(tick, …)` inside `AnimatedSlider` (`VariableSlider/index.tsx:116`) — is driven by the slider _form UI_: `tick` dispatches the advancing `value` into Redux, which the scene then reads. Not mounting the sidebar removes that timer, which is exactly what a **still** wants (a frozen, deterministic frame). A hypothetical _live_ render route (animating, no UI) would instead need this tick relocated into a headless per-animating-slider controller that derives the same params (min/max/fps/duration/speed) and dispatches the same `patchProperty`. That controller is not built here — the still route relies on the timer's absence by design. Note the data flow already routes through Redux (the scene reads the store, not the slider component), so a future live route is additive: `headless page = loader + Scene` plus one more headless piece; it does not require reworking this design.
+
+## Part 1 — Extract `useSceneLoader`
+
+Lift the body of `useLoadSceneIntoRedux` into a standalone hook, co-located with the other scene concerns:
+
+**`packages/app/src/features/scene/useSceneLoader.ts`**
+
+```ts
+type OnNotFound = "redirect" | "silent";
+
+const useSceneLoader = (
+  sceneKey: string | undefined,
+  options?: { onNotFound?: OnNotFound },
+): { isLoading: boolean } => {
+  /* ... */
+};
+```
+
+It keeps all current responsibilities:
+
+- Fetch via `useScene(sceneKey, { enabled: sceneKey !== undefined, staleTime: Infinity })`.
+- `defaultScene` fallback when `sceneKey === undefined` (unchanged — the home page's built-in scene).
+- Dispatch `setScene` into Redux (still the only non-test `setScene` dispatcher).
+- Set `document.title` (`Math3d - <title>` / `Math3d`).
+- Return `{ isLoading }`.
+
+**The one behavioral seam is 404 handling**, controlled by `onNotFound` (default `"redirect"`):
+
+- `"redirect"` — current behavior: add the "Not found" notification, set `document.title = "Not found"`, and on confirm `navigate("/")`.
+- `"silent"` — no notification, no redirect, no navigation. The scene simply never populates Redux, so `<Scene>` stays blank. (A headless screenshotter must not be redirected or shown a dialog; it handles the missing scene via its own capture timeout.)
+
+**Consumers:**
+
+- `MainPage` calls `useSceneLoader(sceneKey)` (default redirect behavior) and passes `isLoading` to `<SceneControls loading={isLoading} />`.
+- `FramePage` calls `useSceneLoader(sceneKey, { onNotFound: "silent" })`.
+
+`SceneControls` becomes **presentation-only**: drop its `sceneKey` prop and the `useLoadSceneIntoRedux` definition entirely; accept `loading: boolean` and forward it to `ControlTabs`. It now reads Redux like every other control.
+
+**Why a hook (not a React Router `loader` or a render-null component):** a router `loader` is built to _return_ data the route consumes, but loading here is a _side-effect_ (dispatch into Redux) layered on React Query's cache — bridging loader → Redux → RQ scatters scene-loading across router config and components and duplicates the fetch paradigm. A render-null `<SceneLoader>` component is functionally equivalent to the hook; the hook is chosen because each page can hand `isLoading` straight to its own presentation without an extra element. If a future need arises to mount loading at a specific tree position, the component variant is a trivial reshape.
+
+## Part 2 — The `/app/frame/:sceneKey` render page
+
+### Route
+
+Register the route as a **child of the existing `app` route** (`routes.tsx`), alongside `help/reference`:
+
+```tsx
+{
+  path: "app",
+  children: [
+    // ...existing children (index, help/reference, catch-all)...
+    { path: "frame/:sceneKey", element: <FramePage /> },
+  ],
+}
+```
+
+`/app/` is the deliberate namespace for non-scene routes (established in #1159): scene keys own the root single-segment namespace (`/:sceneKey?`), so everything else lives under `/app/` — as `help/reference` already does. Putting the render page at `/app/frame/:sceneKey` follows that convention and avoids the root-level ambiguity a `/frame/…` route would create (a scene literally keyed `frame` sits at `/frame`).
+
+A **dedicated route** is chosen over a `?frame=1` flag on `MainPage`: frame mode hides _all_ chrome and changes render-loop behavior, so a flag would scatter conditionals through MainPage's Header / Sidebar / banners / legacy-dialog tree. A separate thin page leaves `MainPage` completely untouched — and both pages calling the same `useSceneLoader` is exactly the payoff of Part 1.
+
+### `FramePage`
+
+**`packages/app/src/pages/FramePage/FramePage.tsx`** — a thin page that renders only the scene:
+
+```tsx
+const FramePage: React.FC = () => {
+  const { sceneKey } = useParams();
+  useSceneLoader(sceneKey, { onNotFound: "silent" });
+  return <Scene still className={/* full-viewport */} />;
+};
+```
+
+No `Header`, `Sidebar`/`SceneControls`, `ToggleKeyboardButton`, banners, or legacy dialog. `<Scene>` fills the viewport (100% width/height, no sidebar margin).
+
+### A `still` seam on `<Scene>`
+
+Add an optional `still?: boolean` prop to `<Scene>`. (The prop describes the _behavior_ — a frozen, single frame; the route is named `/app/frame/` as a URL choice. They intentionally read slightly differently.) When `still` is set:
+
+1. **Drop the FPS overlay plugin.** Interactive `mathboxOptions.plugins` is `["core", "controls", "cursor", "stats"]`; still mode uses `["core", "controls", "cursor"]` — dropping only `stats` (the stats.js FPS overlay). `controls` is **retained**: `<Camera>` applies the scene's stored camera _target_ via MathBox's `<Threestrap.Controls target={controlsTarget}>` (`Camera.tsx:127–134`), which is part of the `controls` plugin — dropping it would break framing (the camera would ignore the stored target and look at the origin). `cursor` is harmless and kept for simplicity. No user input occurs in a headless capture regardless, so keeping OrbitControls mounted costs nothing; the loop still halts via `mathbox.stop()`. The `up: Vector3(0,0,1)` camera option is retained.
+2. **Halt the render loop once settled.** There is no MathBox idle event, and with sliders unmounted the scene is deterministic, so "settled" is approximated by a **fixed warmup**: after MathBox mounts, allow a small fixed number of post-render frames (a tunable constant), then call `mathbox.stop()` (`window.mathbox` is already assigned in `Scene.tsx:37`). This ends the perpetual loop so the screenshot-taker's CPU isn't pegged.
+3. **Expose a readiness signal.** Once stopped, set `data-scene-ready="true"` on the scene container `<div>`. A headless screenshotter waits on this selector before capturing. (Neutral name — a property of "the static scene is drawn and stopped", independent of the route name.)
+
+Interactive `<Scene>` (no `still`) is completely unchanged.
+
+### Determinism / freeze — verified
+
+The only auto-advancing timer in the app is the slider's `useInterval` (`VariableSlider/index.tsx:116`), which lives inside the sidebar. There is no `autoRotate`, no global clock, and no `t`. `FramePage` mounts no sidebar, so the frame is already frozen with no extra work. `<Scene>`'s camera-move `patchProperty` (`Scene.tsx:53–71`) fires only on OrbitControls' `onEnd` (a real drag). A headless capture sends no pointer input, so it never fires and no state mutation occurs — even though the `controls` plugin stays mounted.
+
+## Files touched
+
+- **New:** `features/scene/useSceneLoader.ts`, `pages/FramePage/FramePage.tsx` (+ index), and any `FramePage.module.css` for full-viewport layout.
+- **Edit:** `features/sceneControls/SceneControls.tsx` (remove data hook + `sceneKey` prop; accept `loading`), `features/scene/Scene.tsx` (add `still` prop: plugin set, loop halt, ready attribute), `pages/MainPage/MainPage.tsx` (call `useSceneLoader`, pass `loading`), `routes.tsx` (add `frame/:sceneKey` under the `app` route → `/app/frame/:sceneKey`).
+
+## Testing
+
+- **Unit (`useSceneLoader`):** dispatches `setScene` for a loaded scene; falls back to `defaultScene` when `sceneKey` is undefined; sets `document.title`; `onNotFound: "redirect"` produces notification + navigate on a 404; `onNotFound: "silent"` produces neither. (MSW + mock-api `SceneBuilder`.)
+- **Unit (`SceneControls`):** renders controls from Redux state and reflects the injected `loading` prop; no longer performs any fetch.
+- **Unit (`FramePage`):** with a loaded scene in Redux, renders the scene container and none of Header / Sidebar / ToggleKeyboardButton.
+- **Unit (`MainPage`):** unchanged behavior — loads, redirects on 404, sets title, default-scene fallback.
+- **E2E:** the suite disables 3D by default (`disable3d`), so a `/app/frame/:sceneKey` e2e asserts the _chrome is absent_ and the scene container/data are present. The actual 3D render, loop-halt, and `data-scene-ready` signal must be **eyeballed manually with 3D enabled** (run `yarn test-e2e` before declaring `packages/app` work done, per repo convention, then manually verify a real 3D frame).
+
+## Definition of done
+
+- Scene data loads via `useSceneLoader`, independent of `SceneControls`.
+- `/app/frame/:sceneKey` renders a chrome-less, full-viewport scene with real data; the render loop stops after warmup and `data-scene-ready` appears.
+- Normal `MainPage` behavior (loading, 404 redirect, title, default-scene fallback) is unchanged, verified by unit + e2e.

--- a/docs/superpowers/specs/2026-07-12-scene-render-mode-decoupling-design.md
+++ b/docs/superpowers/specs/2026-07-12-scene-render-mode-decoupling-design.md
@@ -1,8 +1,7 @@
-# Design: Decouple scene-loading from chrome + a scene-only `/app/frame/` render page
+# Design: Decouple scene-loading from the editor UI + a scene-only `/app/frame/` render page
 
 **Date:** 2026-07-12
 **Branch:** `scene-render-mode-decoupling`
-**Supersedes the investigation in:** `docs/superpowers/specs/2026-07-12-scene-render-mode-decoupling-handoff.md`
 **Unblocks:** `docs/superpowers/specs/2026-07-11-og-metadata-worker-design.md` (per-scene social-share images)
 
 ## Problem
@@ -10,9 +9,9 @@
 `SceneControls` conflates two unrelated responsibilities:
 
 1. **Data** — `useLoadSceneIntoRedux` (`SceneControls.tsx:16`) fetches the scene (React Query), dispatches `setScene` into Redux, sets `document.title`, and handles 404 (notification + redirect).
-2. **Presentation** — renders the editor chrome (`ControlTabs`, `AddObjectButton`, `MathItemsList`).
+2. **Presentation** — renders the editor UI (`ControlTabs`, `AddObjectButton`, `MathItemsList`).
 
-`<Scene>` renders purely from Redux — it gates on `select.hasItems(REQUIRED_ITEMS)` (`Scene.tsx:106`) and only mounts MathBox once those items exist. So `<Scene>` structurally depends on responsibility #1 having run, but #1 only runs as a side-effect of mounting the chrome for #2. You cannot hide the chrome by unmounting it without also killing scene-loading.
+`<Scene>` renders purely from Redux — it gates on `select.hasItems(REQUIRED_ITEMS)` (`Scene.tsx:106`) and only mounts MathBox once those items exist. So `<Scene>` structurally depends on responsibility #1 having run, but #1 only runs as a side-effect of mounting the editor UI for #2. You cannot hide that UI by unmounting it without also killing scene-loading.
 
 The existing `?controls=0` param does **not** address this: `Sidebar` keeps its children mounted and merely toggles an `inert`/`aria-hidden` CSS state (`Sidebar.tsx:43,74`). `SceneControls` — and any running timer — stays mounted. It hides pixels, not the coupling.
 
@@ -90,7 +89,7 @@ Register the route as a **child of the existing `app` route** (`routes.tsx`), al
 
 `/app/` is the deliberate namespace for non-scene routes (established in #1159): scene keys own the root single-segment namespace (`/:sceneKey?`), so everything else lives under `/app/` — as `help/reference` already does. Putting the render page at `/app/frame/:sceneKey` follows that convention and avoids the root-level ambiguity a `/frame/…` route would create (a scene literally keyed `frame` sits at `/frame`).
 
-A **dedicated route** is chosen over a `?frame=1` flag on `MainPage`: frame mode hides _all_ chrome and changes render-loop behavior, so a flag would scatter conditionals through MainPage's Header / Sidebar / banners / legacy-dialog tree. A separate thin page leaves `MainPage` completely untouched — and both pages calling the same `useSceneLoader` is exactly the payoff of Part 1.
+A **dedicated route** is chosen over a `?frame=1` flag on `MainPage`: frame mode hides _all_ editor UI and changes render-loop behavior, so a flag would scatter conditionals through MainPage's Header / Sidebar / banners / legacy-dialog tree. A separate thin page leaves `MainPage` completely untouched — and both pages calling the same `useSceneLoader` is exactly the payoff of Part 1.
 
 ### `FramePage`
 
@@ -136,11 +135,11 @@ The only auto-advancing timer in the app is the slider's `useInterval` (`Variabl
 - **Unit (`SceneControls`):** renders controls from Redux state and reflects the injected `loading` prop; no longer performs any fetch.
 - **Unit (`FramePage`):** with a loaded scene in Redux, renders the scene container and none of Header / Sidebar / ToggleKeyboardButton.
 - **Unit (`MainPage`):** unchanged behavior — loads, redirects on 404, sets title, default-scene fallback.
-- **E2E:** the suite disables 3D by default (`disable3d`), so a `/app/frame/:sceneKey` e2e asserts the _chrome is absent_ and the scene container/data are present. The actual 3D render, loop-halt, and `data-scene-ready` signal must be **eyeballed manually with 3D enabled** (run `yarn test-e2e` before declaring `packages/app` work done, per repo convention, then manually verify a real 3D frame).
+- **E2E:** the suite disables 3D by default (`disable3d`), so a `/app/frame/:sceneKey` e2e asserts the _editor UI is absent_ and the scene container/data are present. The actual 3D render, loop-halt, and `data-scene-ready` signal must be **eyeballed manually with 3D enabled** (run `yarn test-e2e` before declaring `packages/app` work done, per repo convention, then manually verify a real 3D frame).
 
 ## Definition of done
 
 - Scene data loads via `useSceneLoader`, independent of `SceneControls`.
-- `/app/frame/:sceneKey` renders a chrome-less, full-viewport scene with real data; the render loop stops after warmup and `data-scene-ready` appears.
+- `/app/frame/:sceneKey` renders a bare, full-viewport scene with real data; the render loop stops after warmup and `data-scene-ready` appears.
 - Normal `MainPage` behavior (loading, 404 redirect, title, default-scene fallback) is unchanged, verified by unit + e2e.
 - The stats.js FPS overlay no longer appears in the interactive scene (`stats` removed from `mathboxOptions.plugins`).

--- a/packages/app-tests-e2e/src/tests/frame-render.test.ts
+++ b/packages/app-tests-e2e/src/tests/frame-render.test.ts
@@ -1,0 +1,70 @@
+import type { Page } from "@playwright/test";
+import { expect } from "@playwright/test";
+import { SceneBuilder } from "@math3d/mock-api";
+import { test } from "@/fixtures/users";
+
+// The `/app/frame/:key` render page halts mathbox's render loop once the scene
+// has drawn, then flags `data-scene-ready` for a headless screenshotter. The
+// failure mode this guards against is capturing a blank or half-drawn frame:
+// if readiness fires before the scene's graphics have rendered, the OG image is
+// empty. See docs/superpowers/specs/2026-07-18-still-mode-readiness-handoff.md.
+test.use({ disable3d: false });
+
+/**
+ * Fraction of pixels in a PNG screenshot that carry strong chroma (max channel
+ * minus min channel), decoded via the browser's own image decoder and a 2D
+ * canvas (no Node image library, and no unreliable WebGL read-back).
+ *
+ * Chroma is background-agnostic: white, black, and gray backgrounds, plus the
+ * gray axes and grid lines, all read ~0, while the colored surface reads high.
+ * So the metric isolates "the 3D surface actually drew" from a blank or
+ * half-drawn capture, and is stable across GL backends (SwiftShader on CI vs a
+ * real GPU locally) because it keys off gross color mass, not exact pixels.
+ */
+const colorfulPixelRatio = (page: Page, pngBase64: string): Promise<number> =>
+  page.evaluate(async (b64) => {
+    const img = new Image();
+    await new Promise((resolve, reject) => {
+      img.onload = resolve;
+      img.onerror = reject;
+      img.src = `data:image/png;base64,${b64}`;
+    });
+    const canvas = document.createElement("canvas");
+    canvas.width = img.naturalWidth;
+    canvas.height = img.naturalHeight;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("2D canvas context unavailable");
+    ctx.drawImage(img, 0, 0);
+    const { data } = ctx.getImageData(0, 0, canvas.width, canvas.height);
+    let colorful = 0;
+    for (let i = 0; i < data.length; i += 4) {
+      const chroma =
+        Math.max(data[i], data[i + 1], data[i + 2]) -
+        Math.min(data[i], data[i + 1], data[i + 2]);
+      if (chroma > 40) colorful += 1;
+    }
+    return colorful / (data.length / 4);
+  }, pngBase64);
+
+test("frame page captures the scene after it renders, not blank", async ({
+  page,
+  prepareScene,
+}) => {
+  const scene = new SceneBuilder();
+  scene.folder({ description: "Surface" }).explicitSurface();
+  const key = await prepareScene(scene.json());
+
+  await page.goto(`/app/frame/${key}`);
+  await page.waitForSelector('[data-testid="scene"][data-scene-ready="true"]', {
+    timeout: 60_000,
+  });
+  const png = await page.getByTestId("scene").screenshot();
+  const ratio = await colorfulPixelRatio(page, png.toString("base64"));
+
+  // A fully-rendered default explicit surface fills ~0.51 of the frame with
+  // colored pixels; an empty scene (axes + grid only, i.e. what a too-early
+  // capture at the warmup transient looks like) reads 0.0. 0.1 sits far above
+  // that blank floor with a wide margin below the real render for GL-backend
+  // variance.
+  expect(ratio).toBeGreaterThan(0.1);
+});

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -57,7 +57,7 @@
     "history": "5.3.0",
     "lodash-es": "4.18.1",
     "mathbox": "^2.3.1",
-    "mathbox-react": "^0.3.0",
+    "mathbox-react": "^1.0.1",
     "mathlive": "^0.105.0",
     "ordinal": "1.0.3",
     "react": "^19.2.7",

--- a/packages/app/src/features/scene/Scene.tsx
+++ b/packages/app/src/features/scene/Scene.tsx
@@ -42,16 +42,30 @@ const mathboxOptions = {
 };
 
 // The mathbox root selection proxies three's render Loop via start()/stop() at
-// runtime (see mathbox's index.js), but these aren't in mathbox's TS types.
+// runtime (see mathbox's index.js), and carries the internal render Context on
+// `_context`. Neither is in mathbox's TS types.
+type MathboxContext = {
+  // Number of scene objects still queued in mathbox's warmup pipeline. mathbox
+  // inserts them a few per frame, pre-warming each off-screen; it reaches 0 once
+  // every object has been inserted and drawn (mathbox render/scene.js).
+  getPending: () => number;
+};
 type MathboxRoot = MathboxSelection & {
   stop: () => void;
   start: () => void;
+  _context?: MathboxContext;
 };
 
-// Frames to render before halting the loop in `still` mode. With the controls
-// sidebar (and its slider timers) unmounted the scene is deterministic, so a
-// small fixed warmup is enough to settle one clean frame.
-const STILL_WARMUP_FRAMES = 10;
+// `still`-mode readiness. mathbox drains its warmup queue a couple objects per
+// frame, so a fixed frame count under-renders any scene with more objects than
+// the count covers (e.g. a 40-object scene needs ~20 frames; at 10 it screenshots
+// half-drawn). Instead we poll `getPending()` and halt once the queue has been
+// empty for a few consecutive frames — scaling with scene complexity, and (since
+// it keys off drain state, not wall-clock) unaffected by the slow software-GL the
+// headless screenshotter runs on.
+const STILL_SETTLE_FRAMES = 3; // consecutive drained frames confirming quiescence
+const STILL_MAX_FRAMES = 300; // frame-based backstop so we never spin forever
+const STILL_FALLBACK_FRAMES = 30; // used only if `getPending` is ever unavailable
 
 const REQUIRED_ITEMS = ["axis-x", "axis-y", "axis-z", "camera"];
 const SceneContent = () => {
@@ -129,15 +143,33 @@ const Scene: React.FC<Props> = ({ className, still }) => {
     setMathbox(mb);
   }, []);
 
-  // In `still` mode, let the scene warm up for a few frames, then halt the
+  // In `still` mode, wait for mathbox's warmup queue to drain, then halt the
   // render loop and flag readiness so a screenshotter can capture a static,
-  // CPU-idle frame.
+  // fully-rendered, CPU-idle frame.
   useEffect(() => {
     if (!still || !mathbox) return undefined;
+    const context = (mathbox as MathboxRoot)._context;
+    const readPending =
+      typeof context?.getPending === "function"
+        ? () => context.getPending()
+        : null;
+
     let frame = 0;
+    let settled = 0;
+    // Guard against halting at frame 1, before any object has been queued: only
+    // count "drained" frames once we've seen the queue non-empty at least once.
+    let sawPending = false;
     let raf = requestAnimationFrame(function tick() {
       frame += 1;
-      if (frame >= STILL_WARMUP_FRAMES) {
+      if (readPending) {
+        const pending = readPending();
+        if (pending > 0) sawPending = true;
+        settled = sawPending && pending === 0 ? settled + 1 : 0;
+      }
+      const drained = readPending
+        ? settled >= STILL_SETTLE_FRAMES
+        : frame >= STILL_FALLBACK_FRAMES;
+      if (drained || frame >= STILL_MAX_FRAMES) {
         (mathbox as MathboxRoot).stop();
         setStillReady(true);
         return;

--- a/packages/app/src/features/scene/Scene.tsx
+++ b/packages/app/src/features/scene/Scene.tsx
@@ -59,11 +59,22 @@ type MathboxRoot = MathboxSelection & {
 // `still`-mode readiness. mathbox drains its warmup queue a couple objects per
 // frame, so a fixed frame count under-renders any scene with more objects than
 // the count covers (e.g. a 40-object scene needs ~20 frames; at 10 it screenshots
-// half-drawn). Instead we poll `getPending()` and halt once the queue has been
-// empty for a few consecutive frames — scaling with scene complexity, and (since
-// it keys off drain state, not wall-clock) unaffected by the slow software-GL the
-// headless screenshotter runs on.
-const STILL_SETTLE_FRAMES = 3; // consecutive drained frames confirming quiescence
+// half-drawn). Instead we poll `getPending()` and halt once the queue has stayed
+// empty for a short while — scaling with scene complexity, and (since it keys off
+// drain state, not a frame count) unaffected by the slow software-GL the headless
+// screenshotter runs on.
+//
+// mathbox-react builds the scene tree in more than one React commit (a
+// child-before-parent `forceUpdate` cascade), and the browser runs warmup frames
+// between those commits. So `getPending()` is NOT monotonic: it can drain to 0
+// between commit bursts before the next burst enqueues the rest (measured:
+// 2 -> 0 -> 8 -> 36 for a ~40-object scene). That transient zero is why we can't
+// halt on the first empty frame. We gate on WALL-CLOCK quiescence rather than a
+// frame count because the transient window is made of cheap idle frames (~8ms,
+// independent of GL speed): a few frames barely outlast it, but a few hundred
+// milliseconds clears it with margin on any hardware, including Cloudflare's
+// slower vCPUs.
+const STILL_QUIET_MS = 500; // queue must stay empty this long to count as drained
 const STILL_MAX_FRAMES = 300; // frame-based backstop so we never spin forever
 const STILL_FALLBACK_FRAMES = 30; // used only if `getPending` is ever unavailable
 
@@ -155,19 +166,24 @@ const Scene: React.FC<Props> = ({ className, still }) => {
         : null;
 
     let frame = 0;
-    let settled = 0;
-    // Guard against halting at frame 1, before any object has been queued: only
-    // count "drained" frames once we've seen the queue non-empty at least once.
+    // Timestamp of the last frame the queue was non-empty. Once the queue has
+    // been empty for `STILL_QUIET_MS` past this, the scene has drained.
+    let lastNonEmpty = performance.now();
+    // Guard against halting before any object has been queued: only trust an
+    // empty queue once we've seen it non-empty at least once.
     let sawPending = false;
     let raf = requestAnimationFrame(function tick() {
       frame += 1;
+      const now = performance.now();
       if (readPending) {
         const pending = readPending();
-        if (pending > 0) sawPending = true;
-        settled = sawPending && pending === 0 ? settled + 1 : 0;
+        if (pending > 0) {
+          sawPending = true;
+          lastNonEmpty = now;
+        }
       }
       const drained = readPending
-        ? settled >= STILL_SETTLE_FRAMES
+        ? sawPending && now - lastNonEmpty >= STILL_QUIET_MS
         : frame >= STILL_FALLBACK_FRAMES;
       if (drained || frame >= STILL_MAX_FRAMES) {
         (mathbox as MathboxRoot).stop();

--- a/packages/app/src/features/scene/Scene.tsx
+++ b/packages/app/src/features/scene/Scene.tsx
@@ -1,5 +1,5 @@
 import mergeClassNames from "classnames";
-import React, { useMemo } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import * as MB from "mathbox-react";
 import type { MathboxSelection } from "mathbox";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
@@ -23,10 +23,16 @@ import { useMathResults } from "../sceneControls/mathItems/mathScope";
 
 type Props = {
   className?: string;
+  /**
+   * Render a single still frame: warm up briefly, halt the render loop (rather
+   * than looping at ~60fps forever), and mark the container `data-scene-ready`
+   * for a headless screenshotter. Used by the `/app/frame` render page.
+   */
+  still?: boolean;
 };
 
 const mathboxOptions = {
-  plugins: ["core", "controls", "cursor", "stats"],
+  plugins: ["core", "controls", "cursor"],
   controls: {
     klass: OrbitControls,
   },
@@ -35,10 +41,17 @@ const mathboxOptions = {
   },
 };
 
-const setup = (mathbox: MathboxSelection | null) => {
-  // @ts-expect-error For debugging
-  window.mathbox = mathbox;
+// The mathbox root selection proxies three's render Loop via start()/stop() at
+// runtime (see mathbox's index.js), but these aren't in mathbox's TS types.
+type MathboxRoot = MathboxSelection & {
+  stop: () => void;
+  start: () => void;
 };
+
+// Frames to render before halting the loop in `still` mode. With the controls
+// sidebar (and its slider timers) unmounted the scene is deterministic, so a
+// small fixed warmup is enough to settle one clean frame.
+const STILL_WARMUP_FRAMES = 10;
 
 const REQUIRED_ITEMS = ["axis-x", "axis-y", "axis-z", "camera"];
 const SceneContent = () => {
@@ -101,12 +114,38 @@ const useIsOrthographic = () => {
 // ~5 minutes to ~45 seconds.
 const is3dDisabled = localStorage.getItem("disable3dScene") === "true";
 
-const Scene: React.FC<Props> = (props) => {
-  const [container, setContainer] = React.useState<HTMLDivElement | null>(null);
+const Scene: React.FC<Props> = ({ className, still }) => {
+  const [container, setContainer] = useState<HTMLDivElement | null>(null);
+  const [mathbox, setMathbox] = useState<MathboxSelection | null>(null);
+  const [stillReady, setStillReady] = useState(false);
   const hasRequired = useAppSelector(select.hasItems(REQUIRED_ITEMS));
 
   const isOrthographic = useIsOrthographic();
   const focus = isOrthographic ? ZOOM_FACTOR : 1;
+
+  const handleMathbox = useCallback((mb: MathboxSelection | null) => {
+    // @ts-expect-error Exposed for debugging
+    window.mathbox = mb;
+    setMathbox(mb);
+  }, []);
+
+  // In `still` mode, let the scene warm up for a few frames, then halt the
+  // render loop and flag readiness so a screenshotter can capture a static,
+  // CPU-idle frame.
+  useEffect(() => {
+    if (!still || !mathbox) return undefined;
+    let frame = 0;
+    let raf = requestAnimationFrame(function tick() {
+      frame += 1;
+      if (frame >= STILL_WARMUP_FRAMES) {
+        (mathbox as MathboxRoot).stop();
+        setStillReady(true);
+        return;
+      }
+      raf = requestAnimationFrame(tick);
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [still, mathbox]);
 
   // threestrap's size plugin (mathbox's resize pipeline) already listens for
   // a "resize" event on this container element directly, not just on
@@ -123,7 +162,8 @@ const Scene: React.FC<Props> = (props) => {
   return (
     <div
       data-testid="scene"
-      className={mergeClassNames(props.className)}
+      data-scene-ready={still && stillReady ? "true" : undefined}
+      className={mergeClassNames(className)}
       style={{ width: "100%", height: "100%" }}
       ref={setContainer}
     >
@@ -132,7 +172,7 @@ const Scene: React.FC<Props> = (props) => {
           container={container}
           options={mathboxOptions}
           focus={focus}
-          ref={setup}
+          ref={handleMathbox}
         >
           <SceneContent />
         </MB.Mathbox>

--- a/packages/app/src/features/scene/useSceneLoader.ts
+++ b/packages/app/src/features/scene/useSceneLoader.ts
@@ -20,8 +20,8 @@ const { actions: itemActions } = sceneSlice;
 type OnNotFound = "redirect" | "silent";
 
 /**
- * Fetches a scene by key and loads it into Redux, independently of any UI
- * chrome. This is the single place scene data-loading happens: fetch (React
+ * Fetches a scene by key and loads it into Redux, independently of any editor
+ * UI. This is the single place scene data-loading happens: fetch (React
  * Query) → `setScene` dispatch → `document.title`, plus 404 handling.
  *
  * `SceneControls` and `<Scene>` both read the resulting Redux state; neither

--- a/packages/app/src/features/scene/useSceneLoader.ts
+++ b/packages/app/src/features/scene/useSceneLoader.ts
@@ -1,0 +1,83 @@
+import { useScene, isApiError } from "@math3d/api";
+import { useEffect } from "react";
+import { useNavigate } from "react-router";
+
+import { useAppDispatch } from "@/store/hooks";
+import defaultScene from "@/store/defaultScene";
+import { sceneSlice } from "@/features/sceneControls/mathItems";
+import { useNotifications } from "@/features/notifications/NotificationsContext";
+
+const { actions: itemActions } = sceneSlice;
+
+/**
+ * How a not-found (404) scene is handled.
+ *
+ * - `"redirect"` — notify the user and navigate home. Used by the editor.
+ * - `"silent"` — do nothing; the scene simply never populates Redux. Used by
+ *   the headless `/app/frame` render page, where a screenshotter must not be
+ *   shown a dialog or redirected.
+ */
+type OnNotFound = "redirect" | "silent";
+
+/**
+ * Fetches a scene by key and loads it into Redux, independently of any UI
+ * chrome. This is the single place scene data-loading happens: fetch (React
+ * Query) → `setScene` dispatch → `document.title`, plus 404 handling.
+ *
+ * `SceneControls` and `<Scene>` both read the resulting Redux state; neither
+ * needs to be mounted for the load to occur.
+ */
+const useSceneLoader = (
+  sceneKey?: string,
+  { onNotFound = "redirect" }: { onNotFound?: OnNotFound } = {},
+): { isLoading: boolean } => {
+  const dispatch = useAppDispatch();
+
+  const { isLoading, data, error } = useScene(sceneKey, {
+    enabled: sceneKey !== undefined,
+    staleTime: Infinity,
+  });
+
+  useEffect(() => {
+    const title = data?.title ? `Math3d - ${data.title}` : "Math3d";
+    document.title = title;
+  }, [data]);
+
+  const { add: addNotification } = useNotifications();
+  const navigate = useNavigate();
+  useEffect(() => {
+    if (onNotFound !== "redirect") return;
+    if (isApiError(error, [404])) {
+      const { confirmed } = addNotification({
+        type: "alert",
+        title: "Not found",
+        body: "The requested scene could not be found.",
+      });
+      document.title = "Not found";
+
+      confirmed.then(() => {
+        navigate("/");
+      });
+    }
+  }, [error, onNotFound, addNotification, navigate]);
+
+  const scene = sceneKey === undefined ? defaultScene : data;
+
+  useEffect(() => {
+    if (!scene) return;
+    const payload = {
+      key: scene.key,
+      author: scene.author ?? null,
+      items: scene.items,
+      order: scene.itemOrder,
+      title: scene.title ?? "",
+      isLegacy: scene.isLegacy ?? false,
+    };
+    dispatch(itemActions.setScene(payload));
+  }, [dispatch, scene]);
+
+  return { isLoading };
+};
+
+export default useSceneLoader;
+export type { OnNotFound };

--- a/packages/app/src/features/sceneControls/SceneControls.tsx
+++ b/packages/app/src/features/sceneControls/SceneControls.tsx
@@ -1,74 +1,23 @@
-import { useScene, isApiError } from "@math3d/api";
+import React from "react";
 
-import React, { useEffect } from "react";
-import { useAppDispatch } from "@/store/hooks";
-
-import defaultScene from "@/store/defaultScene";
-import { useNavigate } from "react-router";
 import AddObjectButton from "./AddObjectButton";
 import ControlTabs from "./controlTabs";
-import { sceneSlice, MathItemsList } from "./mathItems";
+import { MathItemsList } from "./mathItems";
 import styles from "./SceneControls.module.css";
-import { useNotifications } from "../notifications/NotificationsContext";
-
-const { actions: itemActions } = sceneSlice;
-
-const useLoadSceneIntoRedux = (sceneKey?: string) => {
-  const dispatch = useAppDispatch();
-
-  const { isLoading, data, error } = useScene(sceneKey, {
-    enabled: sceneKey !== undefined,
-    staleTime: Infinity,
-  });
-  useEffect(() => {
-    const title = data?.title ? `Math3d - ${data.title}` : "Math3d";
-    document.title = title;
-  }, [data]);
-
-  const { add: addNotification } = useNotifications();
-  const navigate = useNavigate();
-  useEffect(() => {
-    if (isApiError(error, [404])) {
-      const { confirmed } = addNotification({
-        type: "alert",
-        title: "Not found",
-        body: "The requested scene could not be found.",
-      });
-      document.title = "Not found";
-
-      confirmed.then(() => {
-        navigate("/");
-      });
-    }
-  }, [error, addNotification, navigate]);
-
-  const scene = sceneKey === undefined ? defaultScene : data;
-
-  useEffect(() => {
-    if (!scene) return;
-    const payload = {
-      key: scene.key,
-      author: scene.author ?? null,
-      items: scene.items,
-      order: scene.itemOrder,
-      title: scene.title ?? "",
-      isLegacy: scene.isLegacy ?? false,
-    };
-    dispatch(itemActions.setScene(payload));
-  }, [dispatch, scene]);
-  return { isLoading };
-};
 
 type Props = {
-  sceneKey?: string;
+  /**
+   * Whether the scene is still loading. Scene data-loading lives in
+   * `useSceneLoader` (mounted by the page), not here — `SceneControls` is
+   * presentation-only and reads scene state from Redux.
+   */
+  loading: boolean;
 };
 
-const SceneControls: React.FC<Props> = (props) => {
-  const { sceneKey } = props;
-  const { isLoading } = useLoadSceneIntoRedux(sceneKey);
+const SceneControls: React.FC<Props> = ({ loading }) => {
   return (
     <ControlTabs
-      loading={isLoading}
+      loading={loading}
       tabBarExtraContent={
         <AddObjectButton className={styles.AddObjectButton} />
       }

--- a/packages/app/src/pages/FramePage/FramePage.spec.tsx
+++ b/packages/app/src/pages/FramePage/FramePage.spec.tsx
@@ -1,0 +1,37 @@
+import { test, expect } from "vitest";
+import { SceneBuilder, seedDb } from "@math3d/mock-api";
+import { renderTestApp, screen, waitFor, waitForAppReady } from "@/test_util";
+import { select } from "@/features/sceneControls/mathItems/sceneSlice";
+
+const REQUIRED_ITEMS = ["axis-x", "axis-y", "axis-z", "camera"];
+
+test("renders the scene with its data loaded and no editor chrome", async () => {
+  const scene = new SceneBuilder();
+  seedDb.withScene(scene.json());
+
+  const { store } = renderTestApp(`/app/frame/${scene.key}`);
+
+  // Scene data loads into Redux even though SceneControls is never mounted.
+  await waitFor(() =>
+    expect(select.hasItems(REQUIRED_ITEMS)(store.getState())).toBe(true),
+  );
+
+  // The 3D scene container is present...
+  expect(screen.getByTestId("scene")).toBeInTheDocument();
+
+  // ...but none of the editor chrome is.
+  expect(
+    screen.queryByRole("button", { name: "Collapse Controls" }),
+  ).toBeNull();
+  expect(screen.queryByRole("button", { name: "Expand Controls" })).toBeNull();
+  expect(screen.queryByTestId("toggle-keyboard-button")).toBeNull();
+});
+
+test("a missing scene neither alerts nor redirects (silent 404)", async () => {
+  const { location, queryClient } = renderTestApp("/app/frame/does-not-exist");
+
+  await waitForAppReady(queryClient);
+
+  expect(screen.queryByRole("dialog")).toBeNull();
+  expect(location.current.pathname).toBe("/app/frame/does-not-exist");
+});

--- a/packages/app/src/pages/FramePage/FramePage.spec.tsx
+++ b/packages/app/src/pages/FramePage/FramePage.spec.tsx
@@ -5,7 +5,7 @@ import { select } from "@/features/sceneControls/mathItems/sceneSlice";
 
 const REQUIRED_ITEMS = ["axis-x", "axis-y", "axis-z", "camera"];
 
-test("renders the scene with its data loaded and no editor chrome", async () => {
+test("renders the scene with its data loaded and no editor UI", async () => {
   const scene = new SceneBuilder();
   seedDb.withScene(scene.json());
 
@@ -19,7 +19,7 @@ test("renders the scene with its data loaded and no editor chrome", async () => 
   // The 3D scene container is present...
   expect(screen.getByTestId("scene")).toBeInTheDocument();
 
-  // ...but none of the editor chrome is.
+  // ...but none of the editor UI is.
   expect(
     screen.queryByRole("button", { name: "Collapse Controls" }),
   ).toBeNull();

--- a/packages/app/src/pages/FramePage/FramePage.tsx
+++ b/packages/app/src/pages/FramePage/FramePage.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { useParams } from "react-router";
+
+import Scene from "@/features/scene";
+import useSceneLoader from "@/features/scene/useSceneLoader";
+
+/**
+ * A chrome-less, scene-only view for headless screenshots. It loads the scene
+ * by key (silently — no notification/redirect on a missing scene) and renders
+ * only the 3D scene, full-viewport, in `still` mode (render loop halts after
+ * warmup). No header, sidebar, controls, or keyboard chrome.
+ */
+const FramePage: React.FC = () => {
+  const { sceneKey } = useParams();
+  useSceneLoader(sceneKey, { onNotFound: "silent" });
+  return (
+    <div style={{ position: "fixed", inset: 0 }}>
+      <Scene still />
+    </div>
+  );
+};
+
+export default FramePage;

--- a/packages/app/src/pages/FramePage/FramePage.tsx
+++ b/packages/app/src/pages/FramePage/FramePage.tsx
@@ -5,10 +5,10 @@ import Scene from "@/features/scene";
 import useSceneLoader from "@/features/scene/useSceneLoader";
 
 /**
- * A chrome-less, scene-only view for headless screenshots. It loads the scene
- * by key (silently — no notification/redirect on a missing scene) and renders
- * only the 3D scene, full-viewport, in `still` mode (render loop halts after
- * warmup). No header, sidebar, controls, or keyboard chrome.
+ * A bare, scene-only view for headless screenshots — no editor UI (no header,
+ * sidebar, controls, or virtual keyboard). It loads the scene by key (silently
+ * — no notification/redirect on a missing scene) and renders only the 3D scene,
+ * full-viewport, in `still` mode (render loop halts after warmup).
  */
 const FramePage: React.FC = () => {
   const { sceneKey } = useParams();

--- a/packages/app/src/pages/MainPage/MainPage.tsx
+++ b/packages/app/src/pages/MainPage/MainPage.tsx
@@ -6,6 +6,7 @@ import {
   useSearchParams,
 } from "react-router";
 import Scene from "@/features/scene";
+import useSceneLoader from "@/features/scene/useSceneLoader";
 import SceneControls from "@/features/sceneControls";
 import Sidebar from "@/util/components/sidebar";
 import { useBodyClass, useToggle } from "@/util/hooks";
@@ -66,6 +67,7 @@ const CONTROLS_VALUES = ["0", "1"] as const;
 const MainPage: React.FC = () => {
   useBodyClass(styles.bodyVariables);
   const { sceneKey } = useParams();
+  const { isLoading } = useSceneLoader(sceneKey);
   const isLegacy = useSelector(select.isLegacy);
   const [legacyDialogOpen, legacyDialog] = useToggle(false);
   // legacyDialogOpen lives here (not in LegacyDialog) so the banner's "View
@@ -113,7 +115,7 @@ const MainPage: React.FC = () => {
             onVisibleChange={handleControlsClick}
             label="Controls"
           >
-            <SceneControls sceneKey={sceneKey} />
+            <SceneControls loading={isLoading} />
           </Sidebar>
           <Scene
             className={

--- a/packages/app/src/routes.tsx
+++ b/packages/app/src/routes.tsx
@@ -4,6 +4,7 @@ import { Outlet } from "react-router";
 
 import OverlayHost from "@/features/overlays/OverlayHost";
 import MainPage from "./pages/MainPage";
+import FramePage from "./pages/FramePage/FramePage";
 import HelpPage from "./pages/HelpPage/HelpPage";
 import ErrorPage from "./pages/ErrorPage/ErrorPage";
 import ErrorTrigger from "./pages/ErrorPage/ErrorTrigger";
@@ -32,6 +33,9 @@ const routes: RouteObject[] = [
         children: [
           { index: true, element: <NotFoundPage /> },
           { path: "help/reference", element: <HelpPage /> },
+          // Scene-only render page for headless screenshots. Lives under /app/
+          // (the non-scene-key namespace) so it can't be mistaken for a scene.
+          { path: "frame/:sceneKey", element: <FramePage /> },
           { path: "*", element: <NotFoundPage /> },
         ],
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7546,7 +7546,7 @@ __metadata:
     jsdom: "npm:^26.1.0"
     lodash-es: "npm:4.18.1"
     mathbox: "npm:^2.3.1"
-    mathbox-react: "npm:^0.3.0"
+    mathbox-react: "npm:^1.0.1"
     mathlive: "npm:^0.105.0"
     msw: "npm:^2.0.14"
     ordinal: "npm:1.0.3"
@@ -14945,16 +14945,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"mathbox-react@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "mathbox-react@npm:0.3.0"
+"mathbox-react@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "mathbox-react@npm:1.0.1"
   dependencies:
     lodash: "npm:^4.17.21"
   peerDependencies:
     mathbox: ^2.3.1
     react: ^17.0.2 || ^18.0.0
-    three: ">=0.118.0"
-  checksum: 10/b1a0952271a9ce421f6873d116f87a1db34db01f4fa98668672b5bae0ac7e9b5c51f7db6072cf3fa88674a8f5993f80db3d91434b302aa2f0447be9fffecd144
+    three: ">=0.118.0 <0.163"
+  checksum: 10/57edf6186eaca9e90f1a045edc1f2dc75584b252f91dced6bb9bcc3b8f2b5ee670ba7016e6717d41365521a9be8852569bd14ae096722af541fce879e3a8e640
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What are the relevant tickets?

N/A — precursor refactor that unblocks the per-scene social-share image work (the OG-metadata Worker). Design doc: `docs/superpowers/specs/2026-07-12-scene-render-mode-decoupling-design.md`.

### Description (What does it do?)

Scene data-loading used to live *inside* `SceneControls` (the editor UI), so you couldn't render the 3D scene without also mounting the sidebar. This splits that apart and adds a bare, scene-only render page.

**Decoupling**
- New `useSceneLoader(sceneKey, { onNotFound })` hook holds all scene data-loading — fetch (React Query) → `setScene` into Redux → `document.title` → 404 handling — independent of any UI.
- `onNotFound: "redirect"` (the editor's existing behavior: notify + navigate home) vs `"silent"` (do nothing; used by the render page so a headless screenshotter isn't shown a dialog or redirected).
- `SceneControls` is now presentation-only: it takes a `loading` prop and reads Redux like everything else. `MainPage` owns the loader.

**Render page**
- New `/app/frame/:sceneKey` route → `FramePage`, which mounts the loader (silent 404) + `<Scene still>` full-viewport, with **no** editor UI — no header, sidebar, controls, or virtual keyboard. Placed under `/app/` (the non-scene-key namespace, per #1159) so it can't be mistaken for a scene key.
- New `Scene` `still` prop: renders until mathbox's warmup queue has drained and stayed quiescent, halts the render loop (`mathbox.stop()`), and sets `data-scene-ready` on the container for a screenshotter to wait on. Animation freezes for free (the only auto-advancing timer is the slider's `useInterval`, which lives in the now-unmounted sidebar).
- Dropped the stats.js FPS overlay plugin from **all** scene rendering (it didn't fit the UI and was usually obscured by the controls).

### Screenshots (if appropriate):

`/app/frame/:key` — bare/scene-only, fills the frame, no FPS overlay; the interactive editor is unchanged except the FPS counter is gone. (Verified in a real browser with 3D enabled — see Testing. Happy to attach the captures if useful.)

### How can this be tested?

- **Render page:** open `/app/frame/<sceneKey>` for any scene. Expect only the 3D scene, filling the viewport, no editor UI and no FPS overlay. The render loop should stop once settled (`[data-testid="scene"]` gains `data-scene-ready="true"`). A missing key should render silently — no alert, no redirect.
- **Editor regression:** the normal editor (`/`, `/:sceneKey`) should be unchanged — loading, 404 alert + redirect, title, and default-scene fallback all still work; only the FPS overlay is gone.
- **Automated:** new `FramePage.spec.tsx` covers data-loads-without-editor-UI and the silent-404 path via the full-app render harness; existing `MainPage` / sceneControls suites guard the extraction. A new Playwright e2e spec (`frame-render.test.ts`, 3D enabled) loads `/app/frame/:key`, waits for `data-scene-ready`, and asserts the capture is **content-present** — a large fraction of strongly-colored pixels, well above the empty-scene floor — rather than blank or half-drawn. That guards the exact regression the `still`-mode readiness change fixes; the `data-scene-ready` mechanics themselves need real WebGL (mocked in jsdom).

### Additional Context

- **Deliberately out of scope (documented seam):** a *live* (animating, no-UI) render route would need the slider's tick loop relocated out of `AnimatedSlider` into a headless controller. The still route wants that timer *absent*, so it's not built here — see the "Non-goals" section of the design doc.
- **`still` readiness gates on queue quiescence, not a frame count.** mathbox drains its warmup queue a few objects/frame, so readiness halts only after the queue (`getPending()`) has stayed empty for a wall-clock interval (`STILL_QUIET_MS`). Historically `getPending()` was also non-monotonic — under the old passive-effect mathbox-react it could hit 0 *between* React commit bursts before the rest of the scene enqueued — so a frame-count settle risked a blank/half-drawn capture. Wall-clock quiescence clears that window with wide margin on slow (software-GL / low-vCPU) hardware like Cloudflare Browser Rendering. Verified under forced SwiftShader + 6× CPU throttle.
- **mathbox-react `^0.3.0` → `^1.0.1` (major bump, included here).** 1.0.1 creates scene nodes in a `useLayoutEffect` rather than a passive `useEffect`, so the tree builds in one synchronous commit burst before any warmup frame — removing that non-monotonic `getPending()` transient *at the source*. The app-side wall-clock quiescence guard is kept regardless, as version-independent insurance. Verified on 1.0.1: typecheck, lint, the full Playwright e2e suite, and the scene/FramePage unit tests all pass.
- `mathbox.stop()`/`start()` exist at runtime (they proxy three's render `Loop`) but aren't in mathbox's TS types (`Threestrap = any`), so `Scene` casts through a small local `MathboxRoot` type — intentional, not a mistake.