### PR TITLE
chore: add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021-2026 Chris Chudzicki
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -83,3 +83,7 @@ uv add --group dev <package>
 After modifying dependencies, commit both `pyproject.toml` and the updated `uv.lock`.
 
 See [webserver/justfile](./webserver/justfile) for all backend recipes.
+
+## License
+
+MIT — see [LICENSE](./LICENSE).

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "math3d-next",
+  "license": "MIT",
   "workspaces": [
     "packages/*"
   ],


### PR DESCRIPTION
### What are the relevant issues?

N/A

### Description

The repo had no license declared anywhere — no `LICENSE` file, and no `license` field in the root or any workspace `package.json`. A public repo with no license is legally all-rights-reserved, not open source.

This declares MIT in the three places people look:

- `LICENSE` at the repo root
- `"license": "MIT"` in the root `package.json`
- a `## License` section in the README

Copyright range starts at 2021, the date of the first commit. `git shortlog` confirms every human commit in this repo is sole-authored (the rest are renovate and pre-commit bots), so there are no other copyright holders whose agreement would be needed.

### How can this be tested?

Nothing to exercise at runtime — this is metadata only, no source changes. Worth confirming the copyright holder name and year range read the way you want them to, since those are the only judgment calls here.

### Additional context

Motivated by applying for Sentry's sponsored open source plan: their application asks for a repo link with a license reference, and their open source page asks that projects be "released under a friendly license like Apache or MIT."

The predecessor repo, `math3d-react`, is MPL-2.0 and stays that way — it has three outside contributors, so it can't be unilaterally relicensed, and since this repo is a clean rewrite with no files carried over, nothing here inherits that obligation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)