### PR TITLE
chore(pre-commit): format .jsonc files with prettier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 ci:
   skip:
     - prettier
+    - prettier-jsonc
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
@@ -64,3 +65,14 @@ repos:
             markdown,
             html,
           ]
+      # `identify`, which supplies pre-commit's `types_or` tags, has no `jsonc`
+      # tag (it reports no tags at all for a .jsonc filename), so .jsonc files
+      # have to be selected by name. `files` and `types_or` are ANDed, hence a
+      # separate hook rather than another entry in the list above. Prettier
+      # also fails on unparseable JSONC, so this doubles as a syntax check —
+      # `check-json` cannot be used here, as it rejects comments.
+      - id: prettier-jsonc
+        name: prettier (jsonc)
+        entry: npx prettier --write --no-error-on-unmatched-pattern
+        language: node
+        files: \.jsonc$


### PR DESCRIPTION
### What are the relevant issues?

N/A

### Description

The local `prettier` pre-commit hook selects files via `types_or`, whose tags come from [`identify`](https://github.com/pre-commit/identify). `identify` (2.6.9) has **no `jsonc` tag** — it reports no filename tags at all for `.jsonc` — so the hook silently skipped both `.jsonc` files in the repo:

- `packages/app/wrangler.jsonc`
- `packages/og-render/wrangler.jsonc`

CI already covered them (`yarn fmt-check` runs `prettier --check .`, and Prettier does resolve `.jsonc` to its `jsonc` parser), so pre-commit and CI disagreed: a misformatted `wrangler.jsonc` would commit cleanly and then fail in CI.

This adds a dedicated `prettier-jsonc` hook that selects by filename (`files: \.jsonc$`). It has to be a separate hook because pre-commit **ANDs** `files` and `types_or` — adding `files` to the existing hook would have filtered every other file type out.

Also added to `ci.skip` alongside `prettier`, matching how the existing hook is handled on pre-commit.ci.

Other relevant checks were audited and already cover `.jsonc`: `trailing-whitespace`, `end-of-file-fixer`, `detect-secrets`, `check-added-large-files`, and `check-merge-conflict` all default to `types: [file]`/`[text]`, and `identify.tags_from_path()` does return `['file', 'non-executable', 'text']` for these files (the gap is filename-tag-only). `check-json` is deliberately **not** added — it rejects comments, which is the whole point of JSONC. Prettier itself fails on unparseable JSONC, so this hook doubles as the syntax check.

### How can this be tested?

`pre-commit run --all-files` passes with no reformatting (the two `wrangler.jsonc` files were already clean).

To confirm the hook actually fires, drop a misformatted file in and run both hooks:

```console
$ printf '{\n"name":    "bad",\n  // a comment\n     "x": [1,2,3],\n}\n' > packages/app/badfmt.jsonc
$ git add packages/app/badfmt.jsonc

$ pre-commit run prettier --files packages/app/badfmt.jsonc
prettier.............................................(no files to check)Skipped   # <- the bug

$ pre-commit run prettier-jsonc --files packages/app/badfmt.jsonc
prettier (jsonc).........................................................Failed
- files were modified by this hook

$ cat packages/app/badfmt.jsonc
{
  "name": "bad",
  // a comment
  "x": [1, 2, 3]
}
```

Comments survive, the trailing comma is dropped. And on invalid JSONC the hook errors rather than passing:

```console
$ printf '{\n  "a": [1, 2,\n}\n' > packages/app/badfmt.jsonc
$ pre-commit run prettier-jsonc --files packages/app/badfmt.jsonc
[error] packages/app/badfmt.jsonc: SyntaxError: Unexpected token (3:1)
```

### Additional context

Worth revisiting if `identify` ever ships a `jsonc` tag ([pre-commit/identify](https://github.com/pre-commit/identify) — not present as of 2.6.9); at that point the second hook collapses back into the `types_or` list.

The duplicate `entry` line is intentional — two `repo: local` node hooks rather than one, which is the cost of the `files`/`types_or` AND semantics.
