### PR TITLE
docs(og): correct SITE_ORIGIN comment in wrangler.jsonc

### DIFF
--- a/packages/app/wrangler.jsonc
+++ b/packages/app/wrangler.jsonc
@@ -26,9 +26,9 @@
   },
   "vars": {
     "API_BASE": "https://api.math3d.org",
-    // Committed default; overridden at deploy via `--var SITE_ORIGIN:$SITE_ORIGIN`,
-    // sourced from the same CI value as VITE_SITE_ORIGIN so og:url and the static
-    // head defaults can't drift.
+    // Source of truth for the Worker's og:url origin; applied as-is by
+    // `wrangler deploy` (deploy-reusable.yml). Must stay equal to the
+    // production VITE_SITE_ORIGIN so og:url can't drift from the static head.
     "SITE_ORIGIN": "https://next.math3d.org"
   }
 }


### PR DESCRIPTION
### What are the relevant tickets?

N/A — follow-up housekeeping from #1224.

### Description (What does it do?)

Corrects a stale code comment on the `SITE_ORIGIN` var in
`packages/app/wrangler.jsonc`. The old comment claimed the value is
"overridden at deploy via `--var SITE_ORIGIN:$SITE_ORIGIN`", but the
`deploy-cloudflare` job in `deploy-reusable.yml` runs a plain
`wrangler deploy` with no `--var` flag. The committed value is the actual
source of truth, applied as-is on every production deploy.

Comment-only change — no behavior change.

### How can this be tested?

Nothing to test at runtime. Read the diff: the comment now describes what
the deploy actually does (`wrangler deploy` applies the committed value)
and keeps the invariant note (must stay equal to production
`VITE_SITE_ORIGIN` so `og:url` can't drift from the static head).

### Additional Context

Spotted while walking through the deploy path for the OG Worker (#1224).
The `--var` wiring was considered as drift-insurance but never added,
because the committed default already equals production `VITE_SITE_ORIGIN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YY8L3JDNL9ZJiZ7sWDhSsm