### PR TITLE
feat(og): per-scene OG metadata via edge Worker (pass 1)

### DIFF
--- a/docs/superpowers/specs/2026-07-11-og-metadata-worker-design.md
+++ b/docs/superpowers/specs/2026-07-11-og-metadata-worker-design.md
@@ -289,14 +289,17 @@ title as a JS constant (works, but puts a second copy of the string in a differe
    failure paths.
    - Valid `200` → extract `title`, use it.
    - `404` / non-2xx / **malformed or missing-title 200** / timeout / network error →
-     passthrough defaults. **The page must never block or error on the lookup.**
-4. Fetch the SPA shell (`env.ASSETS.fetch`) and pipe it through `HTMLRewriter`, rewriting (see
-   Title handling for the exact strings): the `<title>` element text (→ `{title} | Math3d`),
-   `meta[property="og:title"]` / `meta[name="twitter:title"]` `content` (→ **bare** `{title}`),
-   and `meta[property="og:url"]` `content` (= `${SITE_ORIGIN}/<key>`).
-   Return the transformed response, setting an explicit **short/`private` `Cache-Control`** rather
-   than inheriting `index.html`'s (so no intermediary over-caches per-scene HTML). HTMLRewriter
-   preserves status/headers otherwise.
+     serve the default shell (fail open). **The page must never block or error on the lookup.**
+4. Fetch the SPA shell (`env.ASSETS.fetch`) — in parallel with the `/meta/` lookup — and, for a
+   scene that exists, pipe it through `HTMLRewriter` (see Title handling for the exact strings):
+   `meta[property="og:url"]` `content` (= `${SITE_ORIGIN}/<key>`) always; plus, for a **titled**
+   scene, the `<title>` element text (→ `{name} | Math3d`) and
+   `meta[property="og:title"]` / `meta[name="twitter:title"]` `content` (→ **bare** `{name}`).
+   On **every** scene-key response — the rewrite path _and_ the fail-open shell (a transient
+   failure must not let a titleless generic shell be cached under a scene URL) — set an explicit
+   **short/`private` `Cache-Control`** rather than inheriting `index.html`'s. The real passthrough
+   (non-scene-key paths) keeps the asset's own caching. HTMLRewriter preserves status/headers
+   otherwise.
 
 **Security notes (hard constraints):**
 
@@ -312,26 +315,37 @@ title as a JS constant (works, but puts a second copy of the string in a differe
 Trim the fetched title, then **clamp to ~200 chars** on a **code-point boundary** (`Scene.title`
 is an uncapped `TextField`; cards truncate ~60–90 anyway, and the clamp bounds the rewritten
 value — clamp by code point, not code unit, so a surrogate pair / emoji isn't split). Let
-`name` = the trimmed+clamped title, or `"Untitled scene"` if it's empty or the literal
-`"Untitled"` (a user who deliberately names a scene `"Untitled"` gets the generic text —
+`name` = the trimmed+clamped title, or **`null`** (an "untitled" scene) if it's empty/whitespace
+or the literal default `"Untitled"` (`Scene.title` defaults to `"Untitled"`, so an unrenamed
+scene is untitled by design; a user who deliberately types `"Untitled"` is treated the same —
 acceptable).
 
-**String format (D1) — two surfaces, one brand suffix, `|` separator:**
+**An untitled scene reads like the home page:** it shows the rich site default title, not a
+scene-specific one. On such a scene the card looks brand-generic (`og:site_name` still says
+Math3d) — which is the desired behavior for a scene the author never named.
 
-- `<title>` element (tab + non-JS SEO): `` `${name} | Math3d` `` (e.g. `My Torus | Math3d`,
-  `Untitled scene | Math3d`).
-- `og:title` / `twitter:title` (card headline): **bare `name`** (e.g. `My Torus`,
-  `Untitled scene`) — the card already shows "Math3d" via `og:site_name`, so no redundant suffix.
+**String format (D1) — titled scenes only; one brand suffix, `|` separator:**
+
+- `<title>` element (tab + non-JS SEO): `` `${name} | Math3d` `` (e.g. `My Torus | Math3d`).
+- `og:title` / `twitter:title` (card headline): **bare `name`** (e.g. `My Torus`) — the card
+  already shows "Math3d" via `og:site_name`, so no redundant suffix.
+- **Untitled scene (`name === null`):** the Worker leaves the shell's static rich defaults in
+  place for `<title>`/`og:title`/`twitter:title` (it does **not** substitute an "Untitled scene"
+  string) — so an untitled deep-link matches the home page exactly.
 - **Home / no-scene** keeps the shipped rich defaults unchanged: `<title>` =
   `Math3d: Online 3d Graphing Calculator`, and `og:title` stays that same descriptive string
   (the Worker only rewrites on scene pages). `default-title` = that rich `<title>` verbatim.
-- **Client parity (required):** `useSceneLoader` must set `document.title` to the **same**
-  `` `${data.title} | Math3d` `` (changed from `` `Math3d - ${data.title}` ``) so the Worker's
-  pre-boot `<title>` and the client's post-boot value match — no format flash on deep-links.
-  Update its assertion in `MainPage.spec.tsx`. The no-scene branch restores `default-title`
-  (the rich home title), as before.
+- **Client parity (required):** `useSceneLoader` applies the **same** rule via the shared
+  `sceneTabTitle(rawTitle, siteDefault)` helper (`features/scene/sceneTitle.ts`, imported by both
+  the client and the Worker): a titled scene → `` `${name} | Math3d` `` (changed from
+  `` `Math3d - ${data.title}` ``), an untitled scene → the rich site default read from
+  `default-title`. This keeps the Worker's pre-boot `<title>` and the client's post-boot value
+  identical on deep-links — no format flash, including the common `"Untitled"` case. Assertions in
+  `MainPage.spec.tsx` cover both.
 
-`og:url` = `${SITE_ORIGIN}/<key>` (fixed canonical, regardless of the requested host).
+`og:url` = `${SITE_ORIGIN}/<key>` (fixed canonical, regardless of the requested host). This is
+rewritten for **every** scene that exists — titled or untitled — so a shared untitled scene still
+links to its own canonical URL.
 
 ### URL classification (why it's safe)
 
@@ -467,9 +481,11 @@ Worker cases (assert the **exact** strings, not just "rewritten"):
 - scene key, `/meta/` `200` `{title:"My Torus"}` → `<title>` = `My Torus | Math3d`,
   `og:title` = `twitter:title` = **bare** `My Torus`, `og:url` = `${SITE_ORIGIN}/<key>`;
   `default-title` and `og:description` left untouched;
-- empty / whitespace / `"Untitled"` title → `<title>` = `Untitled scene | Math3d`,
-  `og:title`/`twitter:title` = `Untitled scene`;
-- over-long title → clamped to ~200 chars on a code-point boundary (no split surrogate);
+- empty / whitespace / `"Untitled"` title → `<title>`/`og:title`/`twitter:title` left at the
+  shell's rich defaults (untitled reads like the home page), but `og:url` still rewritten to the
+  scene's canonical URL;
+- over-long title → clamped to ~200 chars on a code-point boundary (no split surrogate); the
+  clamp lives in the shared `sceneTitle.ts` helper and is unit-tested there;
 - **hostile title** (`"><img src=x onerror=alert(1)>` and `&"<>`) → escaped, no attribute
   breakout (round-trips JSON-decode → HTML-escape);
 - invalid key (bad charset, too long, `%2F`, CRLF) → passthrough, **no** `/meta/` touch;

--- a/docs/superpowers/specs/2026-07-11-og-metadata-worker-design.md
+++ b/docs/superpowers/specs/2026-07-11-og-metadata-worker-design.md
@@ -2,33 +2,89 @@
 
 **Date:** 2026-07-11
 **Status:** Approved design, pre-implementation
+**Revised:** 2026-08-07 — split into two passes; reconciled with shipped work
+(#1222 default image, #1223 static head + `VITE_SITE_ORIGIN`, #1209 render mode);
+added the abandonability invariant; landed the `<title>` decision; moved KV +
+API caching out of pass 1 into deferred levers.
 
 ## Problem
 
 Math3d is a client-rendered SPA served from Cloudflare Workers Static Assets. Social
 scrapers (Facebook, X/Twitter, Slack, Discord, LinkedIn) do not execute JavaScript, so a
-shared scene link currently unfurls with whatever static `<head>` ships in `index.html` —
-today that's a placeholder (`<title>Vite + React + TS</title>`, no OG tags at all). Every
-shared scene looks identical and broken.
+shared scene link unfurls with whatever static `<head>` ships in `index.html`. As of #1223
+that head carries sensible **site-level defaults** (title, description, branded default
+`og:image`) — so every scene now unfurls with a real, branded card, but they all look
+**identical**: none shows the specific scene's title.
 
 We want per-scene Open Graph metadata (starting with the scene **title**) injected at the
 edge, without server-side rendering the app.
 
-## Goals (v1)
+## Already shipped (context)
 
-- A shared scene URL unfurls with that scene's **title**.
-- Home page and all non-scene routes unfurl with sensible **site-level defaults**.
-- A single **static, branded default `og:image`** on every card (per-scene screenshots are
-  a deferred fast-follow — see below).
+The pieces this Worker builds on top of are already merged to `main`:
+
+- **#1209 — render-mode route** (`/app/frame/:sceneKey` → `FramePage`). A headless,
+  settle-detecting, single-frame scene render. It's the prerequisite/tool for pass 2
+  (per-scene images), not needed by pass 1. Design:
+  `docs/superpowers/specs/2026-07-12-scene-render-mode-decoupling-design.md`.
+- **#1222 — static branded default `og:image`** (`packages/app/public/og/default.png`,
+  1200×630) plus a committed generator pipeline under `packages/app-tests-e2e/src/og/`.
+- **#1223 — static `<head>` OG/Twitter defaults + `VITE_SITE_ORIGIN`** (commit `d2ea6c0f`).
+  `index.html` now ships the full default tag block (copy reused verbatim from live prod);
+  `%VITE_SITE_ORIGIN%` is substituted at build time and wired through every Vite-running
+  workflow (`test.yaml`, `e2e.yml`, `deploy-reusable.yml`) plus `.env.development`. It also
+  reworked `useSceneLoader` to capture the shipped `document.title` on first render and
+  restore it as the no-scene default (see "The `<title>` decision" — pass 1 changes how the
+  loader sources that default).
+
+So pass 1 is **purely the Worker**: the head defaults, the origin var, and the default
+image already exist.
+
+## The two passes
+
+The remaining work splits into two independent PRs, deliberately kept separate so the
+harder image pipeline can never gate the cheap text win:
+
+- **Pass 1 — per-scene text** (this doc's main design). Worker rewrites `<title>` /
+  `og:title` / `twitter:title` / `og:url` from the scene title. Ships with the existing
+  static default image on every card.
+- **Pass 2 — per-scene image** (see "Pass 2: per-scene images"). Adds `og:image` /
+  `twitter:image` rewrites backed by a rendered-per-scene PNG. Separate PR, separate compute
+  decision.
+
+## Abandonability invariant (hard constraint)
+
+**The SPA must remain fully functional with the entire edge layer removed.** If we drop the
+Worker in a month and serve the built `./dist` from any dumb static host (backend still on
+Django), everything works: the app boots, fetches scene data from the API exactly as it
+does today, and link previews still unfurl — just with the static default image/title
+instead of per-scene values. Graceful degradation, already true after #1223.
+
+The rule that keeps it true: **the SPA may _opportunistically consume_ edge-provided data
+purely as an optimization (hydrate-if-present, else fetch), but must never _depend_ on it.**
+Concretely for pass 1, the Worker only writes crawler-facing `<head>` tags; the SPA gets its
+data from Django and never reads anything the Worker injected as state. The one spot this
+touches — `useSceneLoader`'s default-title source — is handled below by pointing it at a
+Worker-_stable_ value, so the loader behaves identically whether or not the Worker ran.
+
+## Goals (pass 1)
+
+- A shared scene URL unfurls with that scene's **title** (`og:title` / `twitter:title`).
+- A scene URL's **browser tab and `<title>` element** show the scene title at TTFB, before
+  the app boots — and for non-JS crawlers/search.
+- Home page and all non-scene routes keep the shipped site-level **defaults**.
+- The branded **static default `og:image`** stays on every card (per-scene images are pass 2).
 - Everything config-as-code, deployed by the existing `wrangler deploy` CI step.
 
-## Non-goals (v1)
+## Non-goals (pass 1)
 
-- Per-scene screenshot images (deferred — see "Images: deferred fast-follow").
-- Per-scene `og:description` (a static site-tagline default covers every card — this default
-  is load-bearing, see Tag set, and must not be dropped).
-- Instant cache invalidation on scene edits — v1 relies on TTL; edits are admin-only and rare,
-  so ≤ TTL staleness is acceptable. A push-invalidation design is sketched for later.
+- Per-scene screenshot images (pass 2 — see "Pass 2: per-scene images").
+- Per-scene `og:description` (the static site-tagline default covers every card — this
+  default is load-bearing, see Tag set, and must not be dropped).
+- Edge caching of any kind (KV title cache, CDN-cached scene GET). Pass 1 accepts a fetch
+  per scene navigation. See "Deferred backend-load & perf levers" for why and when.
+- Instant cache invalidation on scene edits (only relevant once a cache exists — deferred
+  with KV).
 
 ## Canonical origin & the domain migration
 
@@ -37,12 +93,12 @@ The new app (this repo) is currently served at **`https://next.math3d.org`**. Ap
 canonical origin for the new app is `next.math3d.org` **for now**, not apex.
 
 The intended end state is apex-as-canonical. The origin is consumed in two places — the static
-`index.html` defaults (as `%VITE_SITE_ORIGIN%`, substituted at build time; Vite already does this
-for `%VITE_APP_VERSION%`) and the Worker's per-scene `og:url` (a `SITE_ORIGIN` `var` in
-`wrangler.jsonc`). **To avoid the two drifting, source them from one value in CI**: `vite build`
-reads `VITE_SITE_ORIGIN`, and `wrangler deploy --var SITE_ORIGIN:$SITE_ORIGIN` injects the same
-value. Both are `https://next.math3d.org` now. (Do **not** bake apex into `og:url` yet: a scraper
-hitting `math3d.org/<key>` today is redirected to the legacy site and would unfurl the wrong page.)
+`index.html` defaults (as `%VITE_SITE_ORIGIN%`, substituted at build time; shipped in #1223)
+and the Worker's per-scene `og:url` (a `SITE_ORIGIN` `var` in `wrangler.jsonc`). **To avoid the
+two drifting, source them from one value in CI**: `vite build` reads `VITE_SITE_ORIGIN`, and
+`wrangler deploy --var SITE_ORIGIN:$SITE_ORIGIN` injects the same value. Both are
+`https://next.math3d.org` now. (Do **not** bake apex into `og:url` yet: a scraper hitting
+`math3d.org/<key>` today is redirected to the legacy site and would unfurl the wrong page.)
 
 The apex cutover is **not** a one-line flip — two constraints:
 
@@ -53,23 +109,9 @@ The apex cutover is **not** a one-line flip — two constraints:
   (keyed to `next`) and post-flip shares (keyed to apex) are distinct identities — likes/shares
   won't merge. Acceptable, but know it before flipping.
 
-## Build sequencing
-
-Decided 2026-07-12: build the **render-mode route first**, _before_ the metadata Worker.
-Rationale — it's a self-contained app feature, it's the hard prerequisite for per-scene images,
-and it doubles as the tool for authoring the static default `og:image` (screenshot a nice scene
-in render mode rather than hand-designing a card). Order:
-
-1. **Render-mode route** (app) — the "App-side prerequisite" section under Images below; gets its
-   own plan. Built next.
-2. **v1 metadata Worker** (the main design in this doc) — ships with the static default image,
-   which step 1 helps produce.
-3. **Per-scene image generation** (fast-follow) — pick a compute path; SwiftShader fidelity is
-   already cleared (see Images below).
-
 ## Key facts established during design
 
-- **Scene URL shape:** `/:sceneKey?` at the root (`packages/app/src/routes.tsx:39`). A scene
+- **Scene URL shape:** `/:sceneKey?` at the root (`packages/app/src/routes.tsx`). A scene
   is a single path segment: `<origin>/<key>`. The only other routes are `/app/*` and a
   multi-segment catch-all — no other single-segment routes exist, so "single non-asset segment =
   candidate scene key" is sound.
@@ -77,12 +119,14 @@ in render mode rather than hand-designing a card). Order:
   length 10; the backend reserves only `app` and keys < 2 chars
   (`webserver/scenes/models.py`). Keys never contain `.` or `/`. Legacy scene keys also fit
   `[A-Za-z0-9_-]` (confirmed), so the Worker's validation regex covers them too.
-- **Metadata source:** `GET /scenes/{key}/`, `auth=None` (public) — returns the scene incl.
-  `title` (`webserver/scenes/api.py:60`). Despite `by_alias=True`, `title` has **no alias**
+- **Metadata source:** `GET /scenes/{key}/`, `auth=None` (public) — returns the full scene
+  incl. `title` (`webserver/scenes/api.py`). Despite `by_alias=True`, `title` has **no alias**
   (verified in `webserver/openapi.v1.yaml`), so the Worker reads the JSON field `title`
-  directly. Production host: **`https://api.math3d.org`**.
+  directly. Pass 1 reads `.title` off this full response (the double API call is accepted — see
+  Non-goals; a lean `MiniSceneSchema` exists but is only wired to the list route, so there is no
+  by-key title-only endpoint today). Production host: **`https://api.math3d.org`**.
 - **Title default:** `title` is `TextField(blank=True, default="Untitled")`
-  (`webserver/scenes/models.py:108`) — the API effectively always returns a non-empty title,
+  (`webserver/scenes/models.py`) — the API effectively always returns a non-empty title,
   often the literal `"Untitled"`.
 - **Static Assets + Worker routing (IMPORTANT):** with our `compatibility_date` (≥ 2025-04-01),
   the `assets_navigation_prefers_asset_serving` flag is **on by default**. That means a
@@ -98,68 +142,111 @@ in render mode rather than hand-designing a card). Order:
   cache/engagement identity — verified against FB docs ("Likes and Shares for this URL will
   aggregate at this URL").
 - **No head-manager in the app:** `packages/app` has no react-helmet/unhead; the only runtime
-  `<head>` write is `document.title` in `SceneControls`. So the Worker-injected meta tags are
-  never clobbered or duplicated for real users. (Moot for scrapers, but confirms correctness.)
+  `<head>` write is `document.title` in `useSceneLoader`. So the Worker-injected meta tags are
+  never clobbered or duplicated for real users, and the `<title>` element is the single tag the
+  client and Worker both touch (reconciled by the decision below).
 
-## Architecture
+## Architecture (pass 1)
 
 Convert `packages/app/wrangler.jsonc` from Static-Assets-only to Static-Assets + a Worker.
 The Worker's sole job: for a scene-key navigation, look up the title and rewrite a small,
 fixed set of `<meta>`/`<title>` elements in the SPA shell via `HTMLRewriter`. Everything else
 passes through to `env.ASSETS` untouched.
 
-### Tag set — defaults live in `index.html`, per-scene values rewritten by the Worker
+### Tag set — defaults ship in `index.html`, per-scene values rewritten by the Worker
 
-`packages/app/index.html` ships baked-in defaults (also fixes the placeholder `<title>`).
-`%VITE_SITE_ORIGIN%` is substituted at build time (`https://next.math3d.org` now):
+`packages/app/index.html` already ships the baked-in defaults (#1223), with
+`%VITE_SITE_ORIGIN%` substituted at build time:
 
 ```html
-<title>Math3d — Interactive 3D Math Visualization</title>
+<title>Math3d: Online 3d Graphing Calculator</title>
+<meta
+  name="description"
+  content="An interactive 3D graphing calculator in your browser. Draw, animate, and share surfaces, curves, points, lines, and vectors."
+/>
 <meta property="og:site_name" content="Math3d" />
 <meta property="og:type" content="website" />
+<meta property="og:title" content="Math3d: Online 3d Graphing Calculator" />
 <meta
-  property="og:title"
-  content="Math3d — Interactive 3D Math Visualization"
+  property="og:description"
+  content="An interactive 3D graphing calculator in your browser. Draw, animate, and share surfaces, curves, points, lines, and vectors."
 />
-<meta property="og:description" content="Interactive 3D math visualization." />
 <meta property="og:url" content="%VITE_SITE_ORIGIN%/" />
 <meta property="og:image" content="%VITE_SITE_ORIGIN%/og/default.png" />
 <meta property="og:image:type" content="image/png" />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
-<meta property="og:image:alt" content="Math3d — 3D math visualization" />
-<meta name="twitter:card" content="summary_large_image" />
 <meta
-  name="twitter:title"
-  content="Math3d — Interactive 3D Math Visualization"
+  property="og:image:alt"
+  content="Math3d — interactive 3D graphing calculator"
 />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="Math3d: Online 3d Graphing Calculator" />
 <meta name="twitter:image" content="%VITE_SITE_ORIGIN%/og/default.png" />
-<meta name="twitter:image:alt" content="Math3d — 3D math visualization" />
+<meta
+  name="twitter:image:alt"
+  content="Math3d — interactive 3D graphing calculator"
+/>
 ```
 
-Notes:
+**Pass 1 adds one tag** to `index.html` — a Worker-stable copy of the default title for the
+client to read (see the decision below):
+
+```html
+<meta name="default-title" content="Math3d: Online 3d Graphing Calculator" />
+```
+
+`default-title` holds the **identical** string to `<title>` in the shipped shell — the two are
+the home/default view's title, co-located so a human editing one sees the other. The Worker
+rewrites `<title>` per-scene but **never touches `default-title`**, so it remains the true
+site default at runtime regardless of whether the Worker ran.
+
+Notes (unchanged from #1223):
 
 - **`og:image:width`/`height`/`type`** matter: without them the _first_ share of a URL (before
   any scraper has fetched+measured the PNG) can render blank/mis-cropped, fixed only on a later
   re-scrape. The default image is a known 1200×630 PNG, so these are free to state.
 - **Keep the static `og:description`** — Discord/LinkedIn need a non-empty description to render
-  an embed at all. v1 doesn't vary it per scene; every card shares this text, which is fine.
+  an embed at all. Pass 1 doesn't vary it per scene; every card shares this text, which is fine.
 - **No `twitter:site`/`twitter:creator`** — Math3d has no X handle. (X inherits `og:*` via its
   fallback chain, so `twitter:description` is unnecessary.)
 - Home page and non-scene routes are covered by these defaults: the Worker either isn't invoked
   (a matched asset bypasses it) or runs and passes the request straight through (e.g. `/`, whose
   step-1 filter rejects the empty segment → `env.ASSETS.fetch` serves `index.html`).
 
-The Worker, on a scene page, **overwrites the `content` attribute** of `og:title`,
+On a scene page the Worker **overwrites the `content` attribute** of `og:title`,
 `twitter:title`, and `og:url`, and rewrites the **`<title>` element** text. It leaves
-`og:image*`/`og:site_name`/`og:description` at their defaults in v1. (The images fast-follow
-adds `og:image`/`twitter:image` rewrites.) HTMLRewriter mutates existing elements — no
+`og:image*` / `og:site_name` / `og:description` / `default-title` at their defaults. (Pass 2
+adds `og:image` / `twitter:image` rewrites.) HTMLRewriter mutates existing elements — no
 duplicate tags.
 
-> The static default `og:image` asset (`/og/default.png`, 1200×630, branded) must be
-> produced and committed to `packages/app/public/og/` before launch. **TODO: source/design
-> this image** (the render-mode route is the intended tool for this) — a launch prerequisite,
-> not a blocker for building the Worker.
+### The `<title>` decision
+
+**Chosen: the Worker rewrites the `<title>` element per-scene** (option b), because a
+per-scene `<title>` sets the **browser tab** to the scene name at TTFB — before the heavy
+MathBox app boots and the client would otherwise set it seconds later — and gives non-JS
+crawlers/search the scene title too. `og:title`/`twitter:title` already drive the social card;
+`<title>` adds the tab + SEO win.
+
+The cost is the "strand bug": #1223's loader captures its no-scene default from
+`document.title` via `useRef`, which on a scene-deep-link first load would capture the
+Worker-written _scene_ title as if it were the site default. **Resolution — the loader sources
+its default from the Worker-stable `<meta name="default-title">`** instead of `document.title`:
+
+- `useSceneLoader` reads `meta[name="default-title"]`'s `content` (falling back to
+  `document.title` for dev/tests where the meta may be absent) as its no-scene default, once,
+  via the existing `useRef`.
+- The Worker never rewrites `default-title`, so the loader gets the true site title whether or
+  not the Worker ran — preserving the abandonability invariant.
+
+This is a latent-landmine fix, not a live-bug fix: the strand path (navigating a loaded scene
+back to no-scene while `MainPage` stays mounted) has **no UI affordance today** (verified: no
+home/logo/new-scene control in `MainPage`'s `Header`). It's cheap to fix now and a future
+"New scene" button would otherwise silently reintroduce stale tab titles.
+
+Rejected alternatives: leaving `<title>` static (loses the tab/SEO win); hardcoding the default
+title as a JS constant (works, but puts a second copy of the string in a different file — the
+`default-title` meta keeps both copies co-located in `index.html`).
 
 ### Request flow (Worker `fetch` handler)
 
@@ -167,20 +254,16 @@ duplicate tags.
    is a single non-asset segment: reject `/app` or `/app/*`, empty/`/`, multi-segment (interior
    `/`), and dotted (contains `.`). Otherwise it's a **candidate scene key**.
 2. **Validate the key** against `^[A-Za-z0-9_-]{2,80}$` (a superset of the real key charset). On
-   failure → passthrough defaults with **zero KV/Heroku cost**. (Cheap defense-in-depth: caps the
+   failure → passthrough defaults with zero backend cost. (Cheap defense-in-depth: caps the
    junk-path amplification surface before any backend touch.)
-3. Read the title from KV (`OG_CACHE`, key `title:<key>`):
-   - **Hit** → use the cached title.
-   - **Miss** → `fetch(`${API_BASE}/scenes/${key}/`)` with `AbortSignal.timeout(~1000ms)`. The
-     fetch uses a **bare URL string, not the incoming `request`** — no cookies/headers are
-     forwarded (the endpoint is public `auth=None`; this also rules out any header-based
-     cache-poisoning). On `200`, parse the body **defensively**: wrap `response.json()` and a
-     `typeof body.title === "string"` check in the same try/catch as the failure paths.
-     - Valid `200` → extract `title`, write it to KV behind
-       `ctx.waitUntil(put(...).catch(log))` with an `expirationTtl` (see Caching), and use it.
-     - `404` / non-2xx / **malformed or missing-title 200** / timeout / network error →
-       passthrough defaults, **no KV write** (see Caching rationale). **The page must never block
-       or error on the lookup.**
+3. `fetch(`${API_BASE}/scenes/${key}/`)` with `AbortSignal.timeout(~1000ms)`. The fetch uses a
+   **bare URL string, not the incoming `request`** — no cookies/headers are forwarded (the
+   endpoint is public `auth=None`; this also rules out any header-based cache-poisoning). On
+   `200`, parse the body **defensively**: wrap `response.json()` and a
+   `typeof body.title === "string"` check in the same try/catch as the failure paths.
+   - Valid `200` → extract `title`, use it.
+   - `404` / non-2xx / **malformed or missing-title 200** / timeout / network error →
+     passthrough defaults. **The page must never block or error on the lookup.**
 4. Fetch the SPA shell (`env.ASSETS.fetch`) and pipe it through `HTMLRewriter`, rewriting:
    `meta[property="og:title"]` / `meta[name="twitter:title"]` `content` (the title), the
    `<title>` element text, and `meta[property="og:url"]` `content` (= `${SITE_ORIGIN}/<key>`).
@@ -200,7 +283,7 @@ duplicate tags.
 ### Title handling
 
 - Trim the fetched title, then **clamp to ~200 chars** (`Scene.title` is an uncapped `TextField`;
-  cards truncate ~60–90 anyway, and the clamp bounds the HTML/KV value). If empty or the literal
+  cards truncate ~60–90 anyway, and the clamp bounds the rewritten value). If empty or the literal
   `"Untitled"` → `"Untitled scene — Math3d"`. (A user who deliberately names a scene `"Untitled"`
   gets the generic card — acceptable.)
 - `og:url` = `${SITE_ORIGIN}/<key>` (fixed canonical, regardless of the requested host).
@@ -209,60 +292,12 @@ duplicate tags.
 
 Malformed keys are rejected by the regex (step 2). Well-formed-but-nonexistent keys (e.g.
 `/help`, `/about`, a deleted scene) 404 at the API → passthrough defaults. Reserved routes
-(`/app/*`), asset-like, and multi-segment paths are filtered before any fetch. So the common
-cases never touch KV or Heroku.
+(`/app/*`), asset-like, and multi-segment paths are filtered before any fetch. Every scene
+navigation costs one Heroku fetch (no cache in pass 1); junk valid-charset single-segment paths
+each cost one cheap Heroku 404 — bound abusive volume with a Cloudflare Rate-Limiting/WAF rule
+on the scene route (see Launch prerequisites), which is the right place for it, not the cache.
 
-## Caching rationale
-
-With `run_worker_first`, the Worker runs for **all** scene navigations (humans + scrapers), so
-the KV cache keeps human scene-loads on a ~single-ms edge read instead of a synchronous Heroku
-round-trip, and bounds Heroku load to one fetch per scene per TTL window.
-
-**Positive-cache only — no negative sentinels.** KV's free tier allows only ~1,000 writes/day.
-Writing a sentinel per 404 would let junk/crawler traffic exhaust that budget (a cheap
-amplification). Instead we only write KV on a `200`, so misses cost at most a fast Heroku 404.
-
-**The trade this makes — and its mitigation.** Positive-only means many _distinct_ junk
-single-segment paths (`/aaaa`, `/aaab`, …) are each an uncacheable Heroku 404. The key-regex
-rejects malformed junk, but valid-charset junk still reaches the origin — a new amplification
-surface that didn't exist when Static Assets served every unmatched path at zero origin cost.
-Heroku's 404 is a single indexed-key miss (cheap), so this is acceptable at our scale, but the
-right place to bound abusive volume is **a Cloudflare Rate-Limiting/WAF rule on the scene route**,
-not the cache. (Add such a rule — see Launch prerequisites.)
-
-**TTL.** Since edits are admin-only and rare, a longer TTL is fine and cuts origin load; start
-around **1 hour**, tunable. Keep it bounded even after push-invalidation ships — it's the backstop
-that self-heals the read/write race noted in Cache invalidation, so don't raise it toward infinity.
-
-## Cache invalidation (future — not in v1)
-
-v1 accepts ≤ TTL title staleness. When instant edits are wanted, use **push invalidation from
-the backend** (no polling, no separate infra):
-
-- On scene `PATCH` (`webserver/scenes/api.py:78`), after saving, the Django handler **DELETEs**
-  the key via the KV REST API (`DELETE …/storage/kv/namespaces/{ns}/values/title:<key>`). DELETE
-  (not overwrite) keeps the **Worker the sole formatter** of the KV value — the backend needn't
-  replicate the Worker's trim/`"Untitled"`-normalization; the next read repopulates from Heroku
-  (one cheap re-fetch, negligible for rare admin edits).
-- **Token:** Cloudflare KV write tokens are **account-scoped, not per-namespace** (the
-  `Workers KV Storage Write` permission group is account-wide). So the Heroku token is a single
-  account-scoped, write-only secret — acceptable, but it can write _any_ KV namespace in the
-  account. Endpoint verified: `PUT/DELETE /accounts/{account_id}/storage/kv/namespaces/{ns}/values/{key}`,
-  Bearer auth.
-- **Call it best-effort, in-request, with a strict ~1–2 s timeout**, swallowing all
-  errors/timeouts (there's no task queue — a save must never fail on a Cloudflare hiccup, and a
-  _slow_ Cloudflare must not tie up the WSGI worker for long). Don't reuse this synchronous path
-  for a high-volume write endpoint without revisiting.
-- **Residual race (document, don't over-engineer):** a Worker KV miss reads the old title from
-  Heroku and writes it via `ctx.waitUntil`; if a `PATCH` DELETE lands _between_ that read and the
-  deferred write, the stale value is repopulated and persists until TTL. DELETE doesn't eliminate
-  this. It self-heals at the TTL backstop — so **keep a bounded TTL (~1 h)** rather than raising it
-  toward infinity while this race exists. A true fix (locks/timestamps) is overkill for admin-only
-  rare edits.
-- This same PATCH hook is where the **images fast-follow** bumps `graphicsVersion` / enqueues a
-  re-render — so it's worth building once, for both.
-
-## Config-as-code changes
+## Config-as-code changes (pass 1)
 
 `packages/app/wrangler.jsonc`:
 
@@ -288,9 +323,6 @@ the backend** (no polling, no separate infra):
       "!/index.html"
     ]
   },
-  "kv_namespaces": [
-    { "binding": "OG_CACHE", "id": "<prod-id>", "preview_id": "<preview-id>" }
-  ],
   "vars": {
     "API_BASE": "https://api.math3d.org",
     // Committed default; overridden at deploy via `--var SITE_ORIGIN:$SITE_ORIGIN`, sourced from
@@ -300,25 +332,21 @@ the backend** (no polling, no separate infra):
 }
 ```
 
-One-time setup (documented in the plan, run once):
-
-```bash
-yarn wrangler kv namespace create OG_CACHE
-yarn wrangler kv namespace create OG_CACHE --preview
-```
+(No `kv_namespaces` in pass 1 — KV is a deferred lever.)
 
 New/changed files:
 
 - `packages/app/src/worker/index.ts` — the Worker + `HTMLRewriter` handlers.
 - `packages/app/src/worker/*.test.ts` — Worker unit tests (workers pool — see Testing).
-- `packages/app/index.html` — real `<title>` + default OG/Twitter tags (with `%VITE_SITE_ORIGIN%`).
-- `packages/app/public/og/default.png` — static branded default card (launch prerequisite).
-- `.env.development` (+ build env) — add `VITE_SITE_ORIGIN`.
+- `packages/app/index.html` — add `<meta name="default-title">` (= `<title>`); the existing
+  head-comment should note the Worker leaves `default-title` untouched.
+- `packages/app/src/features/scene/useSceneLoader.ts` — source the no-scene default from
+  `meta[name="default-title"]` instead of `document.title`.
 
 No CI pipeline change: `deploy-reusable.yml` already runs `yarn wrangler deploy` after
 `yarn build` produces `./dist`.
 
-## Testing
+## Testing (pass 1)
 
 Worker unit tests via `@cloudflare/vitest-pool-workers` (runs in workerd — `HTMLRewriter` doesn't
 exist under jsdom).
@@ -344,19 +372,25 @@ Test shell: worker tests run without a build, so `./dist` (the `ASSETS` director
 provide the HTML shell explicitly (a fixture string fed through `HTMLRewriter`, or a mocked
 `env.ASSETS.fetch`) rather than relying on the real asset binding.
 
-Cases:
+Worker cases:
 
 - scene key, API `200` → `og:title`/`twitter:title`/`<title>`/`og:url` all rewritten correctly;
+  `default-title` and `og:description` left untouched;
 - empty / whitespace / `"Untitled"` title → `"Untitled scene — Math3d"` fallback;
 - over-long title → clamped to ~200 chars;
 - **hostile title** (`"><img src=x onerror=alert(1)>` and `&"<>`) → escaped, no attribute
   breakout (round-trips JSON-decode → HTML-escape);
-- invalid key (bad charset, too long, `%2F`, CRLF) → passthrough, **no** KV/Heroku touch;
-- API `404` / timeout / 500 → shell served with default tags (no error, no KV write);
-- **malformed 200** (non-JSON body, or JSON missing a string `title`) → default tags, no KV write;
+- invalid key (bad charset, too long, `%2F`, CRLF) → passthrough, **no** Heroku touch;
+- API `404` / timeout / 500 → shell served with default tags (no error);
+- **malformed 200** (non-JSON body, or JSON missing a string `title`) → default tags;
 - `/app/x`, multi-segment, dotted paths → passthrough, no fetch;
-- KV hit path → no Heroku fetch;
 - no incoming request header/cookie is forwarded to the API fetch.
+
+App-side case (jsdom project):
+
+- `useSceneLoader` no-scene default reads `meta[name="default-title"]`: with the meta present
+  (and a distinct `document.title`, simulating a Worker-rewritten `<title>`), leaving a loaded
+  scene restores the meta value, not the scene title. (#1223's two title tests remain.)
 
 Notes:
 
@@ -365,10 +399,64 @@ Notes:
   globs).
 - The Playwright e2e suite does not exercise the Worker.
 
-## Images: deferred fast-follow (not in v1)
+## Deferred backend-load & perf levers (not in pass 1)
 
-v1 ships the static default `og:image`. Per-scene screenshots of the MathBox scene are a
-separate effort.
+Pass 1 accepts one Heroku fetch per scene navigation (the Worker's) on top of the client's own
+scene fetch — the "double API call." At current traffic each is a cheap indexed-key lookup, and
+the app already does one such fetch per scene load. These levers exist for **if/when** origin
+load or scene-page TTFB is measured to be a problem — none is built now (YAGNI), and each is
+compatible with the abandonability invariant (all are optional optimizations the SPA doesn't
+depend on):
+
+### KV title cache (Worker-side)
+
+Cache the title at the edge in **Cloudflare Workers KV** (`OG_CACHE`, key `title:<key>`) so
+repeat scene navigations read the title in ~1ms instead of re-hitting Heroku, bounding Heroku
+load to one fetch per scene per TTL window and cutting scene-page TTFB after the first load.
+Design details (preserved from the original v1 sketch, for when this lands):
+
+- **Positive-cache only — no negative sentinels.** KV's free tier allows only ~1,000 writes/day.
+  Writing a sentinel per 404 would let junk/crawler traffic exhaust that budget. Write KV only on
+  a `200` (`ctx.waitUntil(put(..., { expirationTtl }).catch(log))`); misses cost at most a fast
+  Heroku 404. Trade-off: distinct valid-charset junk paths are each an uncacheable Heroku 404 —
+  bound with the WAF rule, not the cache.
+- **TTL** ~1 hour, tunable; keep it bounded (it's the self-healing backstop for the invalidation
+  race below).
+- Adds `kv_namespaces` to `wrangler.jsonc` and a one-time
+  `yarn wrangler kv namespace create OG_CACHE` (+ `--preview`).
+- **Cache invalidation (push, optional):** on scene `PATCH` (`webserver/scenes/api.py`), after
+  saving, the Django handler best-effort **DELETEs** `title:<key>` via the KV REST API
+  (`DELETE …/storage/kv/namespaces/{ns}/values/title:<key>`), strict ~1–2 s timeout, swallowing
+  all errors (a save must never fail on a Cloudflare hiccup). DELETE (not overwrite) keeps the
+  Worker the sole formatter of the value. **Token:** KV write tokens are account-scoped, not
+  per-namespace — a single write-only secret that can write any KV namespace in the account.
+  **Residual race:** a Worker miss that reads-then-`waitUntil`-writes can repopulate a stale
+  title if a PATCH DELETE lands between; it self-heals at the TTL backstop, so keep TTL bounded.
+  This same PATCH hook is where pass 2's image invalidation (`graphicsVersion` bump / re-render
+  enqueue) would live — worth building once for both.
+
+### CDN-cached scene GET
+
+Put `Cache-Control` on the public `GET /scenes/{key}/` and let Cloudflare cache it (free on all
+plans; no Cache Reserve). Offloads origin for **every** consumer (Worker, client, direct API
+users), not just navigations. Prerequisites/costs: `api.math3d.org` must be **proxied** through
+Cloudflare (orange-cloud), not DNS-only (unverified today); and invalidation (short TTL +
+stale-while-revalidate, or CF purge on PATCH). More decoupled than the KV cache and survives
+Worker removal, but carries the invalidation + proxying complexity — hence deferred.
+
+### Narrow meta endpoint
+
+Add `GET /scenes/{key}/meta/` returning just `{title}` (later `{title, description}`) so the
+Worker depends on a tiny, stable shape instead of the full item schema (which churns). Cheap
+(`MiniSceneSchema` already models it). Not "edge work" — a normal Django endpoint that survives
+Worker removal. Contract-narrowing, not a load win on its own; fold in if/when we revisit the
+Worker's fetch.
+
+## Pass 2: per-scene images (separate PR)
+
+Pass 1 ships the static default `og:image`. Per-scene screenshots of the MathBox scene are a
+separate effort: the Worker additionally rewrites `og:image` / `twitter:image` to a
+per-scene PNG.
 
 **Fidelity spike — PASSED (2026-07-12).** The open question was whether GPU-less SwiftShader
 (Cloudflare Browser Rendering's environment) renders MathBox scenes acceptably. Tested locally
@@ -403,7 +491,7 @@ Client-side capture (screenshot in the sharer's browser) was **rejected**: nonde
 framing, attacker-controlled uploaded bytes served as public previews, can't regenerate on
 graphics changes, and only covers scenes someone actually shares.
 
-### App-side prerequisite — a deterministic render mode
+### App-side prerequisite — a deterministic render mode (shipped, #1209)
 
 _Implemented in PR #1209 (the `/app/frame/:sceneKey` render page). Design:
 `docs/superpowers/specs/2026-07-12-scene-render-mode-decoupling-design.md`. Summarized here
@@ -467,15 +555,22 @@ when picking the compute path.
 
 ## Launch prerequisites / open items
 
-- [ ] Produce the static branded default `og:image` (1200×630) → `public/og/default.png`.
-- [ ] At apex cutover: flip the single CI origin value to apex, **and** keep `next.math3d.org`
-      resolving (path-preserving `301 → apex`) so already-shared links survive (see Canonical
-      origin & the domain migration).
-- [ ] Create the `OG_CACHE` KV namespace (prod + preview) and paste ids into `wrangler.jsonc`.
+Pass 1:
+
+- [ ] Add `<meta name="default-title">` to `index.html` and point `useSceneLoader`'s no-scene
+      default at it.
 - [ ] Validate the `run_worker_first` globs with `wrangler dev` (confirm `/*` matches
       single-segment scene keys and the asset exclusions bypass correctly; confirm
       `env.ASSETS.fetch` doesn't re-enter the Worker — one invocation per scene nav, no loop).
-- [ ] Add a Cloudflare Rate-Limiting/WAF rule on the scene route to bound origin-404 abuse
-      (see Caching rationale).
+- [ ] Add a Cloudflare Rate-Limiting/WAF rule on the scene route to bound origin-404 abuse.
 - [ ] Wire origin config from a single CI value (`VITE_SITE_ORIGIN` → build; same value →
-      `wrangler deploy --var SITE_ORIGIN:$SITE_ORIGIN`).
+      `wrangler deploy --var SITE_ORIGIN:$SITE_ORIGIN`). (`VITE_SITE_ORIGIN` already shipped
+      in #1223; add the `SITE_ORIGIN` deploy `--var`.)
+
+Cross-cutting / later:
+
+- [ ] At apex cutover: flip the single CI origin value to apex, **and** keep `next.math3d.org`
+      resolving (path-preserving `301 → apex`) so already-shared links survive (see Canonical
+      origin & the domain migration).
+- [ ] Pass 2: pick the image compute path; produce per-scene PNGs; add image rewrites + URL
+      versioning (`/og/<key>-<graphicsVersion>.png`).

--- a/docs/superpowers/specs/2026-07-11-og-metadata-worker-design.md
+++ b/docs/superpowers/specs/2026-07-11-og-metadata-worker-design.md
@@ -4,8 +4,10 @@
 **Status:** Approved design, pre-implementation
 **Revised:** 2026-08-07 — split into two passes; reconciled with shipped work
 (#1222 default image, #1223 static head + `VITE_SITE_ORIGIN`, #1209 render mode);
-added the abandonability invariant; landed the `<title>` decision; moved KV +
-API caching out of pass 1 into deferred levers.
+added the abandonability invariant; landed the `<title>` decision and the title
+**string format** (`{title} | Math3d`); pulled a read-only `GET /scenes/{key}/meta/`
+into pass 1 (the full GET has write side effects); named the human-TTFB cost of
+running the Worker on every navigation; moved KV + CDN caching into deferred levers.
 
 ## Problem
 
@@ -117,14 +119,23 @@ The apex cutover is **not** a one-line flip — two constraints:
   candidate scene key" is sound.
 - **Key charset:** generated keys use `KEY_ALPHABET` (alphanumeric, no `0OlI`-type ambiguities),
   length 10; the backend reserves only `app` and keys < 2 chars
-  (`webserver/scenes/models.py`). Keys never contain `.` or `/`. Legacy scene keys also fit
-  `[A-Za-z0-9_-]` (confirmed), so the Worker's validation regex covers them too.
-- **Metadata source:** `GET /scenes/{key}/`, `auth=None` (public) — returns the full scene
-  incl. `title` (`webserver/scenes/api.py`). Despite `by_alias=True`, `title` has **no alias**
-  (verified in `webserver/openapi.v1.yaml`), so the Worker reads the JSON field `title`
-  directly. Pass 1 reads `.title` off this full response (the double API call is accepted — see
-  Non-goals; a lean `MiniSceneSchema` exists but is only wired to the list route, so there is no
-  by-key title-only endpoint today). Production host: **`https://api.math3d.org`**.
+  (`webserver/scenes/models.py`). Keys never contain `.` or `/`. **Legacy keys:**
+  `LegacyScene.key` is an unconstrained `CharField(max_length=80)`, so "legacy keys fit
+  `[A-Za-z0-9_-]`" rests on old-system data, not the model — **spot-check before relying on it**:
+  `SELECT count(*) FROM scenes_legacyscene WHERE key !~ '^[A-Za-z0-9_-]{2,80}$';`. Blast radius
+  if some don't fit is low: a rejected legacy key just passes through to the default card
+  (graceful), never breakage. Note underscore-leading single segments (e.g. `_headers`) match the
+  regex and are candidate keys by design — harmless (they aren't URL-served, or 404 → passthrough).
+- **Metadata source — a new read-only `GET /scenes/{key}/meta/`** (pass 1 adds it; see
+  "Backend: read-only meta endpoint"). The Worker must **not** use the existing
+  `GET /scenes/{key}/`: that handler has **write side effects on every GET** — it increments
+  `times_accessed` via `F()+1`, and for a **legacy** key it re-runs `migrate_scene(legacy)`
+  (a full re-migration write) _each time_ (`webserver/scenes/api.py`). With `run_worker_first`
+  firing the Worker on every navigation + every crawl, hitting that endpoint would double the
+  view counter and trigger a re-migration storm on legacy scenes. The `/meta/` endpoint is a
+  pure read (no increment, no migration) returning `{ title }`. `title` has **no alias**
+  (single-word field), so the Worker reads the JSON field `title` directly. Endpoint is public
+  (`auth=None`). Production host: **`https://api.math3d.org`**.
 - **Title default:** `title` is `TextField(blank=True, default="Untitled")`
   (`webserver/scenes/models.py`) — the API effectively always returns a non-empty title,
   often the literal `"Untitled"`.
@@ -136,6 +147,18 @@ The apex cutover is **not** a one-line flip — two constraints:
   navigations unless we force it. **`run_worker_first` (a glob-pattern array) is required** — see
   Config. Requests that match a real static asset (`/assets/*`, `/og/*`, `/favicon.*`) should be
   excluded so they keep bypassing the Worker (zero invocations for assets).
+  - **Cost of running for _all_ navigations (accepted, D3):** because `run_worker_first` fires the
+    Worker for humans too (not just crawlers — the two are indistinguishable at the edge without
+    UA/`Sec-Fetch` heuristics), every scene page's **first byte now blocks on the Worker's
+    `/meta/` fetch**. Today the shell ships from the CF edge independent of the backend. Typical
+    added latency is small (~100–300 ms; Heroku Basic dynos don't sleep) and dwarfed by the
+    seconds-long MathBox boot that follows; the timeout (below) is the ceiling, not the expected
+    cost. During a Heroku brownout every scene load waits up to the timeout, then serves the
+    default-tag shell (still functional — the client would fail its own fetch too). Accepted over
+    crawler-gating, which would protect human TTFB but add a bot-detection heuristic to maintain
+    (and, since humans would then never receive a Worker-rewritten `<title>`, would moot the
+    `default-title`/strand-bug machinery). If TTFB is later measured to matter, the KV lever cuts
+    it to a ~1 ms edge read after the first load.
 - **Social caches** are URL-keyed; lifetimes vary (Facebook/LinkedIn effectively cache by URL
   for days-to-indefinite; Slack re-scrapes ~every 30 min; Discord is short). Facebook (and
   others) canonicalize on `og:url`, so pinning `og:url` to a fixed canonical consolidates
@@ -256,17 +279,21 @@ title as a JS constant (works, but puts a second copy of the string in a differe
 2. **Validate the key** against `^[A-Za-z0-9_-]{2,80}$` (a superset of the real key charset). On
    failure → passthrough defaults with zero backend cost. (Cheap defense-in-depth: caps the
    junk-path amplification surface before any backend touch.)
-3. `fetch(`${API_BASE}/scenes/${key}/`)` with `AbortSignal.timeout(~1000ms)`. The fetch uses a
-   **bare URL string, not the incoming `request`** — no cookies/headers are forwarded (the
-   endpoint is public `auth=None`; this also rules out any header-based cache-poisoning). On
-   `200`, parse the body **defensively**: wrap `response.json()` and a
-   `typeof body.title === "string"` check in the same try/catch as the failure paths.
+3. `fetch(`${API_BASE}/scenes/${key}/meta/`)` (the read-only endpoint — never the
+   side-effecting full GET) with `AbortSignal.timeout(~800ms)` (sub-second: bounds the
+   worst-case TTFB add during a Heroku brownout while leaving headroom over the typical
+   ~100–300 ms). The fetch uses a **bare URL string, not the incoming `request`** — no
+   cookies/headers are forwarded (the endpoint is public `auth=None`; this also rules out any
+   header-based cache-poisoning). On `200`, parse the body **defensively**: wrap
+   `response.json()` and a `typeof body.title === "string"` check in the same try/catch as the
+   failure paths.
    - Valid `200` → extract `title`, use it.
    - `404` / non-2xx / **malformed or missing-title 200** / timeout / network error →
      passthrough defaults. **The page must never block or error on the lookup.**
-4. Fetch the SPA shell (`env.ASSETS.fetch`) and pipe it through `HTMLRewriter`, rewriting:
-   `meta[property="og:title"]` / `meta[name="twitter:title"]` `content` (the title), the
-   `<title>` element text, and `meta[property="og:url"]` `content` (= `${SITE_ORIGIN}/<key>`).
+4. Fetch the SPA shell (`env.ASSETS.fetch`) and pipe it through `HTMLRewriter`, rewriting (see
+   Title handling for the exact strings): the `<title>` element text (→ `{title} | Math3d`),
+   `meta[property="og:title"]` / `meta[name="twitter:title"]` `content` (→ **bare** `{title}`),
+   and `meta[property="og:url"]` `content` (= `${SITE_ORIGIN}/<key>`).
    Return the transformed response, setting an explicit **short/`private` `Cache-Control`** rather
    than inheriting `index.html`'s (so no intermediary over-caches per-scene HTML). HTMLRewriter
    preserves status/headers otherwise.
@@ -282,20 +309,59 @@ title as a JS constant (works, but puts a second copy of the string in a differe
 
 ### Title handling
 
-- Trim the fetched title, then **clamp to ~200 chars** (`Scene.title` is an uncapped `TextField`;
-  cards truncate ~60–90 anyway, and the clamp bounds the rewritten value). If empty or the literal
-  `"Untitled"` → `"Untitled scene — Math3d"`. (A user who deliberately names a scene `"Untitled"`
-  gets the generic card — acceptable.)
-- `og:url` = `${SITE_ORIGIN}/<key>` (fixed canonical, regardless of the requested host).
+Trim the fetched title, then **clamp to ~200 chars** on a **code-point boundary** (`Scene.title`
+is an uncapped `TextField`; cards truncate ~60–90 anyway, and the clamp bounds the rewritten
+value — clamp by code point, not code unit, so a surrogate pair / emoji isn't split). Let
+`name` = the trimmed+clamped title, or `"Untitled scene"` if it's empty or the literal
+`"Untitled"` (a user who deliberately names a scene `"Untitled"` gets the generic text —
+acceptable).
+
+**String format (D1) — two surfaces, one brand suffix, `|` separator:**
+
+- `<title>` element (tab + non-JS SEO): `` `${name} | Math3d` `` (e.g. `My Torus | Math3d`,
+  `Untitled scene | Math3d`).
+- `og:title` / `twitter:title` (card headline): **bare `name`** (e.g. `My Torus`,
+  `Untitled scene`) — the card already shows "Math3d" via `og:site_name`, so no redundant suffix.
+- **Home / no-scene** keeps the shipped rich defaults unchanged: `<title>` =
+  `Math3d: Online 3d Graphing Calculator`, and `og:title` stays that same descriptive string
+  (the Worker only rewrites on scene pages). `default-title` = that rich `<title>` verbatim.
+- **Client parity (required):** `useSceneLoader` must set `document.title` to the **same**
+  `` `${data.title} | Math3d` `` (changed from `` `Math3d - ${data.title}` ``) so the Worker's
+  pre-boot `<title>` and the client's post-boot value match — no format flash on deep-links.
+  Update its assertion in `MainPage.spec.tsx`. The no-scene branch restores `default-title`
+  (the rich home title), as before.
+
+`og:url` = `${SITE_ORIGIN}/<key>` (fixed canonical, regardless of the requested host).
 
 ### URL classification (why it's safe)
 
 Malformed keys are rejected by the regex (step 2). Well-formed-but-nonexistent keys (e.g.
 `/help`, `/about`, a deleted scene) 404 at the API → passthrough defaults. Reserved routes
 (`/app/*`), asset-like, and multi-segment paths are filtered before any fetch. Every scene
-navigation costs one Heroku fetch (no cache in pass 1); junk valid-charset single-segment paths
-each cost one cheap Heroku 404 — bound abusive volume with a Cloudflare Rate-Limiting/WAF rule
-on the scene route (see Launch prerequisites), which is the right place for it, not the cache.
+navigation costs one read-only `/meta/` fetch (no cache in pass 1); junk valid-charset
+single-segment paths each cost one cheap `/meta/` 404 — bound abusive volume with a Cloudflare
+Rate-Limiting/WAF rule on the scene route (see Launch prerequisites), which is the right place
+for it, not the cache.
+
+### Backend: read-only meta endpoint
+
+Add `GET /scenes/{key}/meta/`, `auth=None`, response `{ title: string | null }`
+(`MiniSceneSchema` already models a title-only shape, or a purpose-built `SceneMetaSchema`).
+It is a **pure read** — crucially, it must **not** increment `times_accessed` and must **not**
+call `migrate_scene`, the two write side effects that rule out the full GET for the Worker.
+
+- **Legacy-key title source (settle in the plan):** the full GET surfaces a legacy scene's title
+  only by migrating it into a `Scene` row first. The meta endpoint must avoid that. Resolve
+  without persisting a migration: return the migrated `Scene.title` if a row exists; otherwise
+  read the title out of `LegacyScene.dehydrated` (the legacy blob) directly. (Acceptable
+  fallback if that's fiddly: `404`/empty for un-migrated legacy keys → the Worker serves the
+  default card, graceful; but prefer surfacing the title.)
+- **Contract-narrowing bonus:** the Worker now depends on a tiny `{ title }` shape, not the full
+  item schema (which churns) — the abandonability instinct pointed at the API surface. It's also
+  the natural attach point for the deferred CDN cache.
+- Adds the endpoint to `webserver/openapi.v1.yaml` (regenerate via `./scripts/generate_openapi.sh`;
+  CI's spec + generated-client checks enforce it). The generated FE client will include it,
+  unused by the app — harmless.
 
 ## Config-as-code changes (pass 1)
 
@@ -313,6 +379,9 @@ on the scene route (see Launch prerequisites), which is the right place for it, 
     "binding": "ASSETS",
     // Force the Worker to run for scene navigations; keep real assets bypassing it.
     // Exact globs to be validated with `wrangler dev` (multi-segment matching of `/*`).
+    // The dotted root files (robots.txt, mockServiceWorker.js) would pass through anyway via
+    // step-1's dotted filter, but excluding them keeps "zero invocations for assets" literal.
+    // (mockServiceWorker.js is dev-only — ideally it isn't in the prod `./dist` at all.)
     "run_worker_first": [
       "/*",
       "!/assets/*",
@@ -320,6 +389,8 @@ on the scene route (see Launch prerequisites), which is the right place for it, 
       "!/favicon.ico",
       "!/favicon.svg",
       "!/apple-touch-icon.png",
+      "!/robots.txt",
+      "!/mockServiceWorker.js",
       "!/index.html"
     ]
   },
@@ -334,6 +405,12 @@ on the scene route (see Launch prerequisites), which is the right place for it, 
 
 (No `kv_namespaces` in pass 1 — KV is a deferred lever.)
 
+`public/_headers` sets `Cache-Control: public, max-age=31536000, immutable` on `/assets/*` only;
+it does not touch the SPA HTML, whose default is `max-age=0, must-revalidate`. The Worker's
+per-scene response overriding to a short/`private` `Cache-Control` (request-flow step 4) is what
+keeps a rewritten scene page from inheriting that revalidating default — no conflict with
+`_headers`, which governs a disjoint path.
+
 New/changed files:
 
 - `packages/app/src/worker/index.ts` — the Worker + `HTMLRewriter` handlers.
@@ -341,10 +418,19 @@ New/changed files:
 - `packages/app/index.html` — add `<meta name="default-title">` (= `<title>`); the existing
   head-comment should note the Worker leaves `default-title` untouched.
 - `packages/app/src/features/scene/useSceneLoader.ts` — source the no-scene default from
-  `meta[name="default-title"]` instead of `document.title`.
+  `meta[name="default-title"]` instead of `document.title`, **and** change the per-scene
+  `document.title` format to `` `${data.title} | Math3d` `` (D1).
+- `packages/app/src/pages/MainPage/MainPage.spec.tsx` — update the title assertion to the new
+  `{title} | Math3d` format.
+- `webserver/scenes/api.py` (+ `webserver/scenes/schemas/scenes.py`) — the read-only
+  `GET /scenes/{key}/meta/` endpoint (no increment / no migration).
+- `webserver/scenes/api_test.py` — endpoint tests, incl. an assertion that it does **not** bump
+  `times_accessed` or migrate a legacy key.
+- `webserver/openapi.v1.yaml` + `packages/api/src/generated-v1/` — regenerated
+  (`./scripts/generate_openapi.sh`) for the new endpoint; CI enforces both.
 
-No CI pipeline change: `deploy-reusable.yml` already runs `yarn wrangler deploy` after
-`yarn build` produces `./dist`.
+CI: `deploy-reusable.yml` already runs `yarn wrangler deploy` after `yarn build` produces
+`./dist` (no frontend pipeline change). The backend endpoint rides the normal Django deploy.
 
 ## Testing (pass 1)
 
@@ -358,33 +444,42 @@ _matches_ `src/worker/*.test.ts`. Introduce a Vitest **`projects`** split:
 - **jsdom project** — the existing app tests. Move the current root `test` options
   (`globals`, `clearMocks`, `setupFiles: ["./src/setupTests.ts"]`, `env`, `css.modules`,
   `include`) _into_ this project, and add `exclude: ["./src/worker/**"]`.
-- **workers project** — scoped to `src/worker/**`, using the **`cloudflareTest()` Vite plugin**
-  from `@cloudflare/vitest-pool-workers` (options — e.g. `{ wrangler: { configPath: "./wrangler.jsonc" } }`
-  — passed to the plugin). **Do not** load `setupTests.ts` here (it pulls in jsdom/Testing-Library
-  globals absent under workerd, and the pool disallows a custom `environment`/`runner`).
+- **workers project** — scoped to `src/worker/**`, wired to `@cloudflare/vitest-pool-workers`
+  pointed at `./wrangler.jsonc`. **Do not** load `setupTests.ts` here (it pulls in
+  jsdom/Testing-Library globals absent under workerd, and the pool disallows a custom
+  `environment`/`runner`).
 
-Versions: `@cloudflare/vitest-pool-workers` **≥ 0.13** (the Vitest-4 line; the older
-`defineWorkersProject`/`test.poolOptions.workers` API is **removed**) and **Vitest ≥ 4.1** (the app
-pins `^4.0.18` — raise the floor). `yarn test`/Turbo run `vitest --run`, which executes both
-projects in one invocation.
+> **VERIFY before writing the config — the pool's API and version floors are unconfirmed here.**
+> The package is not yet a dependency. The exact wiring (the long-standing API is
+> `defineWorkersProject` + `test.poolOptions.workers.wrangler.configPath`; whether a newer
+> `cloudflareTest()` Vite-plugin form exists / has replaced it), and the claimed floors
+> (`@cloudflare/vitest-pool-workers ≥ 0.13`, `Vitest ≥ 4.1`), must be checked against the pinned
+> package's current README at implementation time. The app already pins `vitest ^4.0.18`, which
+> _resolves_ to ≥ 4.1 — a floor bump only matters as a hard guarantee, not for install
+> correctness. `yarn test`/Turbo run `vitest --run`, which executes both projects in one invocation.
 
 Test shell: worker tests run without a build, so `./dist` (the `ASSETS` directory) may be absent —
 provide the HTML shell explicitly (a fixture string fed through `HTMLRewriter`, or a mocked
 `env.ASSETS.fetch`) rather than relying on the real asset binding.
 
-Worker cases:
+Worker cases (assert the **exact** strings, not just "rewritten"):
 
-- scene key, API `200` → `og:title`/`twitter:title`/`<title>`/`og:url` all rewritten correctly;
+- scene key, `/meta/` `200` `{title:"My Torus"}` → `<title>` = `My Torus | Math3d`,
+  `og:title` = `twitter:title` = **bare** `My Torus`, `og:url` = `${SITE_ORIGIN}/<key>`;
   `default-title` and `og:description` left untouched;
-- empty / whitespace / `"Untitled"` title → `"Untitled scene — Math3d"` fallback;
-- over-long title → clamped to ~200 chars;
+- empty / whitespace / `"Untitled"` title → `<title>` = `Untitled scene | Math3d`,
+  `og:title`/`twitter:title` = `Untitled scene`;
+- over-long title → clamped to ~200 chars on a code-point boundary (no split surrogate);
 - **hostile title** (`"><img src=x onerror=alert(1)>` and `&"<>`) → escaped, no attribute
   breakout (round-trips JSON-decode → HTML-escape);
-- invalid key (bad charset, too long, `%2F`, CRLF) → passthrough, **no** Heroku touch;
-- API `404` / timeout / 500 → shell served with default tags (no error);
+- invalid key (bad charset, too long, `%2F`, CRLF) → passthrough, **no** `/meta/` touch;
+- `/meta/` `404` / timeout / 500 → shell served with default tags (no error);
 - **malformed 200** (non-JSON body, or JSON missing a string `title`) → default tags;
 - `/app/x`, multi-segment, dotted paths → passthrough, no fetch;
-- no incoming request header/cookie is forwarded to the API fetch.
+- no incoming request header/cookie is forwarded to the `/meta/` fetch.
+
+Backend (pytest): `GET /scenes/{key}/meta/` returns the title and — the point of the endpoint —
+does **not** increment `times_accessed` and does **not** migrate a legacy key.
 
 App-side case (jsdom project):
 
@@ -401,19 +496,19 @@ Notes:
 
 ## Deferred backend-load & perf levers (not in pass 1)
 
-Pass 1 accepts one Heroku fetch per scene navigation (the Worker's) on top of the client's own
-scene fetch — the "double API call." At current traffic each is a cheap indexed-key lookup, and
-the app already does one such fetch per scene load. These levers exist for **if/when** origin
-load or scene-page TTFB is measured to be a problem — none is built now (YAGNI), and each is
-compatible with the abandonability invariant (all are optional optimizations the SPA doesn't
-depend on):
+Pass 1 accepts one read-only `/meta/` fetch per scene navigation (the Worker's) on top of the
+client's own full scene fetch — the "double API call." The Worker's call is now write-free and
+tiny (`{ title }`); the client's full GET is the one that increments `times_accessed` (once per
+view, as today). These levers exist for **if/when** origin load or scene-page TTFB is measured to
+be a problem — none is built now (YAGNI), and each is compatible with the abandonability invariant
+(all are optional optimizations the SPA doesn't depend on):
 
 ### KV title cache (Worker-side)
 
 Cache the title at the edge in **Cloudflare Workers KV** (`OG_CACHE`, key `title:<key>`) so
 repeat scene navigations read the title in ~1ms instead of re-hitting Heroku, bounding Heroku
 load to one fetch per scene per TTL window and cutting scene-page TTFB after the first load.
-Design details (preserved from the original v1 sketch, for when this lands):
+Design details (preserved from the original single-pass sketch, for when this lands):
 
 - **Positive-cache only — no negative sentinels.** KV's free tier allows only ~1,000 writes/day.
   Writing a sentinel per 404 would let junk/crawler traffic exhaust that budget. Write KV only on
@@ -435,22 +530,16 @@ Design details (preserved from the original v1 sketch, for when this lands):
   This same PATCH hook is where pass 2's image invalidation (`graphicsVersion` bump / re-render
   enqueue) would live — worth building once for both.
 
-### CDN-cached scene GET
+### CDN-cached scene GET (or `/meta/`)
 
-Put `Cache-Control` on the public `GET /scenes/{key}/` and let Cloudflare cache it (free on all
-plans; no Cache Reserve). Offloads origin for **every** consumer (Worker, client, direct API
-users), not just navigations. Prerequisites/costs: `api.math3d.org` must be **proxied** through
-Cloudflare (orange-cloud), not DNS-only (unverified today); and invalidation (short TTL +
+Put `Cache-Control` on the public read endpoints (the Worker's `/meta/` is the obvious first
+target; the full `GET /scenes/{key}/` too) and let Cloudflare cache them (free on all plans; no
+Cache Reserve). Offloads origin for **every** consumer (Worker, client, direct API users), not
+just navigations. Prerequisites/costs: `api.math3d.org` must be **proxied** through Cloudflare
+(orange-cloud), not DNS-only (unverified today); and invalidation (short TTL +
 stale-while-revalidate, or CF purge on PATCH). More decoupled than the KV cache and survives
-Worker removal, but carries the invalidation + proxying complexity — hence deferred.
-
-### Narrow meta endpoint
-
-Add `GET /scenes/{key}/meta/` returning just `{title}` (later `{title, description}`) so the
-Worker depends on a tiny, stable shape instead of the full item schema (which churns). Cheap
-(`MiniSceneSchema` already models it). Not "edge work" — a normal Django endpoint that survives
-Worker removal. Contract-narrowing, not a load win on its own; fold in if/when we revisit the
-Worker's fetch.
+Worker removal, but carries the invalidation + proxying complexity — hence deferred. (The
+read-only `/meta/` endpoint itself lands in pass 1; only its _caching_ is deferred here.)
 
 ## Pass 2: per-scene images (separate PR)
 
@@ -557,8 +646,11 @@ when picking the compute path.
 
 Pass 1:
 
-- [ ] Add `<meta name="default-title">` to `index.html` and point `useSceneLoader`'s no-scene
-      default at it.
+- [ ] Build the read-only `GET /scenes/{key}/meta/` endpoint (no increment / no migration; legacy
+      title without persisting a migration), with tests, and regenerate the OpenAPI spec + client.
+- [ ] Add `<meta name="default-title">` to `index.html`; point `useSceneLoader`'s no-scene default
+      at it **and** switch its per-scene `document.title` to `{title} | Math3d` (update the test).
+- [ ] Spot-check the legacy-key charset (`SELECT count(*) … WHERE key !~ '^[A-Za-z0-9_-]{2,80}$'`).
 - [ ] Validate the `run_worker_first` globs with `wrangler dev` (confirm `/*` matches
       single-segment scene keys and the asset exclusions bypass correctly; confirm
       `env.ASSETS.fetch` doesn't re-enter the Worker — one invocation per scene nav, no loop).

--- a/docs/superpowers/specs/2026-07-11-og-metadata-worker-design.md
+++ b/docs/superpowers/specs/2026-07-11-og-metadata-worker-design.md
@@ -343,9 +343,10 @@ Math3d) — which is the desired behavior for a scene the author never named.
   identical on deep-links — no format flash, including the common `"Untitled"` case. Assertions in
   `MainPage.spec.tsx` cover both.
 
-`og:url` = `${SITE_ORIGIN}/<key>` (fixed canonical, regardless of the requested host). This is
-rewritten for **every** scene that exists — titled or untitled — so a shared untitled scene still
-links to its own canonical URL.
+`og:url` = `${SITE_ORIGIN}/<key>` (fixed canonical, regardless of the requested host). It is
+rewritten for **every** scene `/meta/` serves — titled or untitled — so a shared untitled scene
+still links to its own canonical URL. (Un-migrated legacy keys `404` and pass through to the
+default card, `og:url` included — see Backend below.)
 
 ### URL classification (why it's safe)
 
@@ -364,12 +365,16 @@ Add `GET /scenes/{key}/meta/`, `auth=None`, response `{ title: string | null }`
 It is a **pure read** — crucially, it must **not** increment `times_accessed` and must **not**
 call `migrate_scene`, the two write side effects that rule out the full GET for the Worker.
 
-- **Legacy-key title source (settle in the plan):** the full GET surfaces a legacy scene's title
-  only by migrating it into a `Scene` row first. The meta endpoint must avoid that. Resolve
-  without persisting a migration: return the migrated `Scene.title` if a row exists; otherwise
-  read the title out of `LegacyScene.dehydrated` (the legacy blob) directly. (Acceptable
-  fallback if that's fiddly: `404`/empty for un-migrated legacy keys → the Worker serves the
-  default card, graceful; but prefer surfacing the title.)
+- **Legacy keys — serve migrated scenes only (settled):** the endpoint looks up a `Scene` row
+  (`get_object_or_404(Scene…)`) and returns its `title`; an un-migrated legacy key `404`s and the
+  Worker serves the branded default card. It deliberately does **not** read the title out of
+  `LegacyScene.dehydrated`. Rationale: the full GET only surfaces a legacy title by _migrating_
+  the scene (a write side effect the meta endpoint must avoid), and reading the raw blob instead
+  means defensively parsing arbitrary old-system JSON — a real 500 surface for malformed blobs, as
+  the pass-1 reviews found. The graceful fallback (default card until first in-app open migrates
+  the scene) is worth that simplification: the endpoint stays a trivial, total, always-string read.
+  This also means `og:url` is rewritten for exactly the scenes `/meta/` serves — every `Scene`
+  row — with no null-title edge.
 - **Contract-narrowing bonus:** the Worker now depends on a tiny `{ title }` shape, not the full
   item schema (which churns) — the abandonability instinct pointed at the API surface. It's also
   the natural attach point for the deferred CDN cache.

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -23,6 +23,6 @@
     "eslint": "^8.57.1",
     "openapi-typescript": "^7.13.0",
     "type-fest": "5.7.0",
-    "vitest": "^4.0.18"
+    "vitest": "^4.1.0"
   }
 }

--- a/packages/api/src/generated-v1/index.ts
+++ b/packages/api/src/generated-v1/index.ts
@@ -155,9 +155,11 @@ export interface paths {
      * Get Scene Meta
      * @description Read-only title lookup for the edge OG Worker.
      *
-     *     No side effects: unlike ``get_scene`` it never increments ``times_accessed``
-     *     and never migrates a legacy key. Legacy titles are read out of the
-     *     dehydrated blob directly, without persisting a migration.
+     *     Serves only migrated (``Scene``) scenes, and does so with no side effects:
+     *     unlike ``get_scene`` it never increments ``times_accessed`` and never
+     *     migrates a legacy key. An un-migrated legacy key 404s here — the Worker
+     *     then serves the branded default card, and the scene picks up per-scene
+     *     metadata once it's opened in-app (which migrates it).
      */
     get: operations["scenes_api_get_scene_meta"];
     put?: never;

--- a/packages/api/src/generated-v1/index.ts
+++ b/packages/api/src/generated-v1/index.ts
@@ -144,6 +144,30 @@ export interface paths {
     patch: operations["scenes_api_update_scene"];
     trace?: never;
   };
+  "/v1/scenes/{key}/meta/": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get Scene Meta
+     * @description Read-only title lookup for the edge OG Worker.
+     *
+     *     No side effects: unlike ``get_scene`` it never increments ``times_accessed``
+     *     and never migrates a legacy key. Legacy titles are read out of the
+     *     dehydrated blob directly, without persisting a migration.
+     */
+    get: operations["scenes_api_get_scene_meta"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -798,6 +822,14 @@ export interface components {
       /** Title */
       title?: string | null;
     };
+    /**
+     * SceneMetaSchema
+     * @description Title-only shape for the read-only meta endpoint the edge OG Worker calls.
+     */
+    SceneMetaSchema: {
+      /** Title */
+      title?: string | null;
+    };
     /** ScenePatchSchema */
     ScenePatchSchema: {
       /** Archived */
@@ -1309,6 +1341,28 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["SceneSchema"];
+        };
+      };
+    };
+  };
+  scenes_api_get_scene_meta: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        key: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["SceneMetaSchema"];
         };
       };
     };

--- a/packages/app/.eslintrc.cjs
+++ b/packages/app/.eslintrc.cjs
@@ -1,0 +1,13 @@
+// The edge Worker (src/worker) is typechecked with Workers types via its own
+// tsconfig, excluded from the app's main tsconfig. Point ESLint's typed-linting
+// parser at that project so worker sources lint under the same rules.
+module.exports = {
+  overrides: [
+    {
+      files: ["src/worker/**/*.ts"],
+      parserOptions: {
+        project: "./src/worker/tsconfig.json",
+      },
+    },
+  ],
+};

--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -8,6 +8,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="app-version" content="%VITE_APP_VERSION%" />
     <title>Math3d: Online 3d Graphing Calculator</title>
+    <!--
+      Worker-stable copy of the default <title>. The metadata Worker rewrites
+      <title> per-scene at the edge but never touches default-title, so the SPA
+      loader reads the true site default from here regardless of whether the
+      Worker ran. Keep this content identical to <title> above.
+    -->
+    <meta
+      name="default-title"
+      content="Math3d: Online 3d Graphing Calculator"
+    />
     <meta
       name="description"
       content="An interactive 3D graphing calculator in your browser. Draw, animate, and share surfaces, curves, points, lines, and vectors."

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -77,6 +77,7 @@
     "yup": "^1.3.2"
   },
   "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "^0.20.3",
     "@faker-js/faker": "^9.9.0",
     "@julr/vite-plugin-validate-env": "^2.2.2",
     "@math3d/eslint-config": "workspace:^",
@@ -114,7 +115,7 @@
     "vite": "^7.3.6",
     "vite-plugin-compile-time": "^0.4.6",
     "vite-tsconfig-paths": "^5.1.4",
-    "vitest": "^4.0.18",
+    "vitest": "^4.1.0",
     "wrangler": "4.110.0"
   },
   "proxy": "http://localhost:3001",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -12,7 +12,7 @@
     "storybook": "start-storybook -p 6006 -s public",
     "test": "vitest --run",
     "test-watch": "vitest",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit && tsc --noEmit -p src/worker/tsconfig.json"
   },
   "browserslist": {
     "production": [
@@ -78,6 +78,7 @@
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.20.3",
+    "@cloudflare/workers-types": "^5.20260808.1",
     "@faker-js/faker": "^9.9.0",
     "@julr/vite-plugin-validate-env": "^2.2.2",
     "@math3d/eslint-config": "workspace:^",

--- a/packages/app/src/features/scene/sceneTitle.spec.ts
+++ b/packages/app/src/features/scene/sceneTitle.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { sceneDisplayName, sceneTabTitle } from "./sceneTitle";
+
+describe("sceneDisplayName", () => {
+  it("returns the trimmed name for a real title", () => {
+    expect(sceneDisplayName("  My Torus  ")).toBe("My Torus");
+  });
+
+  it("treats blank and the default 'Untitled' as untitled (null)", () => {
+    // A scene left at the DB default should read like the home page, not carry
+    // a scene-specific title.
+    expect(sceneDisplayName("")).toBeNull();
+    expect(sceneDisplayName("   ")).toBeNull();
+    expect(sceneDisplayName("Untitled")).toBeNull();
+  });
+
+  it("clamps to 200 code points without splitting a surrogate pair", () => {
+    const name = sceneDisplayName("😀".repeat(300));
+    expect(Array.from(name!)).toHaveLength(200);
+    expect(name!.endsWith("😀")).toBe(true);
+  });
+});
+
+describe("sceneTabTitle", () => {
+  it("formats a real title as '{name} | Math3d'", () => {
+    expect(sceneTabTitle("My Torus", "SITE DEFAULT")).toBe("My Torus | Math3d");
+  });
+
+  it("uses the provided site default for an untitled scene", () => {
+    expect(sceneTabTitle("Untitled", "SITE DEFAULT")).toBe("SITE DEFAULT");
+  });
+});

--- a/packages/app/src/features/scene/sceneTitle.ts
+++ b/packages/app/src/features/scene/sceneTitle.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared scene-title formatting used by BOTH the browser SPA
+ * (`useSceneLoader`) and the edge OG Worker (`src/worker`). Keep it
+ * dependency-free and DOM/Worker-agnostic so it typechecks under both the app's
+ * DOM lib and the Worker's `@cloudflare/workers-types` lib, and so the two
+ * surfaces can never drift (a deep-linked scene must show the same tab title
+ * before and after app boot).
+ *
+ * A scene left at the DB default `"Untitled"` (or blank) is treated as
+ * untitled: it reads like the home page — the site's rich default title —
+ * rather than carrying a scene-specific tab/card title.
+ */
+
+export const TITLE_MAX_CODEPOINTS = 200;
+
+/** Clamp on a code-point boundary so an emoji / surrogate pair isn't split. */
+const clampCodePoints = (value: string, max: number): string => {
+  const cps = Array.from(value);
+  return cps.length <= max ? value : cps.slice(0, max).join("");
+};
+
+/**
+ * The scene's display name (trimmed, code-point-clamped), or `null` when the
+ * scene is effectively untitled — blank/whitespace or the literal default
+ * `"Untitled"`. Callers substitute the site's rich default title for `null`.
+ */
+export const sceneDisplayName = (rawTitle: string): string | null => {
+  const name = clampCodePoints(rawTitle.trim(), TITLE_MAX_CODEPOINTS);
+  return name === "" || name === "Untitled" ? null : name;
+};
+
+/**
+ * The browser tab / `<title>` text for a scene: `"{name} | Math3d"`, or the
+ * provided site default when the scene is untitled.
+ */
+export const sceneTabTitle = (
+  rawTitle: string,
+  siteDefault: string,
+): string => {
+  const name = sceneDisplayName(rawTitle);
+  return name === null ? siteDefault : `${name} | Math3d`;
+};

--- a/packages/app/src/features/scene/useSceneLoader.ts
+++ b/packages/app/src/features/scene/useSceneLoader.ts
@@ -5,6 +5,7 @@ import { useNavigate } from "react-router";
 import { useAppDispatch } from "@/store/hooks";
 import defaultScene from "@/store/defaultScene";
 import { sceneSlice } from "@/features/sceneControls/mathItems";
+import { sceneTabTitle } from "@/features/scene/sceneTitle";
 import { useNotifications } from "@/features/notifications/NotificationsContext";
 
 const { actions: itemActions } = sceneSlice;
@@ -52,10 +53,11 @@ const useSceneLoader = (
   );
 
   useEffect(() => {
-    // Keep this format identical to the Worker's edge-rewritten <title> so a
-    // deep-linked scene shows the same tab title before and after app boot.
-    document.title = data?.title
-      ? `${data.title} | Math3d`
+    // Shared with the Worker's edge <title> rewrite (sceneTitle.ts) so a
+    // deep-linked scene shows the same tab title before and after app boot,
+    // including the untitled case → the rich site default.
+    document.title = data
+      ? sceneTabTitle(data.title ?? "", defaultTitle.current)
       : defaultTitle.current;
   }, [data]);
 

--- a/packages/app/src/features/scene/useSceneLoader.ts
+++ b/packages/app/src/features/scene/useSceneLoader.ts
@@ -38,17 +38,24 @@ const useSceneLoader = (
     staleTime: Infinity,
   });
 
-  // The static <title> baked into index.html is the crawler / link-preview
-  // title for the site. Capture it on first render (before the effect below can
-  // overwrite it) so we can restore it whenever no scene title applies, rather
-  // than clobbering it with a hardcoded default. Restoring (not just skipping
-  // the write) also keeps SPA navigation correct: leaving from a titled scene
-  // back home resets the tab instead of leaving the previous scene's title.
-  const defaultTitle = useRef(document.title);
+  // The site's crawler / link-preview default lives in
+  // <meta name="default-title">, which the metadata Worker leaves untouched
+  // (it only rewrites <title> per-scene at the edge). Read it once as the
+  // no-scene default so the loader gets the true site title whether or not the
+  // Worker ran; fall back to document.title for dev/tests where the meta may be
+  // absent. Restoring it (not just skipping the write) also keeps SPA
+  // navigation correct: leaving a titled scene back home resets the tab instead
+  // of stranding the previous scene's title.
+  const defaultTitle = useRef(
+    document.querySelector<HTMLMetaElement>('meta[name="default-title"]')
+      ?.content ?? document.title,
+  );
 
   useEffect(() => {
+    // Keep this format identical to the Worker's edge-rewritten <title> so a
+    // deep-linked scene shows the same tab title before and after app boot.
     document.title = data?.title
-      ? `Math3d - ${data.title}`
+      ? `${data.title} | Math3d`
       : defaultTitle.current;
   }, [data]);
 

--- a/packages/app/src/pages/MainPage/MainPage.spec.tsx
+++ b/packages/app/src/pages/MainPage/MainPage.spec.tsx
@@ -81,6 +81,17 @@ test("Sets the document title from the loaded scene's title", async () => {
   });
 });
 
+test("Uses the site default title for a scene left at the default 'Untitled'", async () => {
+  // A scene at the DB default "Untitled" reads like the home page — the rich
+  // site default — matching what the OG Worker leaves in <title> at the edge
+  // (no "Untitled | Math3d" flash on boot).
+  document.title = "Math3d: Online 3d Graphing Calculator";
+  const scene = seedDb.withSceneFromItems([], { title: "Untitled" });
+  const { queryClient } = renderTestApp(`/${scene.key}`);
+  await waitForAppReady(queryClient);
+  expect(document.title).toBe("Math3d: Online 3d Graphing Calculator");
+});
+
 test("No-scene default falls back to document.title when default-title meta is absent", async () => {
   // Dev/tests may ship no <meta name="default-title">; the loader then falls
   // back to the static <title> and must not clobber it on the home route.

--- a/packages/app/src/pages/MainPage/MainPage.spec.tsx
+++ b/packages/app/src/pages/MainPage/MainPage.spec.tsx
@@ -75,17 +75,38 @@ test("Sets the document title from the loaded scene's title", async () => {
   const scene = seedDb.withSceneFromItems([], { title: "My Torus" });
   renderTestApp(`/${scene.key}`);
   await waitFor(() => {
-    expect(document.title).toBe("Math3d - My Torus");
+    // Matches the format the OG Worker writes into <title> at the edge, so a
+    // deep-linked scene shows the same tab title before and after app boot.
+    expect(document.title).toBe("My Torus | Math3d");
   });
 });
 
-test("Leaves the static document title untouched when no scene is loaded", async () => {
-  // The static <title> baked into index.html is the crawler/link-preview title.
-  // On the home/new-scene route (no scene key) the loader must not clobber it.
+test("No-scene default falls back to document.title when default-title meta is absent", async () => {
+  // Dev/tests may ship no <meta name="default-title">; the loader then falls
+  // back to the static <title> and must not clobber it on the home route.
   document.title = "Static Head Title";
   const { queryClient } = renderTestApp("/");
   await waitForAppReady(queryClient);
   expect(document.title).toBe("Static Head Title");
+});
+
+test("No-scene default reads the default-title meta when present", async () => {
+  // The OG Worker rewrites <title> per-scene but leaves <meta name="default-title">
+  // untouched, so the loader sources its no-scene default from the meta — not from
+  // a possibly Worker-rewritten <title>.
+  document.title = "Some Scene | Math3d"; // simulate a Worker-rewritten <title>
+  const meta = document.createElement("meta");
+  meta.setAttribute("name", "default-title");
+  meta.setAttribute("content", "Math3d: Online 3d Graphing Calculator");
+  document.head.appendChild(meta);
+
+  try {
+    const { queryClient } = renderTestApp("/");
+    await waitForAppReady(queryClient);
+    expect(document.title).toBe("Math3d: Online 3d Graphing Calculator");
+  } finally {
+    meta.remove();
+  }
 });
 
 test("Alerts and redirects home when the scene key is not found", async () => {

--- a/packages/app/src/worker/index.spec.ts
+++ b/packages/app/src/worker/index.spec.ts
@@ -81,18 +81,17 @@ it("overrides Cache-Control so intermediaries don't cache per-scene HTML", async
   expect(res.headers.get("cache-control")).toContain("private");
 });
 
-it.each([{ title: "" }, { title: "   " }, { title: "Untitled" }])(
-  "keeps the shell's default title for an untitled scene but still rewrites og:url (%o)",
-  async (body) => {
-    stubMeta({ status: 200 }, body);
-    const t = await tags(await call("/abc123", makeEnv()));
-    // Untitled scene reads like the home page — the shell's rich defaults are
-    // left untouched — but og:url still points at this scene's canonical URL.
-    expect(t.title).toBe(DEFAULT_TITLE);
-    expect(t.ogTitle).toBe(DEFAULT_TITLE);
-    expect(t.ogUrl).toBe("https://og.math3d.test/abc123");
-  },
-);
+it("keeps the shell's default title for an untitled scene but still rewrites og:url", async () => {
+  // "Untitled" (the DB default) represents the untitled branch; that blank and
+  // whitespace also collapse to untitled is the shared helper's job, pinned in
+  // sceneTitle.spec.ts. Here the Worker leaves the shell's rich defaults for
+  // the title tags but still points og:url at this scene's canonical URL.
+  stubMeta({ status: 200 }, { title: "Untitled" });
+  const t = await tags(await call("/abc123", makeEnv()));
+  expect(t.title).toBe(DEFAULT_TITLE);
+  expect(t.ogTitle).toBe(DEFAULT_TITLE);
+  expect(t.ogUrl).toBe("https://og.math3d.test/abc123");
+});
 
 it("escapes a hostile title (no tag/attribute breakout)", async () => {
   stubMeta({ status: 200 }, { title: '"><img src=x onerror=alert(1)>' });

--- a/packages/app/src/worker/index.spec.ts
+++ b/packages/app/src/worker/index.spec.ts
@@ -1,13 +1,15 @@
 import { afterEach, expect, it, vi } from "vitest";
 import worker from "./index";
 
+const DEFAULT_TITLE = "Math3d: Online 3d Graphing Calculator";
+
 const SHELL_HTML = `<!doctype html><html><head>
-<title>Math3d: Online 3d Graphing Calculator</title>
-<meta property="og:title" content="Math3d: Online 3d Graphing Calculator" />
-<meta name="twitter:title" content="Math3d: Online 3d Graphing Calculator" />
+<title>${DEFAULT_TITLE}</title>
+<meta property="og:title" content="${DEFAULT_TITLE}" />
+<meta name="twitter:title" content="${DEFAULT_TITLE}" />
 <meta property="og:url" content="https://next.math3d.org/" />
 <meta property="og:description" content="site tagline" />
-<meta name="default-title" content="Math3d: Online 3d Graphing Calculator" />
+<meta name="default-title" content="${DEFAULT_TITLE}" />
 </head><body></body></html>`;
 
 const makeEnv = () => ({
@@ -18,7 +20,9 @@ const makeEnv = () => ({
     ),
   },
   API_BASE: "https://api.example.test",
-  SITE_ORIGIN: "https://next.math3d.org",
+  // Deliberately distinct from the request host below, so tests pin that og:url
+  // is built from SITE_ORIGIN, not the incoming request URL.
+  SITE_ORIGIN: "https://og.math3d.test",
 });
 
 /** Stub the global fetch the Worker uses for the /meta/ lookup. */
@@ -59,16 +63,16 @@ const tags = async (res: Response) => {
 
 afterEach(() => vi.restoreAllMocks());
 
-it("rewrites the title tags on a valid scene key", async () => {
+it("rewrites the title tags on a titled scene", async () => {
   stubMeta({ status: 200 }, { title: "My Torus" });
   const t = await tags(await call("/abc123", makeEnv()));
   expect(t.title).toBe("My Torus | Math3d");
   expect(t.ogTitle).toBe("My Torus");
   expect(t.twitterTitle).toBe("My Torus");
-  expect(t.ogUrl).toBe("https://next.math3d.org/abc123");
+  expect(t.ogUrl).toBe("https://og.math3d.test/abc123");
   // left at their index.html defaults:
   expect(t.ogDesc).toBe("site tagline");
-  expect(t.defaultTitle).toBe("Math3d: Online 3d Graphing Calculator");
+  expect(t.defaultTitle).toBe(DEFAULT_TITLE);
 });
 
 it("overrides Cache-Control so intermediaries don't cache per-scene HTML", async () => {
@@ -78,22 +82,17 @@ it("overrides Cache-Control so intermediaries don't cache per-scene HTML", async
 });
 
 it.each([{ title: "" }, { title: "   " }, { title: "Untitled" }])(
-  "maps empty/whitespace/Untitled to the generic name (%o)",
+  "keeps the shell's default title for an untitled scene but still rewrites og:url (%o)",
   async (body) => {
     stubMeta({ status: 200 }, body);
     const t = await tags(await call("/abc123", makeEnv()));
-    expect(t.title).toBe("Untitled scene | Math3d");
-    expect(t.ogTitle).toBe("Untitled scene");
+    // Untitled scene reads like the home page — the shell's rich defaults are
+    // left untouched — but og:url still points at this scene's canonical URL.
+    expect(t.title).toBe(DEFAULT_TITLE);
+    expect(t.ogTitle).toBe(DEFAULT_TITLE);
+    expect(t.ogUrl).toBe("https://og.math3d.test/abc123");
   },
 );
-
-it("clamps an over-long title on a code-point boundary", async () => {
-  stubMeta({ status: 200 }, { title: "😀".repeat(300) });
-  const t = await tags(await call("/abc123", makeEnv()));
-  const name = t.title!.replace(" | Math3d", "");
-  expect(Array.from(name)).toHaveLength(200); // 200 code points, no split surrogate
-  expect(name.endsWith("😀")).toBe(true);
-});
 
 it("escapes a hostile title (no tag/attribute breakout)", async () => {
   stubMeta({ status: 200 }, { title: '"><img src=x onerror=alert(1)>' });
@@ -114,40 +113,40 @@ it("escapes a hostile title (no tag/attribute breakout)", async () => {
   expect(imgElements).toBe(0);
 });
 
-it.each(["/app", "/app/frame/x", "/a/b", "/foo.png", "/", "/x"])(
+it.each(["/app", "/app/frame/x", "/foo.png", "/", "/x"])(
   "passes through non-candidate/invalid paths without touching /meta/ (%s)",
   async (path) => {
     const spy = vi.fn();
     vi.stubGlobal("fetch", spy);
     const res = await call(path, makeEnv());
     expect(spy).not.toHaveBeenCalled(); // no /meta/ fetch
-    expect(await res.text()).toContain(
-      "<title>Math3d: Online 3d Graphing Calculator</title>",
-    );
+    expect(await res.text()).toContain(`<title>${DEFAULT_TITLE}</title>`);
   },
 );
 
 it.each([
   ["404", { status: 404 } as ResponseInit, { title: "ignored" }],
-  ["500", { status: 500 } as ResponseInit, { title: "ignored" }],
   ["malformed 200 body", { status: 200 } as ResponseInit, undefined],
   ["missing title field", { status: 200 } as ResponseInit, { notTitle: 1 }],
 ])("serves default tags on %s", async (_label, init, body) => {
   stubMeta(init, body);
   const t = await tags(await call("/abc123", makeEnv()));
-  expect(t.title).toBe("Math3d: Online 3d Graphing Calculator");
-  expect(t.ogTitle).toBe("Math3d: Online 3d Graphing Calculator");
+  expect(t.title).toBe(DEFAULT_TITLE);
+  expect(t.ogTitle).toBe(DEFAULT_TITLE);
 });
 
-it("serves default tags when the /meta/ fetch rejects (network/timeout)", async () => {
+it("fails open AND marks the response private when the /meta/ fetch rejects", async () => {
   vi.stubGlobal(
     "fetch",
     vi.fn(async () => {
       throw new Error("network down");
     }),
   );
-  const t = await tags(await call("/abc123", makeEnv()));
-  expect(t.title).toBe("Math3d: Online 3d Graphing Calculator");
+  const res = await call("/abc123", makeEnv());
+  // A transient backend failure must not let a titleless generic shell be
+  // cached by a shared intermediary under this scene's URL.
+  expect(res.headers.get("cache-control")).toContain("private");
+  expect((await tags(res)).title).toBe(DEFAULT_TITLE);
 });
 
 it("fetches /meta/ with a bare URL and forwards no request headers/cookies", async () => {

--- a/packages/app/src/worker/index.spec.ts
+++ b/packages/app/src/worker/index.spec.ts
@@ -1,0 +1,166 @@
+import { afterEach, expect, it, vi } from "vitest";
+import worker from "./index";
+
+const SHELL_HTML = `<!doctype html><html><head>
+<title>Math3d: Online 3d Graphing Calculator</title>
+<meta property="og:title" content="Math3d: Online 3d Graphing Calculator" />
+<meta name="twitter:title" content="Math3d: Online 3d Graphing Calculator" />
+<meta property="og:url" content="https://next.math3d.org/" />
+<meta property="og:description" content="site tagline" />
+<meta name="default-title" content="Math3d: Online 3d Graphing Calculator" />
+</head><body></body></html>`;
+
+const makeEnv = () => ({
+  ASSETS: {
+    fetch: vi.fn(
+      async () =>
+        new Response(SHELL_HTML, { headers: { "content-type": "text/html" } }),
+    ),
+  },
+  API_BASE: "https://api.example.test",
+  SITE_ORIGIN: "https://next.math3d.org",
+});
+
+/** Stub the global fetch the Worker uses for the /meta/ lookup. */
+const stubMeta = (init: ResponseInit, body?: unknown) =>
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () =>
+      body === undefined
+        ? new Response("not json", init)
+        : new Response(JSON.stringify(body), {
+            headers: { "content-type": "application/json" },
+            ...init,
+          }),
+    ),
+  );
+
+const call = (path: string, env: ReturnType<typeof makeEnv>) =>
+  worker.fetch(
+    new Request(`https://next.math3d.org${path}`, {
+      headers: { "Sec-Fetch-Mode": "navigate", cookie: "sessionid=secret" },
+    }),
+    env as unknown as never,
+  );
+
+const tags = async (res: Response) => {
+  const html = await res.text();
+  const g = (re: RegExp) => html.match(re)?.[1] ?? null;
+  return {
+    raw: html,
+    title: g(/<title>([^<]*)<\/title>/),
+    ogTitle: g(/property="og:title" content="([^"]*)"/),
+    twitterTitle: g(/name="twitter:title" content="([^"]*)"/),
+    ogUrl: g(/property="og:url" content="([^"]*)"/),
+    ogDesc: g(/property="og:description" content="([^"]*)"/),
+    defaultTitle: g(/name="default-title" content="([^"]*)"/),
+  };
+};
+
+afterEach(() => vi.restoreAllMocks());
+
+it("rewrites the title tags on a valid scene key", async () => {
+  stubMeta({ status: 200 }, { title: "My Torus" });
+  const t = await tags(await call("/abc123", makeEnv()));
+  expect(t.title).toBe("My Torus | Math3d");
+  expect(t.ogTitle).toBe("My Torus");
+  expect(t.twitterTitle).toBe("My Torus");
+  expect(t.ogUrl).toBe("https://next.math3d.org/abc123");
+  // left at their index.html defaults:
+  expect(t.ogDesc).toBe("site tagline");
+  expect(t.defaultTitle).toBe("Math3d: Online 3d Graphing Calculator");
+});
+
+it("overrides Cache-Control so intermediaries don't cache per-scene HTML", async () => {
+  stubMeta({ status: 200 }, { title: "My Torus" });
+  const res = await call("/abc123", makeEnv());
+  expect(res.headers.get("cache-control")).toContain("private");
+});
+
+it.each([{ title: "" }, { title: "   " }, { title: "Untitled" }])(
+  "maps empty/whitespace/Untitled to the generic name (%o)",
+  async (body) => {
+    stubMeta({ status: 200 }, body);
+    const t = await tags(await call("/abc123", makeEnv()));
+    expect(t.title).toBe("Untitled scene | Math3d");
+    expect(t.ogTitle).toBe("Untitled scene");
+  },
+);
+
+it("clamps an over-long title on a code-point boundary", async () => {
+  stubMeta({ status: 200 }, { title: "😀".repeat(300) });
+  const t = await tags(await call("/abc123", makeEnv()));
+  const name = t.title!.replace(" | Math3d", "");
+  expect(Array.from(name)).toHaveLength(200); // 200 code points, no split surrogate
+  expect(name.endsWith("😀")).toBe(true);
+});
+
+it("escapes a hostile title (no tag/attribute breakout)", async () => {
+  stubMeta({ status: 200 }, { title: '"><img src=x onerror=alert(1)>' });
+  const res = await call("/abc123", makeEnv());
+  // Re-parse the output. A successful breakout — from the <title> inner content
+  // or an og:title/twitter:title attribute value — would introduce a real <img>
+  // element. HTMLRewriter matches only actual elements, never escaped text or
+  // quoted attribute values, so any match here means escaping failed.
+  let imgElements = 0;
+  await new HTMLRewriter()
+    .on("img", {
+      element() {
+        imgElements += 1;
+      },
+    })
+    .transform(res)
+    .text();
+  expect(imgElements).toBe(0);
+});
+
+it.each(["/app", "/app/frame/x", "/a/b", "/foo.png", "/", "/x"])(
+  "passes through non-candidate/invalid paths without touching /meta/ (%s)",
+  async (path) => {
+    const spy = vi.fn();
+    vi.stubGlobal("fetch", spy);
+    const res = await call(path, makeEnv());
+    expect(spy).not.toHaveBeenCalled(); // no /meta/ fetch
+    expect(await res.text()).toContain(
+      "<title>Math3d: Online 3d Graphing Calculator</title>",
+    );
+  },
+);
+
+it.each([
+  ["404", { status: 404 } as ResponseInit, { title: "ignored" }],
+  ["500", { status: 500 } as ResponseInit, { title: "ignored" }],
+  ["malformed 200 body", { status: 200 } as ResponseInit, undefined],
+  ["missing title field", { status: 200 } as ResponseInit, { notTitle: 1 }],
+])("serves default tags on %s", async (_label, init, body) => {
+  stubMeta(init, body);
+  const t = await tags(await call("/abc123", makeEnv()));
+  expect(t.title).toBe("Math3d: Online 3d Graphing Calculator");
+  expect(t.ogTitle).toBe("Math3d: Online 3d Graphing Calculator");
+});
+
+it("serves default tags when the /meta/ fetch rejects (network/timeout)", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => {
+      throw new Error("network down");
+    }),
+  );
+  const t = await tags(await call("/abc123", makeEnv()));
+  expect(t.title).toBe("Math3d: Online 3d Graphing Calculator");
+});
+
+it("fetches /meta/ with a bare URL and forwards no request headers/cookies", async () => {
+  const spy = vi.fn(
+    async () =>
+      new Response(JSON.stringify({ title: "X" }), {
+        headers: { "content-type": "application/json" },
+      }),
+  );
+  vi.stubGlobal("fetch", spy);
+  await call("/abc123", makeEnv());
+  expect(spy).toHaveBeenCalledTimes(1);
+  const [input, init] = spy.mock.calls[0] as unknown as [string, RequestInit?];
+  expect(input).toBe("https://api.example.test/scenes/abc123/meta/");
+  expect(init?.headers).toBeUndefined();
+});

--- a/packages/app/src/worker/index.spec.ts
+++ b/packages/app/src/worker/index.spec.ts
@@ -161,6 +161,6 @@ it("fetches /meta/ with a bare URL and forwards no request headers/cookies", asy
   await call("/abc123", makeEnv());
   expect(spy).toHaveBeenCalledTimes(1);
   const [input, init] = spy.mock.calls[0] as unknown as [string, RequestInit?];
-  expect(input).toBe("https://api.example.test/scenes/abc123/meta/");
+  expect(input).toBe("https://api.example.test/v1/scenes/abc123/meta/");
   expect(init?.headers).toBeUndefined();
 });

--- a/packages/app/src/worker/index.ts
+++ b/packages/app/src/worker/index.ts
@@ -1,0 +1,122 @@
+/**
+ * OG metadata Worker (pass 1: per-scene text).
+ *
+ * Fronts the Static-Assets deployment. For a single-segment scene-key
+ * navigation it looks up the scene title via the read-only
+ * `GET /scenes/{key}/meta/` endpoint and rewrites a fixed set of <head> tags in
+ * the SPA shell via HTMLRewriter. Every other request passes straight through
+ * to env.ASSETS untouched. The SPA never reads anything this injects — it's
+ * crawler-facing metadata only (abandonability invariant).
+ *
+ * Design: docs/superpowers/specs/2026-07-11-og-metadata-worker-design.md
+ */
+interface Env {
+  ASSETS: Fetcher;
+  API_BASE: string;
+  SITE_ORIGIN: string;
+}
+
+/** Superset of the real key charset; cheap defense-in-depth before any backend touch. */
+const KEY_RE = /^[A-Za-z0-9_-]{2,80}$/;
+const META_TIMEOUT_MS = 800;
+const TITLE_MAX_CODEPOINTS = 200;
+
+/** A single non-asset path segment that could be a scene key, else null. */
+const sceneKeyFromPath = (pathname: string): string | null => {
+  const seg = pathname.replace(/^\/+/, "").replace(/\/+$/, "");
+  if (seg === "" || seg.includes("/") || seg.includes(".") || seg === "app") {
+    return null;
+  }
+  return KEY_RE.test(seg) ? seg : null;
+};
+
+/**
+ * Read-only title lookup. Returns the title string (possibly "") on a valid
+ * 200, or null on any failure — non-2xx, malformed body, missing/non-string
+ * title, timeout, or network error. The caller treats null as "passthrough
+ * defaults": the page must never block or error on this lookup.
+ *
+ * Uses a bare URL string (not the incoming request), so no cookies or headers
+ * are forwarded to the public endpoint.
+ */
+const fetchTitle = async (env: Env, key: string): Promise<string | null> => {
+  try {
+    const res = await fetch(`${env.API_BASE}/scenes/${key}/meta/`, {
+      signal: AbortSignal.timeout(META_TIMEOUT_MS),
+    });
+    if (!res.ok) return null;
+    const body: unknown = await res.json();
+    if (
+      typeof body === "object" &&
+      body !== null &&
+      typeof (body as { title?: unknown }).title === "string"
+    ) {
+      return (body as { title: string }).title;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+};
+
+/** Clamp to a code-point boundary so a surrogate pair / emoji isn't split. */
+const clampCodePoints = (value: string, max: number): string => {
+  const cps = Array.from(value);
+  return cps.length <= max ? value : cps.slice(0, max).join("");
+};
+
+/** Trim + clamp; empty or the literal "Untitled" collapses to a generic name. */
+const displayName = (raw: string): string => {
+  const name = clampCodePoints(raw.trim(), TITLE_MAX_CODEPOINTS);
+  return name === "" || name === "Untitled" ? "Untitled scene" : name;
+};
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const key = sceneKeyFromPath(new URL(request.url).pathname);
+    if (key === null) return env.ASSETS.fetch(request);
+
+    const rawTitle = await fetchTitle(env, key);
+    if (rawTitle === null) return env.ASSETS.fetch(request); // graceful default
+
+    const name = displayName(rawTitle);
+    const tabTitle = `${name} | Math3d`;
+    const ogUrl = `${env.SITE_ORIGIN}/${key}`;
+
+    const shell = await env.ASSETS.fetch(request);
+    // The title is user-controlled: inject it ONLY via HTMLRewriter's escaping
+    // setters (setInnerContent {html:false} / setAttribute) — never concatenate
+    // it into raw HTML. All state here is request-local (no module globals).
+    const rewritten = new HTMLRewriter()
+      .on("title", {
+        element(el) {
+          el.setInnerContent(tabTitle, { html: false });
+        },
+      })
+      .on('meta[property="og:title"]', {
+        element(el) {
+          el.setAttribute("content", name);
+        },
+      })
+      .on('meta[name="twitter:title"]', {
+        element(el) {
+          el.setAttribute("content", name);
+        },
+      })
+      .on('meta[property="og:url"]', {
+        element(el) {
+          el.setAttribute("content", ogUrl);
+        },
+      })
+      .transform(shell);
+
+    // Don't let an intermediary over-cache this per-scene HTML (the shell's own
+    // Cache-Control would otherwise carry through).
+    const response = new Response(rewritten.body, rewritten);
+    response.headers.set(
+      "Cache-Control",
+      "private, max-age=0, must-revalidate",
+    );
+    return response;
+  },
+};

--- a/packages/app/src/worker/index.ts
+++ b/packages/app/src/worker/index.ts
@@ -10,6 +10,8 @@
  *
  * Design: docs/superpowers/specs/2026-07-11-og-metadata-worker-design.md
  */
+import { sceneDisplayName } from "../features/scene/sceneTitle";
+
 interface Env {
   ASSETS: Fetcher;
   API_BASE: string;
@@ -19,7 +21,6 @@ interface Env {
 /** Superset of the real key charset; cheap defense-in-depth before any backend touch. */
 const KEY_RE = /^[A-Za-z0-9_-]{2,80}$/;
 const META_TIMEOUT_MS = 800;
-const TITLE_MAX_CODEPOINTS = 200;
 
 /** A single non-asset path segment that could be a scene key, else null. */
 const sceneKeyFromPath = (pathname: string): string | null => {
@@ -60,35 +61,34 @@ const fetchTitle = async (env: Env, key: string): Promise<string | null> => {
   }
 };
 
-/** Clamp to a code-point boundary so a surrogate pair / emoji isn't split. */
-const clampCodePoints = (value: string, max: number): string => {
-  const cps = Array.from(value);
-  return cps.length <= max ? value : cps.slice(0, max).join("");
-};
+/**
+ * Rewrite the shell's crawler-facing <head> tags for a scene. og:url is always
+ * set to the scene's canonical URL. The <title>/og:title/twitter:title are
+ * rewritten only for a *titled* scene; an untitled scene (blank or the literal
+ * default "Untitled") keeps the shell's static rich defaults — matching the
+ * home page and the SPA's own client-side title.
+ *
+ * The title is user-controlled: inject it ONLY via HTMLRewriter's escaping
+ * setters (setInnerContent {html:false} / setAttribute) — never concatenate it
+ * into raw HTML. All state here is request-local (no module globals).
+ */
+const rewriteShell = (
+  shell: Response,
+  rawTitle: string,
+  key: string,
+  env: Env,
+): Response => {
+  const ogUrl = `${env.SITE_ORIGIN}/${key}`;
+  let rewriter = new HTMLRewriter().on('meta[property="og:url"]', {
+    element(el) {
+      el.setAttribute("content", ogUrl);
+    },
+  });
 
-/** Trim + clamp; empty or the literal "Untitled" collapses to a generic name. */
-const displayName = (raw: string): string => {
-  const name = clampCodePoints(raw.trim(), TITLE_MAX_CODEPOINTS);
-  return name === "" || name === "Untitled" ? "Untitled scene" : name;
-};
-
-export default {
-  async fetch(request: Request, env: Env): Promise<Response> {
-    const key = sceneKeyFromPath(new URL(request.url).pathname);
-    if (key === null) return env.ASSETS.fetch(request);
-
-    const rawTitle = await fetchTitle(env, key);
-    if (rawTitle === null) return env.ASSETS.fetch(request); // graceful default
-
-    const name = displayName(rawTitle);
+  const name = sceneDisplayName(rawTitle);
+  if (name !== null) {
     const tabTitle = `${name} | Math3d`;
-    const ogUrl = `${env.SITE_ORIGIN}/${key}`;
-
-    const shell = await env.ASSETS.fetch(request);
-    // The title is user-controlled: inject it ONLY via HTMLRewriter's escaping
-    // setters (setInnerContent {html:false} / setAttribute) — never concatenate
-    // it into raw HTML. All state here is request-local (no module globals).
-    const rewritten = new HTMLRewriter()
+    rewriter = rewriter
       .on("title", {
         element(el) {
           el.setInnerContent(tabTitle, { html: false });
@@ -103,17 +103,33 @@ export default {
         element(el) {
           el.setAttribute("content", name);
         },
-      })
-      .on('meta[property="og:url"]', {
-        element(el) {
-          el.setAttribute("content", ogUrl);
-        },
-      })
-      .transform(shell);
+      });
+  }
 
-    // Don't let an intermediary over-cache this per-scene HTML (the shell's own
-    // Cache-Control would otherwise carry through).
-    const response = new Response(rewritten.body, rewritten);
+  const rewritten = rewriter.transform(shell);
+  return new Response(rewritten.body, rewritten);
+};
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const key = sceneKeyFromPath(new URL(request.url).pathname);
+    if (key === null) return env.ASSETS.fetch(request);
+
+    // Scene-key path: fetch the shell and the title in parallel so the lookup
+    // never adds its full latency on top of the shell fetch.
+    const [shell, rawTitle] = await Promise.all([
+      env.ASSETS.fetch(request),
+      fetchTitle(env, key),
+    ]);
+
+    const response =
+      rawTitle === null
+        ? new Response(shell.body, shell) // fail-open: serve the default shell
+        : rewriteShell(shell, rawTitle, key, env);
+
+    // Anything served under a scene URL — a rewrite or a transient fail-open
+    // shell — is per-scene and must not be cached by shared intermediaries.
+    // (The real passthrough above keeps the asset's own caching.)
     response.headers.set(
       "Cache-Control",
       "private, max-age=0, must-revalidate",

--- a/packages/app/src/worker/index.ts
+++ b/packages/app/src/worker/index.ts
@@ -37,11 +37,12 @@ const sceneKeyFromPath = (pathname: string): string | null => {
  * defaults": the page must never block or error on this lookup.
  *
  * Uses a bare URL string (not the incoming request), so no cookies or headers
- * are forwarded to the public endpoint.
+ * are forwarded to the public endpoint. API_BASE is the bare API origin; the
+ * ninja API is mounted under /v1 (matching the generated client's paths).
  */
 const fetchTitle = async (env: Env, key: string): Promise<string | null> => {
   try {
-    const res = await fetch(`${env.API_BASE}/scenes/${key}/meta/`, {
+    const res = await fetch(`${env.API_BASE}/v1/scenes/${key}/meta/`, {
       signal: AbortSignal.timeout(META_TIMEOUT_MS),
     });
     if (!res.ok) return null;

--- a/packages/app/src/worker/smoke.test.ts
+++ b/packages/app/src/worker/smoke.test.ts
@@ -1,5 +1,0 @@
-import { test, expect } from "vitest";
-
-test("runs under workerd with HTMLRewriter available", () => {
-  expect(typeof HTMLRewriter).toBe("function");
-});

--- a/packages/app/src/worker/smoke.test.ts
+++ b/packages/app/src/worker/smoke.test.ts
@@ -1,0 +1,5 @@
+import { test, expect } from "vitest";
+
+test("runs under workerd with HTMLRewriter available", () => {
+  expect(typeof HTMLRewriter).toBe("function");
+});

--- a/packages/app/src/worker/tsconfig.json
+++ b/packages/app/src/worker/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  // The edge Worker runs in workerd, not the browser: its Request/Response/fetch
+  // and globals like HTMLRewriter come from @cloudflare/workers-types and would
+  // conflict with the app's DOM lib. So this directory is typechecked on its own,
+  // excluded from the app's main tsconfig, with the DOM lib swapped out.
+  "extends": "@math3d/tsconfig/base.json",
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["."]
+}

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -8,5 +8,13 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["src", "vite.config.ts", "src/pages/HelpPage/data.compile.ts"]
+  "include": [
+    "src",
+    "vite.config.ts",
+    "vitest.worker.config.ts",
+    "src/pages/HelpPage/data.compile.ts"
+  ],
+  // The Worker is typechecked separately with Workers (not DOM) types; see
+  // src/worker/tsconfig.json.
+  "exclude": ["src/worker"]
 }

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -110,20 +110,33 @@ export default defineConfig({
     },
   },
   test: {
-    globals: true,
-    clearMocks: true,
-    setupFiles: ["./src/setupTests.ts"],
-    environment: "jsdom",
-    env: {
-      VITE_DISPLAY_AUTH_FLOWS: "true",
-    },
-    exclude: ["**/playwright/**"],
-    include: ["./src/**/*.{test,spec}.{ts,tsx}"],
-    css: {
-      include: /\*.module.css/,
-      modules: {
-        classNameStrategy: "non-scoped",
+    projects: [
+      {
+        // The app's jsdom tests. `extends: true` inherits this file's plugins
+        // and resolve (react, tsconfig paths, validate-env). The worker tests
+        // live in a separate workerd project (vitest.worker.config.ts) and are
+        // excluded here so they don't run under jsdom.
+        extends: true,
+        test: {
+          name: "jsdom",
+          globals: true,
+          clearMocks: true,
+          setupFiles: ["./src/setupTests.ts"],
+          environment: "jsdom",
+          env: {
+            VITE_DISPLAY_AUTH_FLOWS: "true",
+          },
+          exclude: ["**/playwright/**", "./src/worker/**"],
+          include: ["./src/**/*.{test,spec}.{ts,tsx}"],
+          css: {
+            include: /\*.module.css/,
+            modules: {
+              classNameStrategy: "non-scoped",
+            },
+          },
+        },
       },
-    },
+      "./vitest.worker.config.ts",
+    ],
   },
 });

--- a/packages/app/vitest.worker.config.ts
+++ b/packages/app/vitest.worker.config.ts
@@ -1,0 +1,27 @@
+import { defineProject } from "vitest/config";
+import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
+
+/**
+ * Vitest project for the edge OG Worker (src/worker). It runs inside workerd
+ * (via @cloudflare/vitest-pool-workers) so runtime-only globals like
+ * HTMLRewriter exist — they don't under jsdom, where the rest of the app tests.
+ *
+ * This project is deliberately standalone (not `extends`-ing vite.config.ts):
+ * it must NOT inherit the app's react/validate-env plugins or setupTests.ts,
+ * which pull in jsdom/Testing-Library globals the pool disallows.
+ *
+ * The worker unit tests import the worker and build `env` by hand (mocking the
+ * ASSETS binding), so they need no wrangler `assets`/`main` wiring — only a
+ * compatibility date for workerd. Keep this date in sync with wrangler.jsonc.
+ */
+export default defineProject({
+  plugins: [
+    cloudflareTest({
+      miniflare: { compatibilityDate: "2026-07-04" },
+    }),
+  ],
+  test: {
+    name: "workers",
+    include: ["./src/worker/**/*.{test,spec}.ts"],
+  },
+});

--- a/packages/app/wrangler.jsonc
+++ b/packages/app/wrangler.jsonc
@@ -2,8 +2,33 @@
   "$schema": "../../node_modules/wrangler/config-schema.json",
   "name": "math3d-next",
   "compatibility_date": "2026-07-04",
+  "main": "./src/worker/index.ts",
   "assets": {
     "directory": "./dist",
-    "not_found_handling": "single-page-application"
+    "not_found_handling": "single-page-application",
+    "binding": "ASSETS",
+    // With our compatibility_date, assets_navigation_prefers_asset_serving is on
+    // by default, so a scene navigation would be served the SPA fallback WITHOUT
+    // invoking the Worker. Force the Worker to run for navigations, but keep real
+    // assets bypassing it (zero Worker invocations for assets). Validate with
+    // `wrangler dev` when changing these globs.
+    "run_worker_first": [
+      "/*",
+      "!/assets/*",
+      "!/og/*",
+      "!/favicon.ico",
+      "!/favicon.svg",
+      "!/apple-touch-icon.png",
+      "!/robots.txt",
+      "!/mockServiceWorker.js",
+      "!/index.html"
+    ]
+  },
+  "vars": {
+    "API_BASE": "https://api.math3d.org",
+    // Committed default; overridden at deploy via `--var SITE_ORIGIN:$SITE_ORIGIN`,
+    // sourced from the same CI value as VITE_SITE_ORIGIN so og:url and the static
+    // head defaults can't drift.
+    "SITE_ORIGIN": "https://next.math3d.org"
   }
 }

--- a/packages/custom-mathjs/package.json
+++ b/packages/custom-mathjs/package.json
@@ -8,7 +8,7 @@
     "@math3d/test-utils": "workspace:^",
     "@math3d/tsconfig": "workspace:^",
     "eslint": "^8.57.1",
-    "vitest": "^4.0.18"
+    "vitest": "^4.1.0"
   },
   "dependencies": {
     "mathjs": "^14.0.1"

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -58,6 +58,7 @@ module.exports = {
           "**/*.spec.tsx",
           "**/playwright.config.ts",
           "**/vite.config.ts",
+          "**/vitest.*.config.ts",
           "**/*.stories.tsx",
           "**/src/setupTests.ts",
           "**/src/playwright/**",

--- a/packages/mathitem-configs/package.json
+++ b/packages/mathitem-configs/package.json
@@ -12,7 +12,7 @@
     "eslint": "^8.57.1",
     "js-yaml": "^4.1.0",
     "mathjs": "^14.0.1",
-    "vitest": "^4.0.18"
+    "vitest": "^4.1.0"
   },
   "scripts": {
     "test": "vitest --run",

--- a/packages/mathjs-utils/package.json
+++ b/packages/mathjs-utils/package.json
@@ -10,7 +10,7 @@
     "@math3d/eslint-config": "workspace:^",
     "@math3d/tsconfig": "workspace:^",
     "eslint": "^8.57.1",
-    "vitest": "^4.0.18"
+    "vitest": "^4.1.0"
   },
   "scripts": {
     "test": "vitest --run",

--- a/packages/mathscope/package.json
+++ b/packages/mathscope/package.json
@@ -8,7 +8,7 @@
     "@math3d/tsconfig": "workspace:^",
     "eslint": "^8.57.1",
     "mathjs": "^14.0.1",
-    "vitest": "^4.0.18"
+    "vitest": "^4.1.0"
   },
   "scripts": {
     "test": "vitest --run",

--- a/packages/mock-api/package.json
+++ b/packages/mock-api/package.json
@@ -20,7 +20,7 @@
     "eslint": "^8.57.1",
     "lodash-es": "^4.18.1",
     "msw": "^2.0.14",
-    "vitest": "^4.0.18"
+    "vitest": "^4.1.0"
   },
   "scripts": {
     "test": "vitest --run",

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -8,7 +8,7 @@
     "@math3d/tsconfig": "workspace:^",
     "eslint": "^8.57.1",
     "mathjs": "^14.0.1",
-    "vitest": "^4.0.18"
+    "vitest": "^4.1.0"
   },
   "scripts": {
     "test": "vitest --run",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -8,7 +8,7 @@
     "@math3d/tsconfig": "workspace:^",
     "@types/react": "^19.2.17",
     "eslint": "^8.57.1",
-    "vitest": "^4.0.18"
+    "vitest": "^4.1.0"
   },
   "scripts": {
     "test": "vitest --run",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -7,7 +7,7 @@
     "@math3d/eslint-config": "workspace:^",
     "@math3d/tsconfig": "workspace:^",
     "eslint": "^8.57.1",
-    "vitest": "^4.0.18"
+    "vitest": "^4.1.0"
   },
   "scripts": {
     "test": "vitest --run",

--- a/packages/validators/package.json
+++ b/packages/validators/package.json
@@ -8,7 +8,7 @@
     "@math3d/eslint-config": "workspace:^",
     "@math3d/tsconfig": "workspace:^",
     "eslint": "^8.57.1",
-    "vitest": "^4.0.18"
+    "vitest": "^4.1.0"
   },
   "scripts": {
     "test": "vitest --run",

--- a/webserver/openapi.v1.yaml
+++ b/webserver/openapi.v1.yaml
@@ -1936,11 +1936,15 @@ paths:
       description: 'Read-only title lookup for the edge OG Worker.
 
 
-        No side effects: unlike ``get_scene`` it never increments ``times_accessed``
+        Serves only migrated (``Scene``) scenes, and does so with no side effects:
 
-        and never migrates a legacy key. Legacy titles are read out of the
+        unlike ``get_scene`` it never increments ``times_accessed`` and never
 
-        dehydrated blob directly, without persisting a migration.'
+        migrates a legacy key. An un-migrated legacy key 404s here — the Worker
+
+        then serves the branded default card, and the scene picks up per-scene
+
+        metadata once it''s opened in-app (which migrates it).'
       operationId: scenes_api_get_scene_meta
       parameters:
       - in: path

--- a/webserver/openapi.v1.yaml
+++ b/webserver/openapi.v1.yaml
@@ -1217,6 +1217,16 @@ components:
           title: Title
       title: SceneFilterSchema
       type: object
+    SceneMetaSchema:
+      description: Title-only shape for the read-only meta endpoint the edge OG Worker calls.
+      properties:
+        title:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Title
+      title: SceneMetaSchema
+      type: object
     ScenePatchSchema:
       properties:
         archived:
@@ -1919,6 +1929,34 @@ paths:
       security:
       - SessionAuth: []
       summary: Update Scene
+      tags:
+      - Scenes
+  /v1/scenes/{key}/meta/:
+    get:
+      description: 'Read-only title lookup for the edge OG Worker.
+
+
+        No side effects: unlike ``get_scene`` it never increments ``times_accessed``
+
+        and never migrates a legacy key. Legacy titles are read out of the
+
+        dehydrated blob directly, without persisting a migration.'
+      operationId: scenes_api_get_scene_meta
+      parameters:
+      - in: path
+        name: key
+        required: true
+        schema:
+          title: Key
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SceneMetaSchema'
+          description: OK
+      summary: Get Scene Meta
       tags:
       - Scenes
 servers: []

--- a/webserver/scenes/api.py
+++ b/webserver/scenes/api.py
@@ -15,6 +15,7 @@ from scenes.schemas import (
     MiniSceneSchema,
     SceneCreateSchema,
     SceneFilterSchema,
+    SceneMetaSchema,
     ScenePatchSchema,
     SceneSchema,
 )
@@ -55,6 +56,21 @@ def create_scene(request, payload: SceneCreateSchema):
         scene.title = payload.title
     scene.save()  # full_clean() re-validates items (defense in depth)
     return Status(201, scene)
+
+
+@scenes_router.get("/{key}/meta/", response=SceneMetaSchema, auth=None)
+def get_scene_meta(request, key: str):
+    """Read-only title lookup for the edge OG Worker.
+
+    No side effects: unlike ``get_scene`` it never increments ``times_accessed``
+    and never migrates a legacy key. Legacy titles are read out of the
+    dehydrated blob directly, without persisting a migration.
+    """
+    scene = Scene.objects.filter(key=key).only("title").first()
+    if scene is not None:
+        return {"title": scene.title}
+    legacy = get_object_or_404(LegacyScene, key=key)
+    return {"title": legacy.dehydrated.get("metadata", {}).get("title")}
 
 
 @scenes_router.get("/{key}/", response=SceneSchema, auth=None, by_alias=True)

--- a/webserver/scenes/api.py
+++ b/webserver/scenes/api.py
@@ -62,17 +62,14 @@ def create_scene(request, payload: SceneCreateSchema):
 def get_scene_meta(request, key: str):
     """Read-only title lookup for the edge OG Worker.
 
-    No side effects: unlike ``get_scene`` it never increments ``times_accessed``
-    and never migrates a legacy key. Legacy titles are read out of the
-    dehydrated blob directly, without persisting a migration.
+    Serves only migrated (``Scene``) scenes, and does so with no side effects:
+    unlike ``get_scene`` it never increments ``times_accessed`` and never
+    migrates a legacy key. An un-migrated legacy key 404s here — the Worker
+    then serves the branded default card, and the scene picks up per-scene
+    metadata once it's opened in-app (which migrates it).
     """
-    scene = Scene.objects.filter(key=key).only("title").first()
-    if scene is not None:
-        return {"title": scene.title}
-    legacy = get_object_or_404(LegacyScene, key=key)
-    # `metadata` can be present-but-null in a legacy blob; `or {}` keeps that
-    # from raising instead of failing open to a null title.
-    return {"title": (legacy.dehydrated.get("metadata") or {}).get("title")}
+    scene = get_object_or_404(Scene.objects.only("title"), key=key)
+    return {"title": scene.title}
 
 
 @scenes_router.get("/{key}/", response=SceneSchema, auth=None, by_alias=True)

--- a/webserver/scenes/api.py
+++ b/webserver/scenes/api.py
@@ -70,7 +70,9 @@ def get_scene_meta(request, key: str):
     if scene is not None:
         return {"title": scene.title}
     legacy = get_object_or_404(LegacyScene, key=key)
-    return {"title": legacy.dehydrated.get("metadata", {}).get("title")}
+    # `metadata` can be present-but-null in a legacy blob; `or {}` keeps that
+    # from raising instead of failing open to a null title.
+    return {"title": (legacy.dehydrated.get("metadata") or {}).get("title")}
 
 
 @scenes_router.get("/{key}/", response=SceneSchema, auth=None, by_alias=True)

--- a/webserver/scenes/api_test.py
+++ b/webserver/scenes/api_test.py
@@ -133,6 +133,43 @@ def _detail(key):
     return f"/v1/scenes/{key}/"
 
 
+def _meta(key):
+    return f"/v1/scenes/{key}/meta/"
+
+
+@pytest.mark.django_db
+def test_meta_returns_title_only():
+    scene = SceneFactory.create(title="My Torus")
+    resp = Client().get(_meta(scene.key))
+    assert resp.status_code == 200
+    assert resp.json() == {"title": "My Torus"}
+
+
+@pytest.mark.django_db
+def test_meta_does_not_increment_times_accessed():
+    scene = SceneFactory.create()
+    Client().get(_meta(scene.key))
+    scene.refresh_from_db()
+    assert scene.times_accessed == 0
+
+
+@pytest.mark.django_db
+def test_meta_unknown_key_returns_404():
+    assert Client().get(_meta("nonexistent")).status_code == 404
+
+
+@pytest.mark.django_db
+def test_meta_legacy_key_returns_title_without_migrating():
+    legacy = LegacyScene.objects.create(dehydrated=LEGACY_DEHYDRATED_FIXTURE)
+    resp = Client().get(_meta(legacy.key))
+    assert resp.status_code == 200
+    assert resp.json() == {"title": "Old"}  # from dehydrated["metadata"]["title"]
+    # The point of the endpoint: it must NOT persist a migration.
+    assert not Scene.objects.filter(key=legacy.key).exists()
+    legacy.refresh_from_db()
+    assert legacy.times_accessed == 0
+
+
 @pytest.mark.django_db
 def test_post_anonymous_creates_with_null_author_and_server_key():
     data = default_scene()

--- a/webserver/scenes/api_test.py
+++ b/webserver/scenes/api_test.py
@@ -171,6 +171,18 @@ def test_meta_legacy_key_returns_title_without_migrating():
 
 
 @pytest.mark.django_db
+def test_meta_legacy_key_with_null_metadata_returns_null_title():
+    # A legacy blob whose "metadata" is present-but-null must fail open
+    # (title=None → the Worker serves the default card), not raise a 500.
+    legacy = LegacyScene.objects.create(
+        dehydrated={**LEGACY_DEHYDRATED_FIXTURE, "metadata": None}
+    )
+    resp = Client().get(_meta(legacy.key))
+    assert resp.status_code == 200
+    assert resp.json() == {"title": None}
+
+
+@pytest.mark.django_db
 def test_post_anonymous_creates_with_null_author_and_server_key():
     data = default_scene()
     body = {"items": data["items"], "itemOrder": data["itemOrder"], "title": "Mine"}

--- a/webserver/scenes/api_test.py
+++ b/webserver/scenes/api_test.py
@@ -159,27 +159,16 @@ def test_meta_unknown_key_returns_404():
 
 
 @pytest.mark.django_db
-def test_meta_legacy_key_returns_title_without_migrating():
+def test_meta_unmigrated_legacy_key_returns_404_without_migrating():
+    # /meta/ only serves migrated (Scene) scenes: an un-migrated legacy key
+    # 404s (the Worker then serves the default card) and — like the rest of the
+    # endpoint — must NOT trigger or persist a migration.
     legacy = LegacyScene.objects.create(dehydrated=LEGACY_DEHYDRATED_FIXTURE)
     resp = Client().get(_meta(legacy.key))
-    assert resp.status_code == 200
-    assert resp.json() == {"title": "Old"}  # from dehydrated["metadata"]["title"]
-    # The point of the endpoint: it must NOT persist a migration.
+    assert resp.status_code == 404
     assert not Scene.objects.filter(key=legacy.key).exists()
     legacy.refresh_from_db()
     assert legacy.times_accessed == 0
-
-
-@pytest.mark.django_db
-def test_meta_legacy_key_with_null_metadata_returns_null_title():
-    # A legacy blob whose "metadata" is present-but-null must fail open
-    # (title=None → the Worker serves the default card), not raise a 500.
-    legacy = LegacyScene.objects.create(
-        dehydrated={**LEGACY_DEHYDRATED_FIXTURE, "metadata": None}
-    )
-    resp = Client().get(_meta(legacy.key))
-    assert resp.status_code == 200
-    assert resp.json() == {"title": None}
 
 
 @pytest.mark.django_db

--- a/webserver/scenes/schemas/__init__.py
+++ b/webserver/scenes/schemas/__init__.py
@@ -10,6 +10,7 @@ from scenes.schemas.scenes import (
     MiniSceneSchema,
     SceneCreateSchema,
     SceneFilterSchema,
+    SceneMetaSchema,
     ScenePatchSchema,
     SceneSchema,
 )
@@ -24,6 +25,7 @@ __all__ = [
     "MiniSceneSchema",
     "SceneCreateSchema",
     "SceneFilterSchema",
+    "SceneMetaSchema",
     "ScenePatchSchema",
     "SceneSchema",
 ]

--- a/webserver/scenes/schemas/scenes.py
+++ b/webserver/scenes/schemas/scenes.py
@@ -27,6 +27,12 @@ class MiniSceneSchema(_AuthoredSceneSchema):
     archived: bool
 
 
+class SceneMetaSchema(Schema):
+    """Title-only shape for the read-only meta endpoint the edge OG Worker calls."""
+
+    title: Optional[str] = None
+
+
 class SceneSchema(_AuthoredSceneSchema):
     items: List[MathItem]
     item_order: Dict[str, List[str]] = Field(alias="itemOrder")

--- a/yarn.lock
+++ b/yarn.lock
@@ -2038,6 +2038,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@cloudflare/workers-types@npm:^5.20260808.1":
+  version: 5.20260808.1
+  resolution: "@cloudflare/workers-types@npm:5.20260808.1"
+  checksum: 10/5725345aabe6ce69b40459b09571c8141c285cc11737d0b8869b2f80afc17ac069ca3f9be2ede24b85289912572cac94eb4437c01db9384046f4f0ba4fb52e63
+  languageName: node
+  linkType: hard
+
 "@cnakazawa/watch@npm:^1.0.3":
   version: 1.0.4
   resolution: "@cnakazawa/watch@npm:1.0.4"
@@ -7910,6 +7917,7 @@ __metadata:
   resolution: "app@workspace:packages/app"
   dependencies:
     "@cloudflare/vitest-pool-workers": "npm:^0.20.3"
+    "@cloudflare/workers-types": "npm:^5.20260808.1"
     "@dnd-kit/core": "npm:^6.3.1"
     "@dnd-kit/sortable": "npm:^10.0.0"
     "@dnd-kit/utilities": "npm:^3.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1951,9 +1951,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@cloudflare/vitest-pool-workers@npm:^0.20.3":
+  version: 0.20.3
+  resolution: "@cloudflare/vitest-pool-workers@npm:0.20.3"
+  dependencies:
+    cjs-module-lexer: "npm:1.2.3"
+    esbuild: "npm:0.28.1"
+    miniflare: "npm:5.20260801.1-alpha"
+    wrangler: "npm:4.120.0"
+    zod: "npm:4.4.3"
+  peerDependencies:
+    "@vitest/runner": ^4.1.0
+    "@vitest/snapshot": ^4.1.0
+    vitest: ^4.1.0
+  checksum: 10/5fe745d4418102111ae6e89f0ecdd377e32589497126baca9e6f17b88190ac22f42c147640b1ae4fe3128000574847d3145ea1bd4660229534bda201890adff9
+  languageName: node
+  linkType: hard
+
 "@cloudflare/workerd-darwin-64@npm:1.20260708.1":
   version: 1.20260708.1
   resolution: "@cloudflare/workerd-darwin-64@npm:1.20260708.1"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@cloudflare/workerd-darwin-64@npm:1.20260801.1":
+  version: 1.20260801.1
+  resolution: "@cloudflare/workerd-darwin-64@npm:1.20260801.1"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -1965,9 +1989,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@cloudflare/workerd-darwin-arm64@npm:1.20260801.1":
+  version: 1.20260801.1
+  resolution: "@cloudflare/workerd-darwin-arm64@npm:1.20260801.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@cloudflare/workerd-linux-64@npm:1.20260708.1":
   version: 1.20260708.1
   resolution: "@cloudflare/workerd-linux-64@npm:1.20260708.1"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@cloudflare/workerd-linux-64@npm:1.20260801.1":
+  version: 1.20260801.1
+  resolution: "@cloudflare/workerd-linux-64@npm:1.20260801.1"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
@@ -1979,9 +2017,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@cloudflare/workerd-linux-arm64@npm:1.20260801.1":
+  version: 1.20260801.1
+  resolution: "@cloudflare/workerd-linux-arm64@npm:1.20260801.1"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@cloudflare/workerd-windows-64@npm:1.20260708.1":
   version: 1.20260708.1
   resolution: "@cloudflare/workerd-windows-64@npm:1.20260708.1"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@cloudflare/workerd-windows-64@npm:1.20260801.1":
+  version: 1.20260801.1
+  resolution: "@cloudflare/workerd-windows-64@npm:1.20260801.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -2133,6 +2185,15 @@ __metadata:
     "@emnapi/wasi-threads": "npm:1.0.1"
     tslib: "npm:^2.4.0"
   checksum: 10/728eb47408c121286484047915f991ce1383bcf58fd46443202620f7c4f72294aafff85bf40621b9ee37b7a417497a92af5c8881b0cc6dc83a6375231cef2c33
+  languageName: node
+  linkType: hard
+
+"@emnapi/runtime@npm:^1.11.1":
+  version: 1.11.3
+  resolution: "@emnapi/runtime@npm:1.11.3"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10/ec834cc0fe248e06dd84f6dee10162133f8a692636189e99aa992303c791d4be1679536ee91aeee6661c4478609768cee9c085acd858caa92784c67acaab44a5
   languageName: node
   linkType: hard
 
@@ -2845,7 +2906,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@img/colour@npm:^1.0.0":
+"@img/colour@npm:^1.0.0, @img/colour@npm:^1.1.0":
   version: 1.1.0
   resolution: "@img/colour@npm:1.1.0"
   checksum: 10/2a29be7b06b046bd33c80ffa0f3493b7535b0841a69f54af81bf5e2d8867f21704fab42e9cf24ec30c089de34f790bae4dad1fc617c3163fbf264998dc316f0a
@@ -2857,6 +2918,18 @@ __metadata:
   resolution: "@img/sharp-darwin-arm64@npm:0.34.5"
   dependencies:
     "@img/sharp-libvips-darwin-arm64": "npm:1.2.4"
+  dependenciesMeta:
+    "@img/sharp-libvips-darwin-arm64":
+      optional: true
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@img/sharp-darwin-arm64@npm:0.35.2":
+  version: 0.35.2
+  resolution: "@img/sharp-darwin-arm64@npm:0.35.2"
+  dependencies:
+    "@img/sharp-libvips-darwin-arm64": "npm:1.3.1"
   dependenciesMeta:
     "@img/sharp-libvips-darwin-arm64":
       optional: true
@@ -2876,9 +2949,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@img/sharp-darwin-x64@npm:0.35.2":
+  version: 0.35.2
+  resolution: "@img/sharp-darwin-x64@npm:0.35.2"
+  dependencies:
+    "@img/sharp-libvips-darwin-x64": "npm:1.3.1"
+  dependenciesMeta:
+    "@img/sharp-libvips-darwin-x64":
+      optional: true
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@img/sharp-freebsd-wasm32@npm:0.35.2":
+  version: 0.35.2
+  resolution: "@img/sharp-freebsd-wasm32@npm:0.35.2"
+  dependencies:
+    "@img/sharp-wasm32": "npm:0.35.2"
+  conditions: os=freebsd
+  languageName: node
+  linkType: hard
+
 "@img/sharp-libvips-darwin-arm64@npm:1.2.4":
   version: 1.2.4
   resolution: "@img/sharp-libvips-darwin-arm64@npm:1.2.4"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-darwin-arm64@npm:1.3.1":
+  version: 1.3.1
+  resolution: "@img/sharp-libvips-darwin-arm64@npm:1.3.1"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
@@ -2890,9 +2991,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@img/sharp-libvips-darwin-x64@npm:1.3.1":
+  version: 1.3.1
+  resolution: "@img/sharp-libvips-darwin-x64@npm:1.3.1"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@img/sharp-libvips-linux-arm64@npm:1.2.4":
   version: 1.2.4
   resolution: "@img/sharp-libvips-linux-arm64@npm:1.2.4"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linux-arm64@npm:1.3.1":
+  version: 1.3.1
+  resolution: "@img/sharp-libvips-linux-arm64@npm:1.3.1"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
@@ -2904,9 +3019,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@img/sharp-libvips-linux-arm@npm:1.3.1":
+  version: 1.3.1
+  resolution: "@img/sharp-libvips-linux-arm@npm:1.3.1"
+  conditions: os=linux & cpu=arm & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@img/sharp-libvips-linux-ppc64@npm:1.2.4":
   version: 1.2.4
   resolution: "@img/sharp-libvips-linux-ppc64@npm:1.2.4"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linux-ppc64@npm:1.3.1":
+  version: 1.3.1
+  resolution: "@img/sharp-libvips-linux-ppc64@npm:1.3.1"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
@@ -2918,9 +3047,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@img/sharp-libvips-linux-riscv64@npm:1.3.1":
+  version: 1.3.1
+  resolution: "@img/sharp-libvips-linux-riscv64@npm:1.3.1"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@img/sharp-libvips-linux-s390x@npm:1.2.4":
   version: 1.2.4
   resolution: "@img/sharp-libvips-linux-s390x@npm:1.2.4"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linux-s390x@npm:1.3.1":
+  version: 1.3.1
+  resolution: "@img/sharp-libvips-linux-s390x@npm:1.3.1"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
@@ -2932,9 +3075,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@img/sharp-libvips-linux-x64@npm:1.3.1":
+  version: 1.3.1
+  resolution: "@img/sharp-libvips-linux-x64@npm:1.3.1"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@img/sharp-libvips-linuxmusl-arm64@npm:1.2.4":
   version: 1.2.4
   resolution: "@img/sharp-libvips-linuxmusl-arm64@npm:1.2.4"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linuxmusl-arm64@npm:1.3.1":
+  version: 1.3.1
+  resolution: "@img/sharp-libvips-linuxmusl-arm64@npm:1.3.1"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
@@ -2946,11 +3103,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@img/sharp-libvips-linuxmusl-x64@npm:1.3.1":
+  version: 1.3.1
+  resolution: "@img/sharp-libvips-linuxmusl-x64@npm:1.3.1"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "@img/sharp-linux-arm64@npm:0.34.5":
   version: 0.34.5
   resolution: "@img/sharp-linux-arm64@npm:0.34.5"
   dependencies:
     "@img/sharp-libvips-linux-arm64": "npm:1.2.4"
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-arm64":
+      optional: true
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linux-arm64@npm:0.35.2":
+  version: 0.35.2
+  resolution: "@img/sharp-linux-arm64@npm:0.35.2"
+  dependencies:
+    "@img/sharp-libvips-linux-arm64": "npm:1.3.1"
   dependenciesMeta:
     "@img/sharp-libvips-linux-arm64":
       optional: true
@@ -2970,11 +3146,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@img/sharp-linux-arm@npm:0.35.2":
+  version: 0.35.2
+  resolution: "@img/sharp-linux-arm@npm:0.35.2"
+  dependencies:
+    "@img/sharp-libvips-linux-arm": "npm:1.3.1"
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-arm":
+      optional: true
+  conditions: os=linux & cpu=arm & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@img/sharp-linux-ppc64@npm:0.34.5":
   version: 0.34.5
   resolution: "@img/sharp-linux-ppc64@npm:0.34.5"
   dependencies:
     "@img/sharp-libvips-linux-ppc64": "npm:1.2.4"
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-ppc64":
+      optional: true
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linux-ppc64@npm:0.35.2":
+  version: 0.35.2
+  resolution: "@img/sharp-linux-ppc64@npm:0.35.2"
+  dependencies:
+    "@img/sharp-libvips-linux-ppc64": "npm:1.3.1"
   dependenciesMeta:
     "@img/sharp-libvips-linux-ppc64":
       optional: true
@@ -2994,11 +3194,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@img/sharp-linux-riscv64@npm:0.35.2":
+  version: 0.35.2
+  resolution: "@img/sharp-linux-riscv64@npm:0.35.2"
+  dependencies:
+    "@img/sharp-libvips-linux-riscv64": "npm:1.3.1"
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-riscv64":
+      optional: true
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@img/sharp-linux-s390x@npm:0.34.5":
   version: 0.34.5
   resolution: "@img/sharp-linux-s390x@npm:0.34.5"
   dependencies:
     "@img/sharp-libvips-linux-s390x": "npm:1.2.4"
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-s390x":
+      optional: true
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linux-s390x@npm:0.35.2":
+  version: 0.35.2
+  resolution: "@img/sharp-linux-s390x@npm:0.35.2"
+  dependencies:
+    "@img/sharp-libvips-linux-s390x": "npm:1.3.1"
   dependenciesMeta:
     "@img/sharp-libvips-linux-s390x":
       optional: true
@@ -3018,11 +3242,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@img/sharp-linux-x64@npm:0.35.2":
+  version: 0.35.2
+  resolution: "@img/sharp-linux-x64@npm:0.35.2"
+  dependencies:
+    "@img/sharp-libvips-linux-x64": "npm:1.3.1"
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-x64":
+      optional: true
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@img/sharp-linuxmusl-arm64@npm:0.34.5":
   version: 0.34.5
   resolution: "@img/sharp-linuxmusl-arm64@npm:0.34.5"
   dependencies:
     "@img/sharp-libvips-linuxmusl-arm64": "npm:1.2.4"
+  dependenciesMeta:
+    "@img/sharp-libvips-linuxmusl-arm64":
+      optional: true
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linuxmusl-arm64@npm:0.35.2":
+  version: 0.35.2
+  resolution: "@img/sharp-linuxmusl-arm64@npm:0.35.2"
+  dependencies:
+    "@img/sharp-libvips-linuxmusl-arm64": "npm:1.3.1"
   dependenciesMeta:
     "@img/sharp-libvips-linuxmusl-arm64":
       optional: true
@@ -3042,11 +3290,41 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@img/sharp-linuxmusl-x64@npm:0.35.2":
+  version: 0.35.2
+  resolution: "@img/sharp-linuxmusl-x64@npm:0.35.2"
+  dependencies:
+    "@img/sharp-libvips-linuxmusl-x64": "npm:1.3.1"
+  dependenciesMeta:
+    "@img/sharp-libvips-linuxmusl-x64":
+      optional: true
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "@img/sharp-wasm32@npm:0.34.5":
   version: 0.34.5
   resolution: "@img/sharp-wasm32@npm:0.34.5"
   dependencies:
     "@emnapi/runtime": "npm:^1.7.0"
+  conditions: cpu=wasm32
+  languageName: node
+  linkType: hard
+
+"@img/sharp-wasm32@npm:0.35.2":
+  version: 0.35.2
+  resolution: "@img/sharp-wasm32@npm:0.35.2"
+  dependencies:
+    "@emnapi/runtime": "npm:^1.11.1"
+  checksum: 10/10613904362c251fc102f5020ce5e96e430be6ce3bb13069dc8a7f6020fdc3468832740ee9becdb9d1ac9994e9bcc819857cfa43f3e297995f71e94273ec22d7
+  languageName: node
+  linkType: hard
+
+"@img/sharp-webcontainers-wasm32@npm:0.35.2":
+  version: 0.35.2
+  resolution: "@img/sharp-webcontainers-wasm32@npm:0.35.2"
+  dependencies:
+    "@img/sharp-wasm32": "npm:0.35.2"
   conditions: cpu=wasm32
   languageName: node
   linkType: hard
@@ -3058,6 +3336,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@img/sharp-win32-arm64@npm:0.35.2":
+  version: 0.35.2
+  resolution: "@img/sharp-win32-arm64@npm:0.35.2"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@img/sharp-win32-ia32@npm:0.34.5":
   version: 0.34.5
   resolution: "@img/sharp-win32-ia32@npm:0.34.5"
@@ -3065,9 +3350,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@img/sharp-win32-ia32@npm:0.35.2":
+  version: 0.35.2
+  resolution: "@img/sharp-win32-ia32@npm:0.35.2"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@img/sharp-win32-x64@npm:0.34.5":
   version: 0.34.5
   resolution: "@img/sharp-win32-x64@npm:0.34.5"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@img/sharp-win32-x64@npm:0.35.2":
+  version: 0.35.2
+  resolution: "@img/sharp-win32-x64@npm:0.35.2"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -3331,7 +3630,7 @@ __metadata:
     openapi-typescript: "npm:^7.13.0"
     tiny-invariant: "npm:^1.3.1"
     type-fest: "npm:5.7.0"
-    vitest: "npm:^4.0.18"
+    vitest: "npm:^4.1.0"
   languageName: unknown
   linkType: soft
 
@@ -3344,7 +3643,7 @@ __metadata:
     "@math3d/tsconfig": "workspace:^"
     eslint: "npm:^8.57.1"
     mathjs: "npm:^14.0.1"
-    vitest: "npm:^4.0.18"
+    vitest: "npm:^4.1.0"
   languageName: unknown
   linkType: soft
 
@@ -3384,7 +3683,7 @@ __metadata:
     js-yaml: "npm:^4.1.0"
     mathjs: "npm:^14.0.1"
     tinycolor2: "npm:^1.6.0"
-    vitest: "npm:^4.0.18"
+    vitest: "npm:^4.1.0"
   languageName: unknown
   linkType: soft
 
@@ -3396,7 +3695,7 @@ __metadata:
     "@math3d/tsconfig": "workspace:^"
     eslint: "npm:^8.57.1"
     mathjs: "npm:^14.0.1"
-    vitest: "npm:^4.0.18"
+    vitest: "npm:^4.1.0"
   languageName: unknown
   linkType: soft
 
@@ -3413,7 +3712,7 @@ __metadata:
     mathjs: "npm:^14.0.1"
     tarjan-graph: "npm:^3.0.0"
     toposort: "npm:^2.0.2"
-    vitest: "npm:^4.0.18"
+    vitest: "npm:^4.1.0"
   languageName: unknown
   linkType: soft
 
@@ -3431,7 +3730,7 @@ __metadata:
     lodash-es: "npm:^4.18.1"
     msw: "npm:^2.0.14"
     tiny-invariant: "npm:^1.3.1"
-    vitest: "npm:^4.0.18"
+    vitest: "npm:^4.1.0"
   languageName: unknown
   linkType: soft
 
@@ -3449,7 +3748,7 @@ __metadata:
     lodash-es: "npm:4.18.1"
     mathjs: "npm:^14.0.1"
     tiny-invariant: "npm:^1.3.1"
-    vitest: "npm:^4.0.18"
+    vitest: "npm:^4.1.0"
     yup: "npm:^1.3.2"
   languageName: unknown
   linkType: soft
@@ -3480,7 +3779,7 @@ __metadata:
     jest-get-type: "npm:^29.4.3"
     react: "npm:^19.2.7"
     tiny-invariant: "npm:^1.3.1"
-    vitest: "npm:^4.0.18"
+    vitest: "npm:^4.1.0"
   peerDependencies:
     vitest: ^4.0.18
   languageName: unknown
@@ -3508,7 +3807,7 @@ __metadata:
     "@math3d/eslint-config": "workspace:^"
     "@math3d/tsconfig": "workspace:^"
     eslint: "npm:^8.57.1"
-    vitest: "npm:^4.0.18"
+    vitest: "npm:^4.1.0"
   languageName: unknown
   linkType: soft
 
@@ -3523,7 +3822,7 @@ __metadata:
     "@math3d/utils": "workspace:^"
     eslint: "npm:^8.57.1"
     mathjs: "npm:^14.0.1"
-    vitest: "npm:^4.0.18"
+    vitest: "npm:^4.1.0"
     yup: "npm:^1.3.2"
   languageName: unknown
   linkType: soft
@@ -3991,6 +4290,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oxc-project/types@npm:=0.143.0":
+  version: 0.143.0
+  resolution: "@oxc-project/types@npm:0.143.0"
+  checksum: 10/27a70f58e15ea5619b94f1be01a0e3d8cdc41442826f3d08cf6eb55e4c24d3d753cef2a68ae9d298eb55b5f1405145af6b1eacf8cbd4834151b9e3e1206f3401
+  languageName: node
+  linkType: hard
+
 "@pkgjs/parseargs@npm:^0.11.0":
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
@@ -4203,10 +4509,115 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-android-arm64@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-android-arm64@npm:1.2.3"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-darwin-arm64@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-darwin-arm64@npm:1.2.3"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-darwin-x64@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-darwin-x64@npm:1.2.3"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-freebsd-x64@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-freebsd-x64@npm:1.2.3"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm-gnueabihf@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.2.3"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm64-gnu@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.2.3"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm64-musl@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.2.3"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-ppc64-gnu@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.2.3"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-s390x-gnu@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.2.3"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-x64-gnu@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.2.3"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-x64-musl@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-linux-x64-musl@npm:1.2.3"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-openharmony-arm64@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-openharmony-arm64@npm:1.2.3"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-win32-arm64-msvc@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.2.3"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-win32-x64-msvc@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.2.3"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@rolldown/pluginutils@npm:1.0.0-beta.27":
   version: 1.0.0-beta.27
   resolution: "@rolldown/pluginutils@npm:1.0.0-beta.27"
   checksum: 10/4f7da788d88b33d029d5acf84c63be27c62d7c53017476f2e3026172cf94062cb399cd15194c89574578f192016bbcb1e040ce6811b3bb9ec4d4faa2ad386459
+  languageName: node
+  linkType: hard
+
+"@rolldown/pluginutils@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "@rolldown/pluginutils@npm:1.0.1"
+  checksum: 10/4e95cf9ce23d75e5aa03ea0249cd86f7d1e21f83fbf6f8520e4edd8a251ba1b82c4ba9bc13cd24b6c4661daec6225b06e6d35c64c604e731b230b2a49af47d05
   languageName: node
   linkType: hard
 
@@ -6674,83 +7085,85 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/expect@npm:4.0.18":
-  version: 4.0.18
-  resolution: "@vitest/expect@npm:4.0.18"
+"@vitest/expect@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/expect@npm:4.1.10"
   dependencies:
-    "@standard-schema/spec": "npm:^1.0.0"
+    "@standard-schema/spec": "npm:^1.1.0"
     "@types/chai": "npm:^5.2.2"
-    "@vitest/spy": "npm:4.0.18"
-    "@vitest/utils": "npm:4.0.18"
-    chai: "npm:^6.2.1"
-    tinyrainbow: "npm:^3.0.3"
-  checksum: 10/2115bff1bbcad460ce72032022e4dbcf8572c4b0fe07ca60f5644a8d96dd0dfa112986b5a1a5c5705f4548119b3b829c45d1de0838879211e0d6bb276b4ece73
+    "@vitest/spy": "npm:4.1.10"
+    "@vitest/utils": "npm:4.1.10"
+    chai: "npm:^6.2.2"
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10/487fcad404a68968a54ae5fb9d099f12170cd793420a04b34a5606516317090c50a8303ab687c70166ee181864e3e138941d4a96d0405434dcd37696b3105350
   languageName: node
   linkType: hard
 
-"@vitest/mocker@npm:4.0.18":
-  version: 4.0.18
-  resolution: "@vitest/mocker@npm:4.0.18"
+"@vitest/mocker@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/mocker@npm:4.1.10"
   dependencies:
-    "@vitest/spy": "npm:4.0.18"
+    "@vitest/spy": "npm:4.1.10"
     estree-walker: "npm:^3.0.3"
     magic-string: "npm:^0.30.21"
   peerDependencies:
     msw: ^2.4.9
-    vite: ^6.0.0 || ^7.0.0-0
+    vite: ^6.0.0 || ^7.0.0 || ^8.0.0
   peerDependenciesMeta:
     msw:
       optional: true
     vite:
       optional: true
-  checksum: 10/46f584a4c1180dfb513137bc8db6e2e3b53e141adfe964307297e98321652d86a3f2a52d80cda1f810205bd5fdcab789bb8b52a532e68f175ef1e20be398218d
+  checksum: 10/ae9645d1bcdad3ab7de7182feb4f1c9148a5ff97cef19581eec9257112aace94889eee9a1ad12e40ce59453ac05f52453b5fdb49ff76a31af8ccdbaaa4471ef3
   languageName: node
   linkType: hard
 
-"@vitest/pretty-format@npm:4.0.18":
-  version: 4.0.18
-  resolution: "@vitest/pretty-format@npm:4.0.18"
+"@vitest/pretty-format@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/pretty-format@npm:4.1.10"
   dependencies:
-    tinyrainbow: "npm:^3.0.3"
-  checksum: 10/4cafc7c9853097345bd94e8761bf47c2c04e00d366ac56d79928182787ff83c512c96f1dc2ce9b6aeed4d3a8c23ce12254da203783108d3c096bc398eed2a62d
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10/e4f6907143ab0e40dda29d70b17027586c92921d622091321f10512e660b3995dcee7aa56e17b750b72560f295e25f96035372348415f18ebfd39b66a55b4704
   languageName: node
   linkType: hard
 
-"@vitest/runner@npm:4.0.18":
-  version: 4.0.18
-  resolution: "@vitest/runner@npm:4.0.18"
+"@vitest/runner@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/runner@npm:4.1.10"
   dependencies:
-    "@vitest/utils": "npm:4.0.18"
+    "@vitest/utils": "npm:4.1.10"
     pathe: "npm:^2.0.3"
-  checksum: 10/d7deebf086d7e084f449733ecea6c9c81737a18aafece318cbe7500e45debea00fa9dbf9315fd38aa88550dd5240a791b885ac71665f89b154d71a6c63da5836
+  checksum: 10/2c962cb13af0880990036808a35679b7ac6657c8f542490234c2faa6ffd2ab080ac6bf21b487c64d84aa635cfb37b49eb679098c2003a100dfc6c4d5e87bf055
   languageName: node
   linkType: hard
 
-"@vitest/snapshot@npm:4.0.18":
-  version: 4.0.18
-  resolution: "@vitest/snapshot@npm:4.0.18"
+"@vitest/snapshot@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/snapshot@npm:4.1.10"
   dependencies:
-    "@vitest/pretty-format": "npm:4.0.18"
+    "@vitest/pretty-format": "npm:4.1.10"
+    "@vitest/utils": "npm:4.1.10"
     magic-string: "npm:^0.30.21"
     pathe: "npm:^2.0.3"
-  checksum: 10/50aa5fb7fca45c499c145cc2f20e53b8afb0990b53ff4a4e6447dd6f147437edc5316f22e2d82119e154c3cf7c59d44898e7b2faf7ba614ac1051cbe4d662a77
+  checksum: 10/7940d83ffd2fbebf9a04ea31e196b7e8bf981093ec739950959fe8dd29caa33c80823780fb4b1063d9459c44a0a8d8b2748c00dfb6941becd7404e6d687eea01
   languageName: node
   linkType: hard
 
-"@vitest/spy@npm:4.0.18":
-  version: 4.0.18
-  resolution: "@vitest/spy@npm:4.0.18"
-  checksum: 10/f7b1618ae13790105771dd2a8c973c63c018366fcc69b50f15ce5d12f9ac552efd3c1e6e5ae4ebdb6023d0b8d8f31fef2a0b1b77334284928db45c80c63de456
+"@vitest/spy@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/spy@npm:4.1.10"
+  checksum: 10/7c1b79a95474338e0659f0f2e43be4df1ef7939ff5b37b044954e0287582947803bd417508f44a7f244809672309d9b3dd67660b704ec3fe7f323cc958ae47a3
   languageName: node
   linkType: hard
 
-"@vitest/utils@npm:4.0.18":
-  version: 4.0.18
-  resolution: "@vitest/utils@npm:4.0.18"
+"@vitest/utils@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/utils@npm:4.1.10"
   dependencies:
-    "@vitest/pretty-format": "npm:4.0.18"
-    tinyrainbow: "npm:^3.0.3"
-  checksum: 10/e8b2ad7bc35b2bc5590f9dc1d1a67644755da416b47ab7099a6f26792903fa0aacb81e6ba99f0f03858d9d3a1d76eeba65150a1a0849690a40817424e749c367
+    "@vitest/pretty-format": "npm:4.1.10"
+    convert-source-map: "npm:^2.0.0"
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10/95484aad55c7b00bbcd4963e27cbb86fe207620a6093973d68da9d0a06bad37c388d84c9ab43d5f35d88e46c8f376a5592d9c54c025c958361160f4802bb25ee
   languageName: node
   linkType: hard
 
@@ -7496,6 +7909,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "app@workspace:packages/app"
   dependencies:
+    "@cloudflare/vitest-pool-workers": "npm:^0.20.3"
     "@dnd-kit/core": "npm:^6.3.1"
     "@dnd-kit/sortable": "npm:^10.0.0"
     "@dnd-kit/utilities": "npm:^3.2.2"
@@ -7580,7 +7994,7 @@ __metadata:
     vite: "npm:^7.3.6"
     vite-plugin-compile-time: "npm:^0.4.6"
     vite-tsconfig-paths: "npm:^5.1.4"
-    vitest: "npm:^4.0.18"
+    vitest: "npm:^4.1.0"
     wrangler: "npm:4.110.0"
     yup: "npm:^1.3.2"
   languageName: unknown
@@ -8780,7 +9194,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chai@npm:^6.2.1":
+"chai@npm:^6.2.2":
   version: 6.2.2
   resolution: "chai@npm:6.2.2"
   checksum: 10/13cda42cc40aa46da04a41cf7e5c61df6b6ae0b4e8a8c8b40e04d6947e4d7951377ea8c14f9fa7fe5aaa9e8bd9ba414f11288dc958d4cee6f5221b9436f2778f
@@ -8920,6 +9334,13 @@ __metadata:
     inherits: "npm:^2.0.1"
     safe-buffer: "npm:^5.0.1"
   checksum: 10/3d5d6652ca499c3f7c5d7fdc2932a357ec1e5aa84f2ad766d850efd42e89753c97b795c3a104a8e7ae35b4e293f5363926913de3bf8181af37067d9d541ca0db
+  languageName: node
+  linkType: hard
+
+"cjs-module-lexer@npm:1.2.3":
+  version: 1.2.3
+  resolution: "cjs-module-lexer@npm:1.2.3"
+  checksum: 10/f96a5118b0a012627a2b1c13bd2fcb92509778422aaa825c5da72300d6dcadfb47134dd2e9d97dfa31acd674891dd91642742772d19a09a8adc3e56bd2f5928c
   languageName: node
   linkType: hard
 
@@ -9909,7 +10330,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detect-libc@npm:^2.1.2":
+"detect-libc@npm:^2.0.3, detect-libc@npm:^2.1.2":
   version: 2.1.2
   resolution: "detect-libc@npm:2.1.2"
   checksum: 10/b736c8d97d5d46164c0d1bed53eb4e6a3b1d8530d460211e2d52f1c552875e706c58a5376854e4e54f8b828c9cada58c855288c968522eb93ac7696d65970766
@@ -10606,10 +11027,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-module-lexer@npm:^1.7.0":
-  version: 1.7.0
-  resolution: "es-module-lexer@npm:1.7.0"
-  checksum: 10/b6f3e576a3fed4d82b0d0ad4bbf6b3a5ad694d2e7ce8c4a069560da3db6399381eaba703616a182b16dde50ce998af64e07dcf49f2ae48153b9e07be3f107087
+"es-module-lexer@npm:^2.0.0":
+  version: 2.3.1
+  resolution: "es-module-lexer@npm:2.3.1"
+  checksum: 10/15bd9f6d70ec7f046a308b7fbeb56a1fd4bde09e6a46df0015caee58bd5888fc114029754e922ca68577b761890ac95cc450683424209464530cfe54f69b8566
   languageName: node
   linkType: hard
 
@@ -11459,10 +11880,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expect-type@npm:^1.2.2":
-  version: 1.3.0
-  resolution: "expect-type@npm:1.3.0"
-  checksum: 10/a5fada3d0c621649261f886e7d93e6bf80ce26d8a86e5d517e38301b8baec8450ab2cb94ba6e7a0a6bf2fc9ee55f54e1b06938ef1efa52ddcfeffbfa01acbbcc
+"expect-type@npm:^1.3.0":
+  version: 1.4.0
+  resolution: "expect-type@npm:1.4.0"
+  checksum: 10/bad91f4b7eb807248695ee840a935d12818fe531ad523bc7ac7dcc540a4d86dc566a3ef829f4da6e8b5a458ac84092771739865114c91e7e8a9317302f401f09
   languageName: node
   linkType: hard
 
@@ -14567,6 +14988,126 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lightningcss-android-arm64@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-android-arm64@npm:1.33.0"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lightningcss-darwin-arm64@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-darwin-arm64@npm:1.33.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lightningcss-darwin-x64@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-darwin-x64@npm:1.33.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss-freebsd-x64@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-freebsd-x64@npm:1.33.0"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-arm-gnueabihf@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-linux-arm-gnueabihf@npm:1.33.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-arm64-gnu@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-linux-arm64-gnu@npm:1.33.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-arm64-musl@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-linux-arm64-musl@npm:1.33.0"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-x64-gnu@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-linux-x64-gnu@npm:1.33.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-x64-musl@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-linux-x64-musl@npm:1.33.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"lightningcss-win32-arm64-msvc@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-win32-arm64-msvc@npm:1.33.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lightningcss-win32-x64-msvc@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-win32-x64-msvc@npm:1.33.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss@npm:^1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss@npm:1.33.0"
+  dependencies:
+    detect-libc: "npm:^2.0.3"
+    lightningcss-android-arm64: "npm:1.33.0"
+    lightningcss-darwin-arm64: "npm:1.33.0"
+    lightningcss-darwin-x64: "npm:1.33.0"
+    lightningcss-freebsd-x64: "npm:1.33.0"
+    lightningcss-linux-arm-gnueabihf: "npm:1.33.0"
+    lightningcss-linux-arm64-gnu: "npm:1.33.0"
+    lightningcss-linux-arm64-musl: "npm:1.33.0"
+    lightningcss-linux-x64-gnu: "npm:1.33.0"
+    lightningcss-linux-x64-musl: "npm:1.33.0"
+    lightningcss-win32-arm64-msvc: "npm:1.33.0"
+    lightningcss-win32-x64-msvc: "npm:1.33.0"
+  dependenciesMeta:
+    lightningcss-android-arm64:
+      optional: true
+    lightningcss-darwin-arm64:
+      optional: true
+    lightningcss-darwin-x64:
+      optional: true
+    lightningcss-freebsd-x64:
+      optional: true
+    lightningcss-linux-arm-gnueabihf:
+      optional: true
+    lightningcss-linux-arm64-gnu:
+      optional: true
+    lightningcss-linux-arm64-musl:
+      optional: true
+    lightningcss-linux-x64-gnu:
+      optional: true
+    lightningcss-linux-x64-musl:
+      optional: true
+    lightningcss-win32-arm64-msvc:
+      optional: true
+    lightningcss-win32-x64-msvc:
+      optional: true
+  checksum: 10/9b3b5db404af352fe5861926b9909281d29bede175539035c1a01e1ad4dcee8bb6f871e8e3d01a67a85e9e1cd18a63e52871a48cf62feab4d1aa868d4f2c3c2e
+  languageName: node
+  linkType: hard
+
 "lines-and-columns@npm:^1.1.6":
   version: 1.2.4
   resolution: "lines-and-columns@npm:1.2.4"
@@ -15301,6 +15842,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"miniflare@npm:5.20260801.1-alpha":
+  version: 5.20260801.1-alpha
+  resolution: "miniflare@npm:5.20260801.1-alpha"
+  dependencies:
+    "@cspotcode/source-map-support": "npm:0.8.1"
+    sharp: "npm:0.35.2"
+    undici: "npm:7.29.0"
+    workerd: "npm:1.20260801.1"
+    ws: "npm:8.21.0"
+    youch: "npm:4.1.0-beta.10"
+  checksum: 10/8bc5effcc0e18c1a526dc890834621adfdd7553a53f979837323c21180cd2e698e4fa49f23fb805869f79dd7ae74434ecfcd52372034d989a85c6d5468e0ef45
+  languageName: node
+  linkType: hard
+
 "minimalistic-assert@npm:^1.0.0, minimalistic-assert@npm:^1.0.1":
   version: 1.0.1
   resolution: "minimalistic-assert@npm:1.0.1"
@@ -15580,6 +16135,15 @@ __metadata:
   bin:
     nanoid: bin/nanoid.cjs
   checksum: 10/73b5afe5975a307aaa3c95dfe3334c52cdf9ae71518176895229b8d65ab0d1c0417dd081426134eb7571c055720428ea5d57c645138161e7d10df80815527c48
+  languageName: node
+  linkType: hard
+
+"nanoid@npm:^3.3.17":
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: 10/1b3b4fdac831b92b56d1dbe8b1e63a372432faf86ea383134e3b53141ef8108a60b7f84343b5cefecac9550bb74edf8164da93ea07d1c4f757039bc75d8a5d9e
   languageName: node
   linkType: hard
 
@@ -16646,6 +17210,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"picomatch@npm:^4.0.4, picomatch@npm:^4.0.5":
+  version: 4.0.5
+  resolution: "picomatch@npm:4.0.5"
+  checksum: 10/8bad770af9dcdb7f94ad1a893adcbe08a97d75a18872f8fed37161d3124217471c402b3929f051532f795f4ff2e53dcebb1644df4c1a5f3a9c476fef3b9f8c51
+  languageName: node
+  linkType: hard
+
 "pify@npm:^2.0.0":
   version: 2.3.0
   resolution: "pify@npm:2.3.0"
@@ -16935,6 +17506,17 @@ __metadata:
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
   checksum: 10/6d7e21a772e8b05bf102636918654dac097bac013f0dc8346b72ac3604fc16829646f94ea862acccd8f82e910b00e2c11c1f0ea276543565d278c7ca35516a7c
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.5.25":
+  version: 8.5.26
+  resolution: "postcss@npm:8.5.26"
+  dependencies:
+    nanoid: "npm:^3.3.17"
+    picocolors: "npm:^1.1.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10/842a624f822f77cb37264cc24f0cf97c0a69dd8d6f7b4a6d76b5a8dc95355899dd044f33a2d4e890da858293de570fce18dff453f3b629ff14cac67a3591895a
   languageName: node
   linkType: hard
 
@@ -18091,6 +18673,61 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rolldown@npm:~1.2.1":
+  version: 1.2.3
+  resolution: "rolldown@npm:1.2.3"
+  dependencies:
+    "@oxc-project/types": "npm:=0.143.0"
+    "@rolldown/binding-android-arm64": "npm:1.2.3"
+    "@rolldown/binding-darwin-arm64": "npm:1.2.3"
+    "@rolldown/binding-darwin-x64": "npm:1.2.3"
+    "@rolldown/binding-freebsd-x64": "npm:1.2.3"
+    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.2.3"
+    "@rolldown/binding-linux-arm64-gnu": "npm:1.2.3"
+    "@rolldown/binding-linux-arm64-musl": "npm:1.2.3"
+    "@rolldown/binding-linux-ppc64-gnu": "npm:1.2.3"
+    "@rolldown/binding-linux-s390x-gnu": "npm:1.2.3"
+    "@rolldown/binding-linux-x64-gnu": "npm:1.2.3"
+    "@rolldown/binding-linux-x64-musl": "npm:1.2.3"
+    "@rolldown/binding-openharmony-arm64": "npm:1.2.3"
+    "@rolldown/binding-win32-arm64-msvc": "npm:1.2.3"
+    "@rolldown/binding-win32-x64-msvc": "npm:1.2.3"
+    "@rolldown/pluginutils": "npm:^1.0.0"
+  dependenciesMeta:
+    "@rolldown/binding-android-arm64":
+      optional: true
+    "@rolldown/binding-darwin-arm64":
+      optional: true
+    "@rolldown/binding-darwin-x64":
+      optional: true
+    "@rolldown/binding-freebsd-x64":
+      optional: true
+    "@rolldown/binding-linux-arm-gnueabihf":
+      optional: true
+    "@rolldown/binding-linux-arm64-gnu":
+      optional: true
+    "@rolldown/binding-linux-arm64-musl":
+      optional: true
+    "@rolldown/binding-linux-ppc64-gnu":
+      optional: true
+    "@rolldown/binding-linux-s390x-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-musl":
+      optional: true
+    "@rolldown/binding-openharmony-arm64":
+      optional: true
+    "@rolldown/binding-win32-arm64-msvc":
+      optional: true
+    "@rolldown/binding-win32-x64-msvc":
+      optional: true
+  bin:
+    rolldown: ./bin/cli.mjs
+  checksum: 10/553fae06b40d5df3679685807971525b5b5b5fc4e0b5bc661d4cc4214aa6f316b460c6cb296d0352db75287f1fc38cfad1505e54920714e94ac837d1f6e8eceb
+  languageName: node
+  linkType: hard
+
 "rollup-plugin-visualizer@npm:5.14.0":
   version: 5.14.0
   resolution: "rollup-plugin-visualizer@npm:5.14.0"
@@ -18456,7 +19093,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.7.3":
+"semver@npm:^7.7.3, semver@npm:^7.8.4":
   version: 7.8.5
   resolution: "semver@npm:7.8.5"
   bin:
@@ -18729,6 +19366,93 @@ __metadata:
     "@img/sharp-win32-x64":
       optional: true
   checksum: 10/d62bc638c8ad382dffc266beeaffab71457d592abeb6fdf95b512e6dcbce0abf47b8d903b4ea081f012ceb40e4462f1e219184c729329146df32a5ccec2c231f
+  languageName: node
+  linkType: hard
+
+"sharp@npm:0.35.2":
+  version: 0.35.2
+  resolution: "sharp@npm:0.35.2"
+  dependencies:
+    "@img/colour": "npm:^1.1.0"
+    "@img/sharp-darwin-arm64": "npm:0.35.2"
+    "@img/sharp-darwin-x64": "npm:0.35.2"
+    "@img/sharp-freebsd-wasm32": "npm:0.35.2"
+    "@img/sharp-libvips-darwin-arm64": "npm:1.3.1"
+    "@img/sharp-libvips-darwin-x64": "npm:1.3.1"
+    "@img/sharp-libvips-linux-arm": "npm:1.3.1"
+    "@img/sharp-libvips-linux-arm64": "npm:1.3.1"
+    "@img/sharp-libvips-linux-ppc64": "npm:1.3.1"
+    "@img/sharp-libvips-linux-riscv64": "npm:1.3.1"
+    "@img/sharp-libvips-linux-s390x": "npm:1.3.1"
+    "@img/sharp-libvips-linux-x64": "npm:1.3.1"
+    "@img/sharp-libvips-linuxmusl-arm64": "npm:1.3.1"
+    "@img/sharp-libvips-linuxmusl-x64": "npm:1.3.1"
+    "@img/sharp-linux-arm": "npm:0.35.2"
+    "@img/sharp-linux-arm64": "npm:0.35.2"
+    "@img/sharp-linux-ppc64": "npm:0.35.2"
+    "@img/sharp-linux-riscv64": "npm:0.35.2"
+    "@img/sharp-linux-s390x": "npm:0.35.2"
+    "@img/sharp-linux-x64": "npm:0.35.2"
+    "@img/sharp-linuxmusl-arm64": "npm:0.35.2"
+    "@img/sharp-linuxmusl-x64": "npm:0.35.2"
+    "@img/sharp-webcontainers-wasm32": "npm:0.35.2"
+    "@img/sharp-win32-arm64": "npm:0.35.2"
+    "@img/sharp-win32-ia32": "npm:0.35.2"
+    "@img/sharp-win32-x64": "npm:0.35.2"
+    detect-libc: "npm:^2.1.2"
+    semver: "npm:^7.8.4"
+  dependenciesMeta:
+    "@img/sharp-darwin-arm64":
+      optional: true
+    "@img/sharp-darwin-x64":
+      optional: true
+    "@img/sharp-freebsd-wasm32":
+      optional: true
+    "@img/sharp-libvips-darwin-arm64":
+      optional: true
+    "@img/sharp-libvips-darwin-x64":
+      optional: true
+    "@img/sharp-libvips-linux-arm":
+      optional: true
+    "@img/sharp-libvips-linux-arm64":
+      optional: true
+    "@img/sharp-libvips-linux-ppc64":
+      optional: true
+    "@img/sharp-libvips-linux-riscv64":
+      optional: true
+    "@img/sharp-libvips-linux-s390x":
+      optional: true
+    "@img/sharp-libvips-linux-x64":
+      optional: true
+    "@img/sharp-libvips-linuxmusl-arm64":
+      optional: true
+    "@img/sharp-libvips-linuxmusl-x64":
+      optional: true
+    "@img/sharp-linux-arm":
+      optional: true
+    "@img/sharp-linux-arm64":
+      optional: true
+    "@img/sharp-linux-ppc64":
+      optional: true
+    "@img/sharp-linux-riscv64":
+      optional: true
+    "@img/sharp-linux-s390x":
+      optional: true
+    "@img/sharp-linux-x64":
+      optional: true
+    "@img/sharp-linuxmusl-arm64":
+      optional: true
+    "@img/sharp-linuxmusl-x64":
+      optional: true
+    "@img/sharp-webcontainers-wasm32":
+      optional: true
+    "@img/sharp-win32-arm64":
+      optional: true
+    "@img/sharp-win32-ia32":
+      optional: true
+    "@img/sharp-win32-x64":
+      optional: true
+  checksum: 10/4a099cf84c44807bf760b8fd801ec6d4f65370b21d1a2a53031510226e3e61376330bc1c4030c4440860b5f87c0af56a81954675b7933c42d6769a5b617df8e4
   languageName: node
   linkType: hard
 
@@ -19180,10 +19904,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"std-env@npm:^3.10.0":
-  version: 3.10.0
-  resolution: "std-env@npm:3.10.0"
-  checksum: 10/19c9cda4f370b1ffae2b8b08c72167d8c3e5cfa972aaf5c6873f85d0ed2faa729407f5abb194dc33380708c00315002febb6f1e1b484736bfcf9361ad366013a
+"std-env@npm:^4.0.0-rc.1":
+  version: 4.2.0
+  resolution: "std-env@npm:4.2.0"
+  checksum: 10/d30c3ae49c5568b4e61dca628eaafe12944dbcfe76980e5b1b1499b48e23f85f1ee01fe2306eeef5964a80b763948bbf2ba40490bc53709f45cf989071c9e4e7
   languageName: node
   linkType: hard
 
@@ -20047,10 +20771,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyrainbow@npm:^3.0.3":
-  version: 3.0.3
-  resolution: "tinyrainbow@npm:3.0.3"
-  checksum: 10/169cc63c15e1378674180f3207c82c05bfa58fc79992e48792e8d97b4b759012f48e95297900ede24a81f0087cf329a0d85bb81109739eacf03c650127b3f6c1
+"tinyglobby@npm:^0.2.17":
+  version: 0.2.17
+  resolution: "tinyglobby@npm:0.2.17"
+  dependencies:
+    fdir: "npm:^6.5.0"
+    picomatch: "npm:^4.0.4"
+  checksum: 10/f85e8a217d675c3f78d5f0ad25ea4557e7e023ed13ddc2b014da10bd0312eea53a34cd52356af07ccdff777f1243012547656282a4ca70936f68bf5065fbaa71
+  languageName: node
+  linkType: hard
+
+"tinyrainbow@npm:^3.1.0":
+  version: 3.1.1
+  resolution: "tinyrainbow@npm:3.1.1"
+  checksum: 10/6aa4aadf89cc8ecf8c227ef189616911292c4f0d2d5708b669b00375c5a8b43058115685f043034ffb11a8744c24650a30493525ff62134b436d94c84fa33ed5
   languageName: node
   linkType: hard
 
@@ -20715,6 +21449,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici@npm:7.29.0":
+  version: 7.29.0
+  resolution: "undici@npm:7.29.0"
+  checksum: 10/ca73639071bdcbc41e57be1800847fa18f86f8fbf7a5641ff9899f7bbb6f5cecdd593e225f5fd94e31703dcbfaea4a722a3b81cab90c5c4e2b406aec1ae55732
+  languageName: node
+  linkType: hard
+
 "unenv@npm:2.0.0-rc.24":
   version: 2.0.0-rc.24
   resolution: "unenv@npm:2.0.0-rc.24"
@@ -21313,7 +22054,64 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^6.0.0 || ^7.0.0, vite@npm:^7.3.6":
+"vite@npm:^6.0.0 || ^7.0.0 || ^8.0.0":
+  version: 8.2.1
+  resolution: "vite@npm:8.2.1"
+  dependencies:
+    fsevents: "npm:~2.3.3"
+    lightningcss: "npm:^1.33.0"
+    picomatch: "npm:^4.0.5"
+    postcss: "npm:^8.5.25"
+    rolldown: "npm:~1.2.1"
+    tinyglobby: "npm:^0.2.17"
+  peerDependencies:
+    "@types/node": ^20.19.0 || >=22.12.0
+    "@vitejs/devtools": ^0.4.0
+    esbuild: ^0.27.0 || ^0.28.0
+    jiti: ">=1.21.0"
+    less: ^4.0.0
+    sass: ^1.70.0
+    sass-embedded: ^1.70.0
+    stylus: ">=0.54.8"
+    sugarss: ^5.0.0
+    terser: ^5.16.0
+    tsx: ^4.8.1
+    yaml: ^2.4.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    "@vitejs/devtools":
+      optional: true
+    esbuild:
+      optional: true
+    jiti:
+      optional: true
+    less:
+      optional: true
+    sass:
+      optional: true
+    sass-embedded:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+    tsx:
+      optional: true
+    yaml:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 10/af65bf23dc346f968b8b2f577da4c5d18a5a21eea2ce699eb0018918151238ed185067de1749408d26ba93c743635c5870602bd77b4b6f2f678d8d685a9635d8
+  languageName: node
+  linkType: hard
+
+"vite@npm:^7.3.6":
   version: 7.3.6
   resolution: "vite@npm:7.3.6"
   dependencies:
@@ -21368,40 +22166,43 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vitest@npm:^4.0.18":
-  version: 4.0.18
-  resolution: "vitest@npm:4.0.18"
+"vitest@npm:^4.1.0":
+  version: 4.1.10
+  resolution: "vitest@npm:4.1.10"
   dependencies:
-    "@vitest/expect": "npm:4.0.18"
-    "@vitest/mocker": "npm:4.0.18"
-    "@vitest/pretty-format": "npm:4.0.18"
-    "@vitest/runner": "npm:4.0.18"
-    "@vitest/snapshot": "npm:4.0.18"
-    "@vitest/spy": "npm:4.0.18"
-    "@vitest/utils": "npm:4.0.18"
-    es-module-lexer: "npm:^1.7.0"
-    expect-type: "npm:^1.2.2"
+    "@vitest/expect": "npm:4.1.10"
+    "@vitest/mocker": "npm:4.1.10"
+    "@vitest/pretty-format": "npm:4.1.10"
+    "@vitest/runner": "npm:4.1.10"
+    "@vitest/snapshot": "npm:4.1.10"
+    "@vitest/spy": "npm:4.1.10"
+    "@vitest/utils": "npm:4.1.10"
+    es-module-lexer: "npm:^2.0.0"
+    expect-type: "npm:^1.3.0"
     magic-string: "npm:^0.30.21"
     obug: "npm:^2.1.1"
     pathe: "npm:^2.0.3"
     picomatch: "npm:^4.0.3"
-    std-env: "npm:^3.10.0"
+    std-env: "npm:^4.0.0-rc.1"
     tinybench: "npm:^2.9.0"
     tinyexec: "npm:^1.0.2"
     tinyglobby: "npm:^0.2.15"
-    tinyrainbow: "npm:^3.0.3"
-    vite: "npm:^6.0.0 || ^7.0.0"
+    tinyrainbow: "npm:^3.1.0"
+    vite: "npm:^6.0.0 || ^7.0.0 || ^8.0.0"
     why-is-node-running: "npm:^2.3.0"
   peerDependencies:
     "@edge-runtime/vm": "*"
     "@opentelemetry/api": ^1.9.0
     "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
-    "@vitest/browser-playwright": 4.0.18
-    "@vitest/browser-preview": 4.0.18
-    "@vitest/browser-webdriverio": 4.0.18
-    "@vitest/ui": 4.0.18
+    "@vitest/browser-playwright": 4.1.10
+    "@vitest/browser-preview": 4.1.10
+    "@vitest/browser-webdriverio": 4.1.10
+    "@vitest/coverage-istanbul": 4.1.10
+    "@vitest/coverage-v8": 4.1.10
+    "@vitest/ui": 4.1.10
     happy-dom: "*"
     jsdom: "*"
+    vite: ^6.0.0 || ^7.0.0 || ^8.0.0
   peerDependenciesMeta:
     "@edge-runtime/vm":
       optional: true
@@ -21415,15 +22216,21 @@ __metadata:
       optional: true
     "@vitest/browser-webdriverio":
       optional: true
+    "@vitest/coverage-istanbul":
+      optional: true
+    "@vitest/coverage-v8":
+      optional: true
     "@vitest/ui":
       optional: true
     happy-dom:
       optional: true
     jsdom:
       optional: true
+    vite:
+      optional: false
   bin:
-    vitest: vitest.mjs
-  checksum: 10/6c6464ebcf3af83546862896fd1b5f10cb6607261bffce39df60033a288b8c1687ae1dd20002b6e4997a7a05303376d1eb58ce20afe63be052529a4378a8c165
+    vitest: ./vitest.mjs
+  checksum: 10/020843460fe696c23be2a363634dde4daf54625f1c443c24066ba3f87c478b0ccfdd5124343ba30eb092f54902ffea09f4bed0af4a16a9ee805e494ee2dce34e
   languageName: node
   linkType: hard
 
@@ -21900,6 +22707,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"workerd@npm:1.20260801.1":
+  version: 1.20260801.1
+  resolution: "workerd@npm:1.20260801.1"
+  dependencies:
+    "@cloudflare/workerd-darwin-64": "npm:1.20260801.1"
+    "@cloudflare/workerd-darwin-arm64": "npm:1.20260801.1"
+    "@cloudflare/workerd-linux-64": "npm:1.20260801.1"
+    "@cloudflare/workerd-linux-arm64": "npm:1.20260801.1"
+    "@cloudflare/workerd-windows-64": "npm:1.20260801.1"
+  dependenciesMeta:
+    "@cloudflare/workerd-darwin-64":
+      optional: true
+    "@cloudflare/workerd-darwin-arm64":
+      optional: true
+    "@cloudflare/workerd-linux-64":
+      optional: true
+    "@cloudflare/workerd-linux-arm64":
+      optional: true
+    "@cloudflare/workerd-windows-64":
+      optional: true
+  bin:
+    workerd: bin/workerd
+  checksum: 10/62b4bb75bd8018d46359294f75c330cd41427a1d518d7cf7e4a5bf2c5c065bb71b6b66748f1096d70cc9cb1c796b268075750189b3bb2a07cb324772e34bd545
+  languageName: node
+  linkType: hard
+
 "worktank@npm:^2.6.0":
   version: 2.6.0
   resolution: "worktank@npm:2.6.0"
@@ -21936,6 +22769,35 @@ __metadata:
     wrangler: bin/wrangler.js
     wrangler2: bin/wrangler.js
   checksum: 10/648500287c9d554c1cc7ec771b155b5b85a5a0749420a69aa0d463596acc958d6fe71d46cd2b37000813917743c8dd7e6f73842db91e0137dd5a449eea6c121f
+  languageName: node
+  linkType: hard
+
+"wrangler@npm:4.120.0":
+  version: 4.120.0
+  resolution: "wrangler@npm:4.120.0"
+  dependencies:
+    "@cloudflare/kv-asset-handler": "npm:0.5.0"
+    "@cloudflare/unenv-preset": "npm:2.16.1"
+    blake3-wasm: "npm:2.1.5"
+    esbuild: "npm:0.28.1"
+    fsevents: "npm:2.3.3"
+    miniflare: "npm:5.20260801.1-alpha"
+    path-to-regexp: "npm:6.3.0"
+    unenv: "npm:2.0.0-rc.24"
+    workerd: "npm:1.20260801.1"
+  peerDependencies:
+    "@cloudflare/workers-types": ^5.20260801.1
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@cloudflare/workers-types":
+      optional: true
+  bin:
+    cf-wrangler: bin/cf-wrangler.js
+    wrangler: bin/wrangler.js
+    wrangler2: bin/wrangler.js
+  checksum: 10/02e2adffaff25a0aa4623d8ed8151aa67442ea53f0bc611bf89feedab94d222e33059357a5e4b9f1ec06d5eaed8049f6cea58ee7305ceb02bf319d0351007303
   languageName: node
   linkType: hard
 
@@ -22215,6 +23077,13 @@ __metadata:
   dependencies:
     grammex: "npm:^3.1.1"
   checksum: 10/2a260200f857462264222c8cba1dc955e60a7f6cbcf9d57c7ac94fe874f52029a4efe8ff24b29497925a492151fe7ee56e63b3b31874c5d138ee1c11f0052f18
+  languageName: node
+  linkType: hard
+
+"zod@npm:4.4.3":
+  version: 4.4.3
+  resolution: "zod@npm:4.4.3"
+  checksum: 10/804b9a42aa8f35f2b3c5a8dff906291cb749115f83ee2afe3576d70b5b5c53c965365c7f4967690647a9c54af9838ff232a85ff9577a0a36c44b68bc6cdefe36
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What are the relevant issues?

N/A — pass 1 of the OG social-sharing epic. Builds directly on two merged predecessors:

- https://github.com/ChristopherChudzicki/math3d-next/pull/1222 — static branded default `og:image` + generator pipeline
- https://github.com/ChristopherChudzicki/math3d-next/pull/1223 — static `<head>` OG/Twitter defaults + `VITE_SITE_ORIGIN`

### Description

Math3d is a client-rendered SPA served from Cloudflare Workers Static Assets, so social scrapers (which don't run JS) currently unfurl every scene link with the same static defaults. This adds a Cloudflare **Worker** in front of the static assets that injects **per-scene text metadata** at the edge — the cheap "text" half of the epic. (Per-scene images are a deliberately separate pass 2.)

**Edge Worker** (`packages/app/src/worker/index.ts`): on a single-segment scene-key navigation it calls a read-only backend endpoint for the scene title and rewrites `<title>`, `og:title`, `twitter:title`, and `og:url` in the SPA shell via `HTMLRewriter` (escaping-safe setters only — the title is user-controlled). Every non-scene request passes straight through to static assets untouched. The lookup fails open: any error/timeout serves the branded default shell, never a 500.

- **Untitled scenes read as the home page.** A scene left at the DB-default `"Untitled"` (or blank) shows the rich site default title rather than a scene-specific one — on both the Worker and the client, via a shared dependency-free helper (`features/scene/sceneTitle.ts`) imported by both surfaces so they can't drift (no boot-time tab-title flip). `og:url` is still rewritten for untitled scenes.
- **Client parity:** `useSceneLoader` now formats `document.title` through that same helper (`{title} | Math3d`), matching the Worker's pre-boot `<title>`.

**Backend** (`webserver/scenes/api.py`): new read-only `GET /scenes/{key}/meta/` (`auth=None`) returning `{ title }`. Unlike the full `GET /scenes/{key}/`, it has **no write side effects** — no `times_accessed` increment, no legacy migration. It serves **migrated (`Scene`) scenes only**; an un-migrated legacy key 404s (→ default card), which keeps the endpoint a trivial, total read instead of defensively parsing arbitrary legacy JSON.

**Test infra:** Vitest is split into a `jsdom` project (the app) and a `workers` project (the Worker, run under real `workerd` via `@cloudflare/vitest-pool-workers`); this required bumping Vitest to `4.1.x` monorepo-wide.

**Config-as-code** (`wrangler.jsonc`): `run_worker_first` globs force the Worker on navigations while real assets bypass it (validated with `wrangler dev`); `API_BASE` / `SITE_ORIGIN` vars.

**Abandonability preserved:** the Worker only writes crawler-facing `<head>` tags; the SPA sources all state from Django and reads nothing the Worker injects, so removing the edge layer degrades gracefully to the static defaults.

The design doc travels with this PR: `docs/superpowers/specs/2026-07-11-og-metadata-worker-design.md`.

### How can this be tested?

- **Backend:** `just be test` (or `docker compose run --rm webserver uv run pytest scenes/api_test.py`) — covers the meta endpoint's title-only response, no-side-effect invariants, unknown-key 404, and un-migrated-legacy-key 404-without-migrating.
- **Worker:** `yarn workspace app test` runs both projects; the `workers` project exercises the Worker under `workerd` — title rewrite, untitled → shell defaults + og:url rewrite, hostile-title escaping, fail-open + private `Cache-Control`, passthrough classification, and no cookie/header forwarding to `/meta/`.
- **App unit:** `MainPage.spec.tsx` pins the client title format (titled → `{t} | Math3d`, untitled → site default) and the default-title fallback.
- **E2E:** `yarn test-e2e` (guards the `useSceneLoader` change; the suite doesn't run the Worker).
- **Manual routing:** `wrangler dev` against a built `./dist` + local backend confirms the Worker runs for navigations, assets bypass it (zero invocations), and the positive rewrite works against a seeded scene.

### Additional context

- **Two deviations worth flagging for a reviewer** (both intentional, both validated): `@cloudflare/vitest-pool-workers@0.20.3` uses the Vitest-4 plugin API `cloudflareTest()` (not the older `defineWorkersProject`) and genuinely needs Vitest ≥ 4.1 — hence the monorepo bump. And the ninja API is mounted under `/v1`, so the Worker fetches `${API_BASE}/v1/scenes/{key}/meta/` (`API_BASE` is the bare origin).
- **Reviewed:** two rounds of multi-lens review (spec-conformance, security, test-quality) on the branch; findings folded in (untitled parity, fail-open cache-control, the migrated-only meta endpoint, test-quality collapses).
- **Pass 2 (per-scene images)** is a separate future PR — it needs the headless render route (#1209) and its own compute decision.

### Checklist:

Launch prerequisites (tracked in the design doc; some are deploy/ops, not code):

- [ ] Confirm the `SITE_ORIGIN` deploy var — add `wrangler deploy --var SITE_ORIGIN:$SITE_ORIGIN` (same CI value as `VITE_SITE_ORIGIN`) to `deploy-reusable.yml`. `wrangler.jsonc` ships a committed default (`https://next.math3d.org`), so deploy works without it, but wiring the var keeps `og:url` from drifting from the static head.
- [ ] Add a Cloudflare Rate-Limiting/WAF rule on the scene route (every scene navigation is an uncached `/meta/` read; bogus valid-charset keys each cost one backend 404).
- [ ] Legacy-key charset spot-check: `SELECT count(*) FROM scenes_legacyscene WHERE key !~ '^[A-Za-z0-9_-]{2,80}$';` (non-matching keys just fall through to the default card — graceful).
- [ ] Confirm `mockServiceWorker.js` is not in the production `./dist` (dev-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YY8L3JDNL9ZJiZ7sWDhSsm
