### PR TITLE
ci: move all GitHub Actions onto the node24 runtime

### DIFF
--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -34,7 +34,7 @@ jobs:
     env:
       SKIP_YARN_COREPACK_CHECK: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v6
         with:
@@ -57,7 +57,7 @@ jobs:
           VITE_APP_VERSION: ${{ inputs.version }}
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.dry_run && format('frontend-build-{0}', inputs.version) || 'frontend-build' }}
           path: packages/app/dist/
@@ -74,10 +74,10 @@ jobs:
       AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
       AWS_S3_BUCKET: ${{ vars.AWS_S3_BUCKET }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: frontend-build
           path: packages/app/dist/
@@ -93,7 +93,7 @@ jobs:
           curl https://cli-assets.heroku.com/install.sh | sh
 
       - name: Deploy to Heroku
-        uses: akhileshns/heroku-deploy@v3.14.15
+        uses: akhileshns/heroku-deploy@v3.15.15
         with:
           heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
           heroku_app_name: ${{ vars.HEROKU_APP_NAME }}
@@ -109,7 +109,7 @@ jobs:
     env:
       SKIP_YARN_COREPACK_CHECK: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v6
         with:
@@ -127,7 +127,7 @@ jobs:
           yarn install --immutable
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: frontend-build
           path: packages/app/dist/

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,7 +41,7 @@ jobs:
           API_HOST=$(echo "$TEST_API_URL" | sed -E 's|https?://||; s|:[0-9]+$||')
           echo "127.0.0.1 $APP_HOST $API_HOST" | sudo tee -a /etc/hosts
           echo "::1       $APP_HOST $API_HOST" | sudo tee -a /etc/hosts
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
@@ -83,7 +83,7 @@ jobs:
         run: yarn test-e2e
         env:
           CI: True
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -20,7 +20,7 @@ jobs:
         id: lint_pr_title
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
+      - uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         # When the previous steps fails, the workflow would stop. By adding this
         # condition you can continue the execution with the populated error message.
         if: always() && (steps.lint_pr_title.outputs.error_message != null)
@@ -42,7 +42,7 @@ jobs:
 
       # Delete a previous comment when the issue has been resolved
       - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           header: pr-title-lint-error
           delete: true

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -15,7 +15,7 @@ jobs:
       version: ${{ steps.extract_version.outputs.version }}
       prod_tag: ${{ steps.extract_version.outputs.prod_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Validate branch is main
         run: |
@@ -81,7 +81,7 @@ jobs:
     needs: validate-rc
     runs-on: ubuntu-26.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Fetch tags
         run: git fetch --tags --force
@@ -100,8 +100,8 @@ jobs:
           git tag -a "${{ needs.validate-rc.outputs.prod_tag }}" $RC_SHA -m "Production release ${{ needs.validate-rc.outputs.version }}"
           git push origin "${{ needs.validate-rc.outputs.prod_tag }}"
 
-      - name: Update GitHub Release
-        uses: softprops/action-gh-release@v1
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.validate-rc.outputs.prod_tag }}
           name: Release ${{ needs.validate-rc.outputs.version }}
@@ -112,7 +112,6 @@ jobs:
             ## Production Release ${{ needs.validate-rc.outputs.version }}
 
             This release was promoted from RC tag `${{ needs.validate-rc.outputs.rc_tag }}`.
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   deploy:
     needs: [validate-rc, create-prod-tag]

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -15,7 +15,7 @@ jobs:
       version: ${{ steps.generate_version.outputs.version }}
       rc_tag: ${{ steps.generate_version.outputs.rc_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Validate branch is main
         run: |
@@ -91,7 +91,7 @@ jobs:
           echo "Last production tag: $LAST_PROD_TAG"
 
       - name: Create GitHub pre-release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.generate_version.outputs.rc_tag }}
           name: Release Candidate ${{ steps.generate_version.outputs.version }}
@@ -106,8 +106,6 @@ jobs:
             **To promote to production**: Run the "Promote RC to Production" workflow with tag `${{ steps.generate_version.outputs.rc_tag }}`
 
             ---
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build:
     needs: create-rc

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,7 @@ jobs:
       VITE_ISSUE_URL: ${{ vars.VITE_ISSUE_URL }}
       VITE_SITE_ORIGIN: ${{ vars.VITE_SITE_ORIGIN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
@@ -44,16 +44,16 @@ jobs:
       run:
         working-directory: ./webserver
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           # Single source of truth, shared with local dev and the Heroku build,
           # which both read webserver/.python-version. `3.12` resolves to the
           # latest available 3.12 patch, matching Heroku's runtime selection.
           python-version-file: webserver/.python-version
       - name: Install just
-        uses: extractions/setup-just@v3
+        uses: extractions/setup-just@v4
       - name: Install python dependencies
         run: just setup_python
       - name: Check v1 OpenAPI up-to-date
@@ -73,7 +73,7 @@ jobs:
       SKIP_YARN_COREPACK_CHECK: true # https://github.com/actions/setup-node/issues/531#issuecomment-1819151412
     runs-on: ubuntu-26.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"


### PR DESCRIPTION
### What are the relevant issues?

N/A — GitHub's deprecation of the `node20` action runtime.

### Description

Moves every GitHub Action referenced under `.github/` onto the `node24` runtime.

Worth clarifying up front, because the deprecation warning is easy to misread: **nothing here builds with Node 20.** All five `setup-node` steps read `.nvmrc` (24.13.1). The warnings come from the *action runtime* (`runs.using` inside each action's own `action.yml`), which isn't something we set — it comes with the action version. GitHub only ships `node20` and `node24` runtimes, so node24 is the ceiling.

| Action | | Note |
|---|---|---|
| `softprops/action-gh-release` | v1 → v3 | was **node16** |
| `actions/checkout` | v4 → v6 | |
| `actions/setup-python` | v5 → v6 | |
| `actions/upload-artifact` | v4 → v7 | |
| `actions/download-artifact` | v4 → v8 | |
| `marocchino/sticky-pull-request-comment` | v2 → v3.0.5 | SHA-pinned, as before |
| `akhileshns/heroku-deploy` | v3.14.15 → v3.15.15 | |
| `extractions/setup-just` | v3 → v4 | see below |

**`setup-just` was a hidden one.** It's a composite action, so it reports no runtime of its own — but it internally pinned `extractions/setup-crate` at a node20 SHA, and would have kept warning after every other bump. v4 pins `setup-crate` v2.0.0 (node24); the two versions' `inputs:` blocks are identical and we pass none.

**Token plumbing removed from both release workflows.** `action-gh-release` resolves its token as `INPUT_TOKEN || GITHUB_TOKEN`, and the `token` input defaults to `${{ github.token }}` — so `INPUT_TOKEN` is always set and the env var is never reached. `release-prod` additionally had the value under `with:` instead of `env:`, making it an undeclared input (`INPUT_GITHUB_TOKEN`, which the action never reads) that logged an "Unexpected input" warning. Both workflows keep using the same token via the input default.

The prod step is also renamed from "Update" to "Create GitHub Release": an earlier step hard-fails the job if the production tag already exists, so it never updates one.

**Deliberately not included:** `checkout`, `setup-node`, and `setup-python` all have v7 majors, also node24. v6 fully clears the deprecation, and Renovate already has v7 queued as its own focused PR — bundling a second major into a sweep that touches release-critical workflows adds blast radius for no deprecation benefit. `.nvmrc` is likewise untouched; Renovate has `node → 24.19.0` queued, and Node 26 isn't LTS until October.

### How can this be tested?

CI on this PR exercises `test.yaml` and `e2e.yml` directly. The release and deploy workflows can't be tested by a PR, so those were verified against the actions' own sources and schemas:

- **`checkout` v4 → v6** was the main risk: `release-prod` runs `git fetch --tags`, `git tag`, and `git push origin <tag>` in plain `run:` steps after checkout. v6 moves the credential out of `.git/config` into a `RUNNER_TEMP` file referenced by an `includeIf.gitdir` directive. Git resolves `includeIf` at config-read time, so later `run:` steps still authenticate; `persist-credentials` still defaults to `true`. The known v6 credential issues (#2359/#2386) affect container actions, and #2336 affects self-hosted macOS — neither applies here.
- **`action-gh-release` v1 → v3** is two majors, but both are pure runtime bumps; all six inputs used here (`tag_name`, `name`, `generate_release_notes`, `draft`, `prerelease`, `body`) exist with unchanged defaults, and every new input is opt-in.
- **`upload-artifact` v7 / `download-artifact` v8** are a matched pair on one `@actions/artifact` backend. `archive` defaults to `true`, so the zip round-trip is unchanged, and v8's new `digest-mismatch: error` only fires on genuine corruption. v5's breaking change applied to `artifact-ids:` lookups; this flow downloads by `name:`.
- **`heroku-deploy`** changed only its `using:` line between these two tags.
- **Runner minimum**: several new majors require runner ≥ 2.327.1. Recent runs report 2.336.0 on both `ubuntu-26.04` and the `ubuntu-24.04` used by e2e.

### Additional context

Renovate had already detected **every one of these bumps** — they're sitting unmerged in the Dependency Dashboard (#28), along with the `checkout`/`setup-node`/`setup-python` v7 majors and `node → 24.19.0`. So these weren't stale because Renovate ignores GitHub Actions; the PRs were just never actioned. Probably worth a separate look at why, or they'll drift back.

### Checklist:

- [ ] Nothing to do before merging — no secrets, migrations, or config changes.
