### PR TITLE
refactor(scene): extract + unit-test still-mode readiness (review follow-ups)

### DIFF
--- a/docs/superpowers/specs/2026-07-11-og-metadata-worker-design.md
+++ b/docs/superpowers/specs/2026-07-11-og-metadata-worker-design.md
@@ -450,6 +450,13 @@ synchronous commit burst (removing the transient at the source). A committed e2e
 (`frame-render.test.ts`) asserts the capture is content-present, not blank. A canonical default
 camera framing for un-oriented scenes remains a possible follow-up.
 
+**Worker-side item — not-found timeout.** The render page loads scenes with `onNotFound:
+"silent"` (no dialog/redirect for a headless viewer), so a missing or deleted scene simply never
+populates Redux and `data-scene-ready` **never fires**. The image-capture worker must therefore
+apply a **short not-found timeout** (and ideally distinguish it — e.g. probe `GET /scenes/{key}/`
+first, or cap the wait well under its full render budget) so a dead key doesn't cost a full
+browser-hold per request. Do **not** raise the worker's readiness wait to cover this case.
+
 **Social-cache implications for images:** updating an image later reaches only _future_ shares
 and platforms that re-scrape soon (Slack ~30 min); already-posted links on FB/LinkedIn/X keep
 the old image until they expire or are manually refreshed (FB Sharing Debugger / LinkedIn Post

--- a/packages/app/src/features/scene/Scene.tsx
+++ b/packages/app/src/features/scene/Scene.tsx
@@ -19,6 +19,7 @@ import useAxesInfo from "./useAxesInfo";
 import Camera from "./Camera";
 import type { OnMoveEnd } from "./Camera";
 import { ZOOM_FACTOR } from "./dollyZoom";
+import { initDrainState, stepDrain } from "./stillReadiness";
 import { useMathResults } from "../sceneControls/mathItems/mathScope";
 
 type Props = {
@@ -55,28 +56,6 @@ type MathboxRoot = MathboxSelection & {
   start: () => void;
   _context?: MathboxContext;
 };
-
-// `still`-mode readiness. mathbox drains its warmup queue a couple objects per
-// frame, so a fixed frame count under-renders any scene with more objects than
-// the count covers (e.g. a 40-object scene needs ~20 frames; at 10 it screenshots
-// half-drawn). Instead we poll `getPending()` and halt once the queue has stayed
-// empty for a short while — scaling with scene complexity, and (since it keys off
-// drain state, not a frame count) unaffected by the slow software-GL the headless
-// screenshotter runs on.
-//
-// mathbox-react builds the scene tree in more than one React commit (a
-// child-before-parent `forceUpdate` cascade), and the browser runs warmup frames
-// between those commits. So `getPending()` is NOT monotonic: it can drain to 0
-// between commit bursts before the next burst enqueues the rest (measured:
-// 2 -> 0 -> 8 -> 36 for a ~40-object scene). That transient zero is why we can't
-// halt on the first empty frame. We gate on WALL-CLOCK quiescence rather than a
-// frame count because the transient window is made of cheap idle frames (~8ms,
-// independent of GL speed): a few frames barely outlast it, but a few hundred
-// milliseconds clears it with margin on any hardware, including Cloudflare's
-// slower vCPUs.
-const STILL_QUIET_MS = 500; // queue must stay empty this long to count as drained
-const STILL_MAX_FRAMES = 300; // frame-based backstop so we never spin forever
-const STILL_FALLBACK_FRAMES = 30; // used only if `getPending` is ever unavailable
 
 const REQUIRED_ITEMS = ["axis-x", "axis-y", "axis-z", "camera"];
 const SceneContent = () => {
@@ -142,6 +121,10 @@ const is3dDisabled = localStorage.getItem("disable3dScene") === "true";
 const Scene: React.FC<Props> = ({ className, still }) => {
   const [container, setContainer] = useState<HTMLDivElement | null>(null);
   const [mathbox, setMathbox] = useState<MathboxSelection | null>(null);
+  // Single-shot latch: once ready, it stays ready for this component's life.
+  // Correct for the frame page (one load, one mathbox instance, no refetch). A
+  // future "re-render this frame" feature that swaps the mathbox instance would
+  // need to reset this so a new warmup isn't advertised as ready.
   const [stillReady, setStillReady] = useState(false);
   const hasRequired = useAppSelector(select.hasItems(REQUIRED_ITEMS));
 
@@ -165,27 +148,15 @@ const Scene: React.FC<Props> = ({ className, still }) => {
         ? () => context.getPending()
         : null;
 
-    let frame = 0;
-    // Timestamp of the last frame the queue was non-empty. Once the queue has
-    // been empty for `STILL_QUIET_MS` past this, the scene has drained.
-    let lastNonEmpty = performance.now();
-    // Guard against halting before any object has been queued: only trust an
-    // empty queue once we've seen it non-empty at least once.
-    let sawPending = false;
+    let state = initDrainState(performance.now());
     let raf = requestAnimationFrame(function tick() {
-      frame += 1;
-      const now = performance.now();
-      if (readPending) {
-        const pending = readPending();
-        if (pending > 0) {
-          sawPending = true;
-          lastNonEmpty = now;
-        }
-      }
-      const drained = readPending
-        ? sawPending && now - lastNonEmpty >= STILL_QUIET_MS
-        : frame >= STILL_FALLBACK_FRAMES;
-      if (drained || frame >= STILL_MAX_FRAMES) {
+      const pending = readPending ? readPending() : null;
+      const result = stepDrain(state, { pending, now: performance.now() });
+      state = result.state;
+      if (result.ready) {
+        // `stop()` is mathbox's documented loop control (start()/stop() on the
+        // root selection, see index.js) — stable enough to call bare, unlike
+        // the internal `_context.getPending` we feature-detect above.
         (mathbox as MathboxRoot).stop();
         setStillReady(true);
         return;

--- a/packages/app/src/features/scene/stillReadiness.spec.ts
+++ b/packages/app/src/features/scene/stillReadiness.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from "vitest";
+import {
+  initDrainState,
+  stepDrain,
+  STILL_QUIET_MS,
+  STILL_MAX_FRAMES,
+  STILL_FALLBACK_FRAMES,
+} from "./stillReadiness";
+
+type Sample = { pending: number | null; now: number };
+
+/** `ready` flag produced at each frame, driving stepDrain over a sequence. */
+const runReady = (startNow: number, samples: Sample[]): boolean[] => {
+  let state = initDrainState(startNow);
+  return samples.map((sample) => {
+    const result = stepDrain(state, sample);
+    state = result.state;
+    return result.ready;
+  });
+};
+
+/** Index of the first frame that reports ready, or -1 if it never does. */
+const firstReady = (startNow: number, samples: Sample[]): number =>
+  runReady(startNow, samples).indexOf(true);
+
+test("halts once the queue has been empty for STILL_QUIET_MS", () => {
+  const samples: Sample[] = [
+    { pending: 5, now: 0 }, // last non-empty at t=0
+    { pending: 0, now: STILL_QUIET_MS - 1 }, // not quiet long enough
+    { pending: 0, now: STILL_QUIET_MS }, // quiet ≥ threshold → ready
+  ];
+  expect(firstReady(0, samples)).toBe(2);
+});
+
+test("waits through the transient zero between commit bursts, not halting early", () => {
+  // The measured 2 → 0 → 8 → 36 sequence: a brief empty frame appears before
+  // the second burst enqueues the rest of the scene.
+  const samples: Sample[] = [
+    { pending: 2, now: 0 },
+    { pending: 0, now: 20 }, // transient zero — must NOT count as drained
+    { pending: 8, now: 40 },
+    { pending: 36, now: 60 },
+    { pending: 4, now: 100 }, // last non-empty at t=100
+    { pending: 0, now: 100 + STILL_QUIET_MS - 1 },
+    { pending: 0, now: 100 + STILL_QUIET_MS }, // ready only now
+  ];
+  const readys = runReady(0, samples);
+  expect(readys[1]).toBe(false); // did not halt on the transient zero
+  expect(readys.indexOf(true)).toBe(6);
+});
+
+test("does not halt while the queue has never been observed non-empty", () => {
+  // sawPending guard: an empty queue that was never seen filling up must not
+  // count as drained (guards against halting before the scene enqueues).
+  const samples: Sample[] = Array.from({ length: 10 }, (_, i) => ({
+    pending: 0,
+    now: (i + 1) * 16,
+  }));
+  expect(runReady(0, samples).every((ready) => ready === false)).toBe(true);
+});
+
+test("falls back to the STILL_MAX_FRAMES backstop when pending is never seen", () => {
+  const samples: Sample[] = Array.from(
+    { length: STILL_MAX_FRAMES },
+    (_, i) => ({
+      pending: 0,
+      now: (i + 1) * 16,
+    }),
+  );
+  expect(firstReady(0, samples)).toBe(STILL_MAX_FRAMES - 1);
+});
+
+test("uses STILL_FALLBACK_FRAMES when getPending is unavailable (pending null)", () => {
+  const samples: Sample[] = Array.from(
+    { length: STILL_FALLBACK_FRAMES },
+    () => ({ pending: null, now: 0 }),
+  );
+  expect(firstReady(0, samples)).toBe(STILL_FALLBACK_FRAMES - 1);
+});

--- a/packages/app/src/features/scene/stillReadiness.ts
+++ b/packages/app/src/features/scene/stillReadiness.ts
@@ -1,0 +1,75 @@
+// `still`-mode readiness: deciding when a warming-up mathbox scene has settled
+// enough to screenshot. Extracted as a pure state machine (no rAF, no mathbox)
+// so the branching — which is subtle — can be unit-tested against synthetic
+// sample sequences. `Scene.tsx` drives it once per animation frame.
+//
+// mathbox drains its warmup queue a couple objects per frame, so a fixed frame
+// count under-renders any scene with more objects than the count covers (e.g. a
+// 40-object scene needs ~20 frames; at 10 it screenshots half-drawn). Instead we
+// poll `getPending()` and halt once the queue has stayed empty for a short while
+// — scaling with scene complexity, and (since it keys off drain state, not a
+// frame count) unaffected by the slow software-GL the headless screenshotter
+// runs on.
+//
+// mathbox-react builds the scene tree in more than one React commit (a
+// child-before-parent `forceUpdate` cascade under the pre-1.0 passive-effect
+// build), and the browser runs warmup frames between those commits. So
+// `getPending()` is NOT necessarily monotonic: it can drain to 0 between commit
+// bursts before the next burst enqueues the rest (measured: 2 -> 0 -> 8 -> 36
+// for a ~40-object scene). That transient zero is why we can't halt on the first
+// empty frame. We gate on WALL-CLOCK quiescence rather than a frame count because
+// the transient window is made of cheap idle frames (~8ms, independent of GL
+// speed): a few frames barely outlast it, but a few hundred milliseconds clears
+// it with margin on any hardware, including Cloudflare's slower vCPUs.
+export const STILL_QUIET_MS = 500; // queue must stay empty this long to count as drained
+export const STILL_MAX_FRAMES = 300; // frame-based backstop so we never spin forever
+export const STILL_FALLBACK_FRAMES = 30; // used only if `getPending` is unavailable
+
+export type DrainState = {
+  /** Animation frames observed so far. */
+  frame: number;
+  /** Timestamp of the last frame the queue was seen non-empty. */
+  lastNonEmpty: number;
+  /** Whether the queue has ever been observed non-empty (the halt guard). */
+  sawPending: boolean;
+};
+
+export const initDrainState = (now: number): DrainState => ({
+  frame: 0,
+  lastNonEmpty: now,
+  sawPending: false,
+});
+
+/**
+ * Advance the drain machine by one animation frame.
+ *
+ * @param pending warmup-queue depth this frame, or `null` if `getPending` is
+ *   unavailable (then we fall back to a fixed frame count).
+ * @returns the next state and whether the scene has settled enough to halt.
+ *
+ * `sawPending` guards against halting before any object has been queued: an
+ * empty queue only counts as "drained" once we've seen it non-empty at least
+ * once. The consequence is that a scene whose queue is never observed non-empty
+ * (instant drain, or nothing async to warm up) exits only via the
+ * `STILL_MAX_FRAMES` backstop — acceptable because real scenes carry
+ * axes/grid/camera and are observed pending on the slow hardware this targets.
+ */
+export const stepDrain = (
+  state: DrainState,
+  { pending, now }: { pending: number | null; now: number },
+): { state: DrainState; ready: boolean } => {
+  const frame = state.frame + 1;
+  let { lastNonEmpty, sawPending } = state;
+  if (pending !== null && pending > 0) {
+    sawPending = true;
+    lastNonEmpty = now;
+  }
+  const drained =
+    pending !== null
+      ? sawPending && now - lastNonEmpty >= STILL_QUIET_MS
+      : frame >= STILL_FALLBACK_FRAMES;
+  return {
+    state: { frame, lastNonEmpty, sawPending },
+    ready: drained || frame >= STILL_MAX_FRAMES,
+  };
+};


### PR DESCRIPTION
### What are the relevant tickets?

N/A — post-merge follow-up to the review of #1209 (already merged). No behavior change.

### Description (What does it do?)

Addresses the low-severity comments from the #1209 review:

- **Extracts the still-mode readiness logic into a pure, unit-tested state machine.** The drain decision (the `sawPending` guard, `STILL_QUIET_MS` quiescence, the frame backstops) moves out of the `Scene.tsx` rAF effect into `stepDrain` in `stillReadiness.ts`, with the mechanism comment and constants alongside it. `Scene.tsx`'s effect just drives it once per animation frame.
- **Adds `stillReadiness.spec.ts`** — deterministic coverage the e2e can't give (mathbox is mocked in jsdom): it asserts the machine **waits through the measured `2→0→8→36` transient zero** rather than halting early, plus the normal quiescence exit, the `sawPending` guard, and both backstops.
- **Comments** two intentional-but-surprising spots: why `stop()` is called bare while `getPending` is feature-detected (`start()`/`stop()` are mathbox's documented loop control; `getPending` is an internal), and that `stillReady` is a single-shot latch (assumes one mathbox instance).
- **OG-worker design doc:** notes the image-capture worker needs a short not-found timeout, since the render page's silent 404 means `data-scene-ready` never fires for a dead scene key.

### How can this be tested?

- `yarn workspace app test src/features/scene/stillReadiness` — 5 cases over the drain branches.
- The e2e `frame-render.test.ts` still passes against the refactored readiness (verified locally); it's the real guard that the extraction didn't change runtime behavior.

### Additional Context

Pure refactor + tests + docs on logic that shipped in #1209 — no runtime behavior change. `STILL_QUIET_MS` is unchanged and still documented as version-independent insurance atop the mathbox-react 1.0.1 `useLayoutEffect` fix.