### PR TITLE
feat(og): static OG/Twitter head defaults + VITE_SITE_ORIGIN

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -12,6 +12,10 @@ VITE_APP_VERSION=dev
 VITE_LEGACY_APP_BASE_URL=http://localhost:3001
 VITE_ISSUE_URL=https://github.com/ChristopherChudzicki/math3d-next/issues
 VITE_DISPLAY_AUTH_FLOWS=false
+# Absolute origin the SPA is served from; baked into index.html's og:image /
+# og:url so crawlers resolve them (relative URLs don't unfurl). Per-env override
+# via the VITE_SITE_ORIGIN GitHub Actions variable.
+VITE_SITE_ORIGIN=http://math3d.localdev:3000
 ENABLE_REGISTRATION=false
 DISABLE_ALLAUTH_RATE_LIMITS=true
 

--- a/.env.development
+++ b/.env.development
@@ -13,8 +13,9 @@ VITE_LEGACY_APP_BASE_URL=http://localhost:3001
 VITE_ISSUE_URL=https://github.com/ChristopherChudzicki/math3d-next/issues
 VITE_DISPLAY_AUTH_FLOWS=false
 # Absolute origin the SPA is served from; baked into index.html's og:image /
-# og:url so crawlers resolve them (relative URLs don't unfurl). Per-env override
-# via the VITE_SITE_ORIGIN GitHub Actions variable.
+# og:url so crawlers resolve them (relative URLs don't unfurl). No trailing
+# slash (index.html appends the path). Per-env override via the
+# VITE_SITE_ORIGIN GitHub Actions variable.
 VITE_SITE_ORIGIN=http://math3d.localdev:3000
 ENABLE_REGISTRATION=false
 DISABLE_ALLAUTH_RATE_LIMITS=true

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -53,6 +53,7 @@ jobs:
           VITE_LEGACY_APP_BASE_URL: ${{ vars.VITE_LEGACY_APP_BASE_URL }}
           VITE_ISSUE_URL: ${{ vars.VITE_ISSUE_URL }}
           VITE_DISPLAY_AUTH_FLOWS: ${{ vars.VITE_DISPLAY_AUTH_FLOWS }}
+          VITE_SITE_ORIGIN: ${{ vars.VITE_SITE_ORIGIN }}
           VITE_APP_VERSION: ${{ inputs.version }}
 
       - name: Upload build artifacts

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,6 +26,7 @@ jobs:
       VITE_DISPLAY_AUTH_FLOWS: "true"
       VITE_LEGACY_APP_BASE_URL: ${{ vars.VITE_LEGACY_APP_BASE_URL }}
       VITE_ISSUE_URL: ${{ vars.VITE_ISSUE_URL }}
+      VITE_SITE_ORIGIN: ${{ vars.VITE_SITE_ORIGIN }}
       TEST_API_URL: ${{ vars.TEST_API_URL }}
       TEST_APP_URL: ${{ vars.TEST_APP_URL }}
       TEST_EMAIL_PROVIDER: ${{ vars.TEST_EMAIL_PROVIDER }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,6 +18,7 @@ jobs:
       VITE_APP_VERSION: ci
       VITE_LEGACY_APP_BASE_URL: ${{ vars.VITE_LEGACY_APP_BASE_URL }}
       VITE_ISSUE_URL: ${{ vars.VITE_ISSUE_URL }}
+      VITE_SITE_ORIGIN: ${{ vars.VITE_SITE_ORIGIN }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v6

--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -7,7 +7,48 @@
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="app-version" content="%VITE_APP_VERSION%" />
-    <title>Vite + React + TS</title>
+    <title>Math3d: Online 3d Graphing Calculator</title>
+    <meta
+      name="description"
+      content="An interactive 3D graphing calculator in your browser. Draw, animate, and share surfaces, curves, points, lines, and vectors."
+    />
+    <meta
+      name="keywords"
+      content="graphing,3d,math,calculator,threejs,mathbox,multivariable, three dimensional"
+    />
+
+    <!--
+      Open Graph / Twitter defaults for social link previews. These are the
+      site-wide defaults baked into the SPA shell; the metadata Worker rewrites
+      the per-scene title/og:title/og:url at the edge. %VITE_SITE_ORIGIN% is
+      substituted at build time (crawlers need absolute image/url values).
+    -->
+    <meta property="og:site_name" content="Math3d" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Math3d: Online 3d Graphing Calculator" />
+    <meta
+      property="og:description"
+      content="An interactive 3D graphing calculator in your browser. Draw, animate, and share surfaces, curves, points, lines, and vectors."
+    />
+    <meta property="og:url" content="%VITE_SITE_ORIGIN%/" />
+    <meta property="og:image" content="%VITE_SITE_ORIGIN%/og/default.png" />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta
+      property="og:image:alt"
+      content="Math3d — interactive 3D graphing calculator"
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta
+      name="twitter:title"
+      content="Math3d: Online 3d Graphing Calculator"
+    />
+    <meta name="twitter:image" content="%VITE_SITE_ORIGIN%/og/default.png" />
+    <meta
+      name="twitter:image:alt"
+      content="Math3d — interactive 3D graphing calculator"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/packages/app/src/features/scene/useSceneLoader.ts
+++ b/packages/app/src/features/scene/useSceneLoader.ts
@@ -1,5 +1,5 @@
 import { useScene, isApiError } from "@math3d/api";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useNavigate } from "react-router";
 
 import { useAppDispatch } from "@/store/hooks";
@@ -38,9 +38,18 @@ const useSceneLoader = (
     staleTime: Infinity,
   });
 
+  // The static <title> baked into index.html is the crawler / link-preview
+  // title for the site. Capture it on first render (before the effect below can
+  // overwrite it) so we can restore it whenever no scene title applies, rather
+  // than clobbering it with a hardcoded default. Restoring (not just skipping
+  // the write) also keeps SPA navigation correct: leaving from a titled scene
+  // back home resets the tab instead of leaving the previous scene's title.
+  const defaultTitle = useRef(document.title);
+
   useEffect(() => {
-    const title = data?.title ? `Math3d - ${data.title}` : "Math3d";
-    document.title = title;
+    document.title = data?.title
+      ? `Math3d - ${data.title}`
+      : defaultTitle.current;
   }, [data]);
 
   const { add: addNotification } = useNotifications();

--- a/packages/app/src/pages/MainPage/MainPage.spec.tsx
+++ b/packages/app/src/pages/MainPage/MainPage.spec.tsx
@@ -1,5 +1,13 @@
 import { test, expect } from "vitest";
-import { renderTestApp, screen, user, waitFor, within } from "@/test_util";
+import { seedDb } from "@math3d/mock-api";
+import {
+  renderTestApp,
+  screen,
+  user,
+  waitFor,
+  waitForAppReady,
+  within,
+} from "@/test_util";
 import invariant from "tiny-invariant";
 
 test.each([
@@ -61,6 +69,23 @@ test("Clicking the 'Expand/Collapse Controls' button toggles the controls and pr
     hash: "#foo",
     search: "",
   });
+});
+
+test("Sets the document title from the loaded scene's title", async () => {
+  const scene = seedDb.withSceneFromItems([], { title: "My Torus" });
+  renderTestApp(`/${scene.key}`);
+  await waitFor(() => {
+    expect(document.title).toBe("Math3d - My Torus");
+  });
+});
+
+test("Leaves the static document title untouched when no scene is loaded", async () => {
+  // The static <title> baked into index.html is the crawler/link-preview title.
+  // On the home/new-scene route (no scene key) the loader must not clobber it.
+  document.title = "Static Head Title";
+  const { queryClient } = renderTestApp("/");
+  await waitForAppReady(queryClient);
+  expect(document.title).toBe("Static Head Title");
 });
 
 test("Alerts and redirects home when the scene key is not found", async () => {

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -86,6 +86,7 @@ export default defineConfig({
       VITE_API_BASE_URL: Schema.string(),
       VITE_LEGACY_APP_BASE_URL: Schema.string(),
       VITE_ISSUE_URL: Schema.string(),
+      VITE_SITE_ORIGIN: Schema.string(),
       VITE_APP_VERSION: Schema.string.optional(),
       VITE_DISPLAY_AUTH_FLOWS: Schema.string.optional(),
     }),


### PR DESCRIPTION
### What are the relevant issues?

N/A — follow-up to the merged default OG image (#1222). Prerequisite for the v1 metadata Worker (per-scene link previews), which rewrites on top of these defaults.

### Description

Bakes site-wide Open Graph / Twitter meta defaults into the SPA shell so the home page and every non-scene route unfurls with the branded default card (the torus/TNB image shipped in #1222) and a real title/description. Today the served `<head>` has a placeholder `<title>` ("Vite + React + TS") and **no** OG tags at all, so links to the app unfurl bare.

- **`packages/app/index.html`** — real `<title>`, `description`, `keywords`, and a full OG/Twitter default set (`og:site_name`/`type`/`title`/`description`/`url`/`image` with image `type`/`width`/`height`/`alt`, plus `twitter:card=summary_large_image`/`title`/`image`/`image:alt`). Copy is reused verbatim from the current production site (`math3d.org`) for SEO continuity.
- **`VITE_SITE_ORIGIN`** — crawlers read the static `<head>` before JS runs, so `og:image`/`og:url` must be **absolute**. Introduces a build-time `VITE_SITE_ORIGIN`, substituted into `index.html` the same way as `%VITE_APP_VERSION%`, validated (required) in `vite.config.ts`, and threaded through the deploy + CI (`test`, `e2e`) workflows. GitHub environment variables were set for `production` (`https://next.math3d.org`), `rc`, and `ci`.
- **Title loader** (`useSceneLoader.ts`) — previously hardcoded `document.title = "Math3d"` whenever no scene was loaded, which would clobber the new static `<title>` on hydration. It now captures the shipped title on first render and restores it, so the static head is the single source of the default. Per-scene tab titles (`"Math3d - {scene}"`) are unchanged; this also keeps SPA nav correct (leaving a titled scene for `/` resets the tab instead of stranding the old title).

Per-scene `<title>`/`og:title`/`og:url` are intentionally left at defaults here — the future edge Worker rewrites them. Per-scene `og:image` is a later fast-follow.

### Screenshots (if appropriate)

N/A — no visible UI change. The effect is in link-preview cards / the browser tab title. The default card image itself landed in #1222.

### How can this be tested?

- `VITE_SITE_ORIGIN=https://next.math3d.org yarn workspace app build`, then confirm `packages/app/dist/index.html` has absolute `og:image`/`og:url` (`https://next.math3d.org/...`) and the real `<title>` — no literal `%VITE_SITE_ORIGIN%`.
- New unit tests in `MainPage.spec.tsx` cover the title loader's two branches: a loaded scene sets `document.title` to `Math3d - {title}`; with no scene the static `<title>` is left untouched (the previously-hardcoded `"Math3d"` would fail this).
- Paste a deployed URL into a link-preview validator (or Slack/Discord) to see the branded card.

### Additional context

- **`rc` origin is inferred** as `https://next.rc.math3d.org` (parallel to prod's `api.rc`/`old.rc` naming). Correct the `rc`-environment `VITE_SITE_ORIGIN` variable if the rc SPA lives elsewhere.
- `VITE_SITE_ORIGIN` is **required** in ValidateEnv on purpose — a missing value fails the build loudly rather than emitting relative OG URLs that don't unfurl. This is why it had to be added to every workflow that runs Vite (`test`, `e2e`, `deploy`).
- **Forward note for the metadata Worker PR:** the title loader captures `document.title` once on first render. If the Worker later rewrites the `<title>` *element* per-scene, a scene deep-link entry would capture the scene title as the "site default" and strand it on scene→home nav. The Worker PR must either rewrite only `og:title`/`twitter:title`/`og:url` (leave `<title>` static) or source the loader's default from a Worker-stable value. (Captured in the handoff spec.)