### PR TITLE
chore(just): run yarn install in `just start`

### DIFF
--- a/justfile
+++ b/justfile
@@ -7,6 +7,7 @@ default:
 
 # Start frontend and backend dev servers
 start:
+    yarn install
     docker compose up -d
     yarn start
 


### PR DESCRIPTION
### What are the relevant issues?

N/A

### Description

`just start` brought up the backend and the Vite dev server without ever syncing `node_modules`, so starting work right after a branch switch or a dependency bump ran the dev server against stale deps.

Adds `yarn install` as the first step. A no-op install with Yarn 4 takes ~1s (measured on this checkout: `Done with warnings in 0s 759ms`), so it is cheap when deps are already current and essential when they are not.

### How can this be tested?

- `just --list` still parses the recipe.
- `just start` — the install step should complete in ~1s when `node_modules` is already in sync, then proceed to `docker compose up -d` and `yarn start` as before.

### Additional context

Not `--immutable`: a legitimately-updated lockfile should install, not fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)