### PR TITLE
feat(og): enable per-scene og:image (set OG_RENDER_ORIGIN)

### DIFF
--- a/packages/app/wrangler.jsonc
+++ b/packages/app/wrangler.jsonc
@@ -29,9 +29,9 @@
     // Source of truth for the Worker's og:url origin; applied as-is by
     // `wrangler deploy` (deploy-reusable.yml). Must stay equal to the
     // production VITE_SITE_ORIGIN so og:url can't drift from the static head.
-    "SITE_ORIGIN": "https://next.math3d.org"
-    // TODO(og pass-2): set after deploying the render Worker (packages/og-render);
-    // its *.workers.dev host. Unset → static default card (pass-1 behavior).
-    // "OG_RENDER_ORIGIN": "https://<deployed-render-worker-host>"
+    "SITE_ORIGIN": "https://next.math3d.org",
+    // Render Worker origin (packages/og-render). Set → per-scene og:image;
+    // unset → static default card (pass-1 behavior).
+    "OG_RENDER_ORIGIN": "https://math3d-og-render.christopher-chudzicki.workers.dev"
   }
 }


### PR DESCRIPTION
Follow-up to #1226. Flips the dark switch: sets `OG_RENDER_ORIGIN` to the deployed `math3d-og-render` Worker so scene `og:image`/`twitter:image` tags point at per-scene renders. Render Worker + R2/Browser-Rendering infra provisioned and smoke-tested.

Revert = unset the var + redeploy the app Worker.