### PR TITLE
test(webserver): run backend tests against postgres, not sqlite

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,6 +40,24 @@ jobs:
       # posture would 301 everything), and production behavior is pinned
       # hermetically by the load_settings tests, not by this job's env.
       IS_DEVELOPMENT: "True"
+      # Tests run against PostgreSQL, like local dev and production;
+      # main/test_settings.py refuses to run on any other engine.
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/math3d # pragma: allowlist secret
+    services:
+      db:
+        # Keep in sync with the `db` service in docker-compose.yml.
+        image: postgres:16.8
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres # pragma: allowlist secret
+          POSTGRES_DB: math3d
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -h localhost -U postgres -d math3d"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
     defaults:
       run:
         working-directory: ./webserver

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,7 +47,7 @@ jobs:
       db:
         # Keep the image tag in sync with the `db` service in
         # docker-compose.yml. The credentials intentionally differ.
-        image: postgres:16.8
+        image: postgres:18.6
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres # pragma: allowlist secret

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,7 +45,8 @@ jobs:
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/math3d # pragma: allowlist secret
     services:
       db:
-        # Keep in sync with the `db` service in docker-compose.yml.
+        # Keep the image tag in sync with the `db` service in
+        # docker-compose.yml. The credentials intentionally differ.
         image: postgres:16.8
         env:
           POSTGRES_USER: postgres
@@ -58,6 +59,7 @@ jobs:
           --health-interval 5s
           --health-timeout 5s
           --health-retries 10
+          --health-start-period 10s
     defaults:
       run:
         working-directory: ./webserver

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,15 +40,13 @@ jobs:
       # posture would 301 everything), and production behavior is pinned
       # hermetically by the load_settings tests, not by this job's env.
       IS_DEVELOPMENT: "True"
-      # Tests run against PostgreSQL, like local dev and production;
-      # main/test_settings.py refuses to run on any other engine.
+      # main/test_settings.py refuses to run on any engine but postgres.
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/math3d # pragma: allowlist secret
     services:
       db:
-        # Keep the image tag in sync with the `db` service in
-        # docker-compose.yml. Credentials differ because this service is
-        # created by Actions rather than compose, so it uses the image's
-        # default superuser rather than compose's `docker` role.
+        # Keep the tag in sync with the `db` service in docker-compose.yml.
+        # Actions creates this one, so it uses the image's default superuser
+        # rather than compose's `docker` role.
         image: postgres:18.6
         env:
           POSTGRES_USER: postgres

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,7 +46,9 @@ jobs:
     services:
       db:
         # Keep the image tag in sync with the `db` service in
-        # docker-compose.yml. The credentials intentionally differ.
+        # docker-compose.yml. Credentials differ because this service is
+        # created by Actions rather than compose, so it uses the image's
+        # default superuser rather than compose's `docker` role.
         image: postgres:18.6
         env:
           POSTGRES_USER: postgres

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -142,7 +142,7 @@
         "filename": "docker-compose.yml",
         "hashed_secret": "e982f17bcbe0f724063b708a4f76db211a999304",
         "is_verified": false,
-        "line_number": 33
+        "line_number": 35
       }
     ],
     "packages/app/public/mockServiceWorker.js": [
@@ -173,5 +173,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-30T22:55:59Z"
+  "generated_at": "2026-08-18T01:07:46Z"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ Feature-based organization in `packages/app/src/features/` (auth, notifications,
 ### Backend Stack
 
 - **Framework**: Django 5 + django-ninja (v1 API), Python 3.12
-- **DB**: PostgreSQL 16 (Docker, port 5431 host / 5432 container)
+- **DB**: PostgreSQL 18 (Docker, port 5431 host / 5432 container)
 - **Auth**: django-allauth headless (browser flows) + Django session auth
 - **API specs**: `webserver/openapi.v1.yaml` and `webserver/openapi.allauth.yaml`, dumped via management commands (see API Client Generation above)
 - **Deps**: Managed with `uv` (`webserver/pyproject.toml` + `webserver/uv.lock`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,8 +120,20 @@ Feature-based organization in `packages/app/src/features/` (auth, notifications,
 ### Testing
 
 - **Frontend unit tests**: Vitest + Testing Library + MSW mocks. Config in `packages/app/vite.config.ts`
-- **Backend tests**: pytest + pytest-django + factory-boy. Config in `webserver/pyproject.toml`. They run against PostgreSQL, like dev and production — run them in the container (`just be test`), which supplies `DATABASE_URL`. `main/test_settings.py` refuses to start on any other engine rather than silently falling back to SQLite. pytest-django creates a separate `test_math3d` database, so the dev database is untouched.
+- **Backend tests**: pytest + pytest-django + factory-boy. Config in `webserver/pyproject.toml`. They run against PostgreSQL, like dev and production — `just be test` supplies `DATABASE_URL`. `main/test_settings.py` refuses to start on any other engine rather than silently falling back to SQLite. See "Running backend tests" below.
 - **E2E**: Playwright in `packages/app-tests-e2e/`
+
+#### Running backend tests
+
+`just be test` (from the repo root) is the normal path — it runs pytest in the webserver container against the compose postgres.
+
+pytest-django creates a separate `test_`-prefixed database, so the dev database is never touched. That name is fixed, though, and Django autoclobbers it on startup: **two backend suites must not run at once**, or the second drops the first's database mid-run. Set `TEST_DB_NAME` to give a worktree or parallel agent its own.
+
+From a worktree, `just be test` does not work — compose would try to start a duplicate stack on ports the main checkout already holds. Run against the main checkout's database from `webserver/` instead:
+
+```bash
+DATABASE_URL=postgresql://docker:docker@localhost:5431/math3d TEST_DB_NAME=test_math3d_wt uv run pytest # pragma: allowlist secret
+```
 
 #### Running E2E tests locally
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,15 +127,15 @@ Feature-based organization in `packages/app/src/features/` (auth, notifications,
 
 `just be test` (from the repo root) is the normal path — it runs pytest in a one-off webserver container against the compose postgres.
 
-pytest-django creates a separate `test_`-prefixed database, so the dev database is never touched. That name is fixed, though, and Django autoclobbers it on startup: **two backend suites must not run at once**, or the second drops the first's database mid-run. Set `TEST_DB_NAME` (which must start with `test_`) to give a worktree or parallel agent its own — pick a name unique to that checkout, not the one below verbatim.
+pytest-django creates a separate `test_`-prefixed database, so the dev database is never touched. That name is fixed, though, and Django autoclobbers it on startup: **two backend suites must not run at once**, or the second drops the first's database mid-run. Set `TEST_DB_NAME` (which must start with `test_`) to give a worktree or parallel agent its own; the command below names it after the checkout directory.
 
 From a worktree, `just be test` does not work — compose would try to start a duplicate stack on ports the main checkout already holds. Run against the main checkout's database from `webserver/`, in a direnv-enabled shell (the settings require the worktree's env; without it you get `ImproperlyConfigured: APP_BASE_URL is required`):
 
 ```bash
-DATABASE_URL=postgresql://docker:docker@localhost:5431/math3d TEST_DB_NAME=test_math3d_$(basename $PWD) uv run pytest # pragma: allowlist secret
+DATABASE_URL=postgresql://docker:docker@localhost:5431/math3d TEST_DB_NAME=test_math3d_$(basename $(git rev-parse --show-toplevel)) uv run pytest # pragma: allowlist secret
 ```
 
-**After the postgres image version changes** (e.g. the 16 → 18 bump), the `db` service comes up empty: it has no named volume, and the image's data path moves between majors, so the old anonymous volume is orphaned rather than reused. Repopulate it — the old volume is left intact if you need to recover anything first:
+**After the postgres image major version changes** (e.g. the 16 → 18 bump), the `db` service comes up empty: `PGDATA` is major-versioned (`/var/lib/postgresql/<major>/docker`), so a new major finds no data directory and runs `initdb`. The previous major's files are left intact — in the `db-data` volume, or, for majors predating it, in the orphaned anonymous volume. Repopulate:
 
 ```bash
 docker compose run --rm webserver uv run ./manage.py migrate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ Feature-based organization in `packages/app/src/features/` (auth, notifications,
 ### Testing
 
 - **Frontend unit tests**: Vitest + Testing Library + MSW mocks. Config in `packages/app/vite.config.ts`
-- **Backend tests**: pytest + pytest-django + factory-boy. Config in `webserver/pyproject.toml`
+- **Backend tests**: pytest + pytest-django + factory-boy. Config in `webserver/pyproject.toml`. They run against PostgreSQL, like dev and production — run them in the container (`just be test`), which supplies `DATABASE_URL`. `main/test_settings.py` refuses to start on any other engine rather than silently falling back to SQLite. pytest-django creates a separate `test_math3d` database, so the dev database is untouched.
 - **E2E**: Playwright in `packages/app-tests-e2e/`
 
 #### Running E2E tests locally

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,21 +125,28 @@ Feature-based organization in `packages/app/src/features/` (auth, notifications,
 
 #### Running backend tests
 
-`just be test` (from the repo root) is the normal path — it runs pytest in the webserver container against the compose postgres.
+`just be test` (from the repo root) is the normal path — it runs pytest in a one-off webserver container against the compose postgres.
 
-pytest-django creates a separate `test_`-prefixed database, so the dev database is never touched. That name is fixed, though, and Django autoclobbers it on startup: **two backend suites must not run at once**, or the second drops the first's database mid-run. Set `TEST_DB_NAME` to give a worktree or parallel agent its own.
+pytest-django creates a separate `test_`-prefixed database, so the dev database is never touched. That name is fixed, though, and Django autoclobbers it on startup: **two backend suites must not run at once**, or the second drops the first's database mid-run. Set `TEST_DB_NAME` (which must start with `test_`) to give a worktree or parallel agent its own — pick a name unique to that checkout, not the one below verbatim.
 
-From a worktree, `just be test` does not work — compose would try to start a duplicate stack on ports the main checkout already holds. Run against the main checkout's database from `webserver/` instead:
+From a worktree, `just be test` does not work — compose would try to start a duplicate stack on ports the main checkout already holds. Run against the main checkout's database from `webserver/`, in a direnv-enabled shell (the settings require the worktree's env; without it you get `ImproperlyConfigured: APP_BASE_URL is required`):
 
 ```bash
-DATABASE_URL=postgresql://docker:docker@localhost:5431/math3d TEST_DB_NAME=test_math3d_wt uv run pytest # pragma: allowlist secret
+DATABASE_URL=postgresql://docker:docker@localhost:5431/math3d TEST_DB_NAME=test_math3d_$(basename $PWD) uv run pytest # pragma: allowlist secret
+```
+
+**After the postgres image version changes** (e.g. the 16 → 18 bump), the `db` service comes up empty: it has no named volume, and the image's data path moves between majors, so the old anonymous volume is orphaned rather than reused. Repopulate it — the old volume is left intact if you need to recover anything first:
+
+```bash
+docker compose run --rm webserver uv run ./manage.py migrate
+docker compose run --rm webserver uv run ./manage.py seed_test_data
 ```
 
 #### Running E2E tests locally
 
 The E2E tests hit a real backend and a real frontend server, and the full suite takes only ~1 minute (3D/WebGL rendering is disabled by default via the `disable3d` fixture). Lint, typecheck, and unit tests do NOT catch E2E breakage — **run `yarn test-e2e` before declaring work on `packages/app` complete**. CI runs the suite on every PR.
 
-1. Backend up: `docker compose up -d` (from the main checkout). One-time DB prep (also after test credentials change): `docker compose run --rm webserver uv run ./manage.py migrate` and `... seed_test_data`.
+1. Backend up: `docker compose up -d` (from the main checkout). One-time DB prep (also after test credentials change, and after the postgres image version changes — see "Running backend tests"): `docker compose run --rm webserver uv run ./manage.py migrate` and `... seed_test_data`.
 2. The main checkout needs a gitignored `.env` with `VITE_DISPLAY_AUTH_FLOWS=true` and `ENABLE_REGISTRATION=True` (the committed `.env.development` defaults both off; global setup and the signup tests require them).
 3. Frontend: handled automatically — Playwright's `webServer` config reuses a dev server already running at `TEST_APP_URL`, or starts one (`yarn start`) if nothing is serving it. No production build needed locally; CI serves a production build via `yarn preview` to test the real artifact.
 4. `yarn test-e2e` runs the full suite (`yarn test-e2e src/tests/<path>` for one file; `just e2e` is an alias). It is self-sufficient in any shell and any checkout: the script runs Playwright under Node's `--env-file-if-exists` flags, so the checkout's `.env.development` + `.env` fill in whatever the environment doesn't already set (real env vars win, so ad-hoc overrides like `TEST_APP_URL=... yarn test-e2e` still work). Global setup also verifies the server at `TEST_APP_URL` actually serves _this_ checkout (via the `X-Checkout-Root` header the Vite dev/preview server emits) and fails with instructions if not — so testing the wrong checkout's code is loud, never silent.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,10 @@ services:
       default-network:
     ports:
       - "5431:5432"
+    volumes:
+      - db-data:/var/lib/postgresql
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -d math3d -U docker"]
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -d math3d -U docker"]
       interval: 5s
       timeout: 60s
       retries: 5
@@ -48,3 +50,4 @@ services:
 
 volumes:
   venv-data:
+  db-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ networks:
 
 services:
   db:
-    image: postgres:16.8
+    image: postgres:18.6
     environment:
       - POSTGRES_USER=docker
       - POSTGRES_PASSWORD=docker

--- a/webserver/authentication/api.py
+++ b/webserver/authentication/api.py
@@ -3,7 +3,7 @@ from typing import cast
 from allauth.account.models import EmailAddress
 from django.http import HttpRequest
 from django.middleware.csrf import get_token
-from ninja import Router, Schema, Status
+from ninja import Field, Router, Schema, Status
 
 from authentication.models import CustomUser
 from main.ninja_auth import session_auth, staff_auth
@@ -17,9 +17,15 @@ class UserSchema(Schema):
     public_nickname: str  # snake_case on the wire, intentionally
 
 
+_NICKNAME_MAX_LENGTH = CustomUser._meta.get_field("public_nickname").max_length
+
+
 class UserUpdateSchema(Schema):
     # public_nickname is the only writable field (v0: id/email read-only).
-    public_nickname: str
+    # The bound is read off the model so it cannot drift from the column: an
+    # over-length value would otherwise reach the DB and raise DataError (a
+    # 500) rather than a validation error.
+    public_nickname: str = Field(max_length=_NICKNAME_MAX_LENGTH)
 
 
 class DeleteAccountSchema(Schema):

--- a/webserver/authentication/api.py
+++ b/webserver/authentication/api.py
@@ -5,7 +5,7 @@ from django.http import HttpRequest
 from django.middleware.csrf import get_token
 from ninja import Field, Router, Schema, Status
 
-from authentication.models import CustomUser
+from authentication.models import NICKNAME_MAX_LENGTH, CustomUser
 from main.ninja_auth import session_auth, staff_auth
 
 router = Router()
@@ -17,15 +17,9 @@ class UserSchema(Schema):
     public_nickname: str  # snake_case on the wire, intentionally
 
 
-_NICKNAME_MAX_LENGTH = CustomUser._meta.get_field("public_nickname").max_length
-
-
 class UserUpdateSchema(Schema):
     # public_nickname is the only writable field (v0: id/email read-only).
-    # The bound is read off the model so it cannot drift from the column: an
-    # over-length value would otherwise reach the DB and raise DataError (a
-    # 500) rather than a validation error.
-    public_nickname: str = Field(max_length=_NICKNAME_MAX_LENGTH)
+    public_nickname: str = Field(max_length=NICKNAME_MAX_LENGTH)
 
 
 class DeleteAccountSchema(Schema):

--- a/webserver/authentication/api_test.py
+++ b/webserver/authentication/api_test.py
@@ -69,6 +69,22 @@ def test_me_patch_updates_public_nickname_and_ignores_readonly_fields():
 
 
 @pytest.mark.django_db
+def test_me_patch_rejects_over_length_nickname():
+    # public_nickname is a varchar(64); without a schema bound the write reaches
+    # the DB and 500s. Signup already caps it (authentication/forms.py), so the
+    # PATCH path must reject it the same way.
+    user = CustomUserFactory.create()
+    client = Client()
+    client.force_login(user)
+    response = client.patch(
+        ME_URL,
+        data={"public_nickname": "x" * 65},
+        content_type="application/json",
+    )
+    assert response.status_code == 400  # main/api.py maps ninja's 422 to 400
+
+
+@pytest.mark.django_db
 def test_me_patch_enforces_csrf():
     # v0 parity (test_csrf_token_required_for_unsafe_requests): Ninja's SessionAuth
     # must reject an unsafe request lacking the CSRF token. The other patch tests

--- a/webserver/authentication/api_test.py
+++ b/webserver/authentication/api_test.py
@@ -70,9 +70,7 @@ def test_me_patch_updates_public_nickname_and_ignores_readonly_fields():
 
 @pytest.mark.django_db
 def test_me_patch_rejects_over_length_nickname():
-    # public_nickname is a varchar(64); without a schema bound the write reaches
-    # the DB and 500s. Signup already caps it (authentication/forms.py), so the
-    # PATCH path must reject it the same way.
+    # public_nickname is a varchar(64); unbounded, the write reaches the DB and 500s.
     user = CustomUserFactory.create()
     client = Client()
     client.force_login(user)

--- a/webserver/authentication/forms.py
+++ b/webserver/authentication/forms.py
@@ -1,5 +1,7 @@
 from django import forms
 
+from authentication.models import NICKNAME_MAX_LENGTH
+
 
 class CustomSignupForm(forms.Form):
     """
@@ -10,7 +12,7 @@ class CustomSignupForm(forms.Form):
     passed through to the adapter's save_user() via form.cleaned_data.
     """
 
-    public_nickname = forms.CharField(max_length=64, required=False)
+    public_nickname = forms.CharField(max_length=NICKNAME_MAX_LENGTH, required=False)
 
     def signup(self, request, user):
         """Called by allauth after user is saved. Nothing extra to do here

--- a/webserver/authentication/models.py
+++ b/webserver/authentication/models.py
@@ -25,7 +25,6 @@ class CustomUser(AbstractBaseUser, PermissionsMixin):
         verbose_name = "User"
 
 
-# Read off the field so the API schema and the signup form cannot drift from
-# the column: an over-length value that reaches the DB raises DataError (a 500)
-# rather than a validation error.
+# Read off the field so the API schema and signup form can't drift from the
+# column; an over-length value reaching the DB raises DataError (a 500).
 NICKNAME_MAX_LENGTH = CustomUser._meta.get_field("public_nickname").max_length

--- a/webserver/authentication/models.py
+++ b/webserver/authentication/models.py
@@ -23,3 +23,9 @@ class CustomUser(AbstractBaseUser, PermissionsMixin):
 
     class Meta:
         verbose_name = "User"
+
+
+# Read off the field so the API schema and the signup form cannot drift from
+# the column: an over-length value that reaches the DB raises DataError (a 500)
+# rather than a validation error.
+NICKNAME_MAX_LENGTH = CustomUser._meta.get_field("public_nickname").max_length

--- a/webserver/main/settings_test.py
+++ b/webserver/main/settings_test.py
@@ -6,13 +6,13 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
 from main.env import EnvConfig
-from main.test_settings import require_postgres
 from main.origins import (
     WORKTREE_PORTS,
     cors_allowed_origins,
     csrf_trusted_origins,
     dev_cors_allowed_origins,
 )
+from main.test_settings import require_postgres
 
 SETTINGS_PATH = Path(__file__).parent / "settings.py"
 
@@ -326,10 +326,6 @@ def test_local_csrf_trust_handles_unset_app_base_url():
     assert origins == ["http://math3d.localdev:3000"]
 
 
-def test_require_postgres_accepts_postgres():
-    require_postgres("django.db.backends.postgresql")
-
-
 @pytest.mark.parametrize(
     ("database_url", "expected"),
     [
@@ -337,13 +333,15 @@ def test_require_postgres_accepts_postgres():
         ("sqlite:////tmp/db.sqlite3", "DATABASE_URL resolved to"),
     ],
 )
-def test_require_postgres_rejects_sqlite(monkeypatch, database_url, expected):
+def test_require_postgres_rejects_sqlite(database_url, expected):
     """
     The suite must never fall back to SQLite. The two cases report differently
     because an unset DATABASE_URL (settings.py's fallback) is the common cause
     and needs different remediation than a URL explicitly pointing elsewhere.
+
+    The accepting case needs no test: require_postgres runs at settings import,
+    so an inverted condition takes the whole suite red.
     """
-    monkeypatch.setenv("DATABASE_URL", database_url)
     with pytest.raises(ImproperlyConfigured) as exc_info:
-        require_postgres("django.db.backends.sqlite3")
+        require_postgres("django.db.backends.sqlite3", database_url)
     assert expected in str(exc_info.value)

--- a/webserver/main/settings_test.py
+++ b/webserver/main/settings_test.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
 from main.env import EnvConfig
+from main.test_settings import require_postgres
 from main.origins import (
     WORKTREE_PORTS,
     cors_allowed_origins,
@@ -323,3 +324,26 @@ def test_local_csrf_trust_handles_unset_app_base_url():
         cors_allowed_origins=["http://math3d.localdev:3000"],
     )
     assert origins == ["http://math3d.localdev:3000"]
+
+
+def test_require_postgres_accepts_postgres():
+    require_postgres("django.db.backends.postgresql")
+
+
+@pytest.mark.parametrize(
+    ("database_url", "expected"),
+    [
+        ("", "DATABASE_URL is not set"),
+        ("sqlite:////tmp/db.sqlite3", "DATABASE_URL resolved to"),
+    ],
+)
+def test_require_postgres_rejects_sqlite(monkeypatch, database_url, expected):
+    """
+    The suite must never fall back to SQLite. The two cases report differently
+    because an unset DATABASE_URL (settings.py's fallback) is the common cause
+    and needs different remediation than a URL explicitly pointing elsewhere.
+    """
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    with pytest.raises(ImproperlyConfigured) as exc_info:
+        require_postgres("django.db.backends.sqlite3")
+    assert expected in str(exc_info.value)

--- a/webserver/main/settings_test.py
+++ b/webserver/main/settings_test.py
@@ -335,12 +335,9 @@ def test_local_csrf_trust_handles_unset_app_base_url():
 )
 def test_require_postgres_rejects_sqlite(database_url, expected):
     """
-    The suite must never fall back to SQLite. The two cases report differently
-    because an unset DATABASE_URL (settings.py's fallback) is the common cause
-    and needs different remediation than a URL explicitly pointing elsewhere.
-
-    The accepting case needs no test: require_postgres runs at settings import,
-    so an inverted condition takes the whole suite red.
+    The two cases report differently because an unset DATABASE_URL needs
+    different remediation than one explicitly pointing elsewhere. The accepting
+    case needs no test: it runs at settings import, so inverting it goes red.
     """
     with pytest.raises(ImproperlyConfigured) as exc_info:
         require_postgres("django.db.backends.sqlite3", database_url)

--- a/webserver/main/test_settings.py
+++ b/webserver/main/test_settings.py
@@ -1,8 +1,20 @@
+from django.core.exceptions import ImproperlyConfigured
+
 from main.settings import *  # noqa: F403
 
-DATABASES["default"] = {  # noqa: F405
-    "ENGINE": "django.db.backends.sqlite3",
-    "NAME": "mydatabase",
-}
+# Tests run against PostgreSQL, the engine used in local dev and production.
+# main.settings falls back to SQLite when DATABASE_URL is unset; that fallback
+# must never silently apply to the test suite, because SQLite's laxer semantics
+# (unenforced varchar lengths, deferred/absent constraint behavior, different
+# LIKE case-sensitivity and ordering) let bugs pass here that fail in prod.
+# pytest-django creates a separate `test_`-prefixed database, so this does not
+# touch the dev database named in DATABASE_URL.
+if DATABASES["default"]["ENGINE"] != "django.db.backends.postgresql":  # noqa: F405
+    raise ImproperlyConfigured(
+        "The test suite requires PostgreSQL, but DATABASE_URL resolved to "
+        f"{DATABASES['default']['ENGINE']!r}. "  # noqa: F405
+        "Run the tests inside the webserver container (`just be test` from the "
+        "repo root), which sets DATABASE_URL to the compose `db` service."
+    )
 
 SECRET_KEY = "not-so-secret-in-tests"  # pragma: allowlist secret

--- a/webserver/main/test_settings.py
+++ b/webserver/main/test_settings.py
@@ -5,7 +5,7 @@ from django.core.exceptions import ImproperlyConfigured
 from main.settings import *  # noqa: F403
 
 
-def require_postgres(engine: str) -> None:
+def require_postgres(engine: str, database_url: str) -> None:
     """
     Fail loudly unless the test database is PostgreSQL.
 
@@ -20,7 +20,7 @@ def require_postgres(engine: str) -> None:
         return
     detail = (
         f"DATABASE_URL resolved to {engine!r}"
-        if os.environ.get("DATABASE_URL")
+        if database_url
         else "DATABASE_URL is not set, so settings fell back to SQLite"
     )
     raise ImproperlyConfigured(
@@ -31,13 +31,19 @@ def require_postgres(engine: str) -> None:
     )
 
 
-require_postgres(DATABASES["default"]["ENGINE"])  # noqa: F405
+require_postgres(DATABASES["default"]["ENGINE"], ENV.DATABASE_URL)  # noqa: F405
 
 # pytest-django creates a `test_`-prefixed database, so the dev database is
-# untouched — but that name is fixed, and Django autoclobbers it on startup.
-# Concurrent suites (worktrees, parallel agents) would drop each other's
-# in-flight database, so allow each to claim its own.
+# untouched — but that name is fixed, and Django autoclobbers it. Concurrent
+# suites (worktrees, parallel agents) would drop each other's in-flight
+# database, so allow each to claim its own.
 if test_db_name := os.environ.get("TEST_DB_NAME"):
-    DATABASES["default"]["TEST"] = {"NAME": test_db_name}  # noqa: F405
+    if not test_db_name.startswith("test_"):
+        # Django drops and recreates this database without prompting, so a name
+        # that isn't clearly a test database could destroy the dev one.
+        raise ImproperlyConfigured(
+            f"TEST_DB_NAME must start with 'test_' (got {test_db_name!r})."
+        )
+    DATABASES["default"].setdefault("TEST", {})["NAME"] = test_db_name  # noqa: F405
 
 SECRET_KEY = "not-so-secret-in-tests"  # pragma: allowlist secret

--- a/webserver/main/test_settings.py
+++ b/webserver/main/test_settings.py
@@ -1,20 +1,43 @@
+import os
+
 from django.core.exceptions import ImproperlyConfigured
 
 from main.settings import *  # noqa: F403
 
-# Tests run against PostgreSQL, the engine used in local dev and production.
-# main.settings falls back to SQLite when DATABASE_URL is unset; that fallback
-# must never silently apply to the test suite, because SQLite's laxer semantics
-# (unenforced varchar lengths, deferred/absent constraint behavior, different
-# LIKE case-sensitivity and ordering) let bugs pass here that fail in prod.
-# pytest-django creates a separate `test_`-prefixed database, so this does not
-# touch the dev database named in DATABASE_URL.
-if DATABASES["default"]["ENGINE"] != "django.db.backends.postgresql":  # noqa: F405
-    raise ImproperlyConfigured(
-        "The test suite requires PostgreSQL, but DATABASE_URL resolved to "
-        f"{DATABASES['default']['ENGINE']!r}. "  # noqa: F405
-        "Run the tests inside the webserver container (`just be test` from the "
-        "repo root), which sets DATABASE_URL to the compose `db` service."
+
+def require_postgres(engine: str) -> None:
+    """
+    Fail loudly unless the test database is PostgreSQL.
+
+    Dev and production both run PostgreSQL, and main.settings falls back to
+    SQLite when DATABASE_URL is unset. That fallback must never reach the test
+    suite: SQLite does not enforce varchar lengths, folds case only over ASCII
+    in LIKE, and degrades the pg_trgm GIN index on Scene.title to a plain
+    B-tree (TrigramExtension is a no-op there), so bugs that fail in
+    production can pass here.
+    """
+    if engine == "django.db.backends.postgresql":
+        return
+    detail = (
+        f"DATABASE_URL resolved to {engine!r}"
+        if os.environ.get("DATABASE_URL")
+        else "DATABASE_URL is not set, so settings fell back to SQLite"
     )
+    raise ImproperlyConfigured(
+        f"The test suite requires PostgreSQL, but {detail}. Run the tests inside "
+        "the webserver container (`just be test` from the repo root), or point "
+        "them at the compose database directly: "
+        "DATABASE_URL=postgresql://docker:docker@localhost:5431/math3d uv run pytest"  # pragma: allowlist secret
+    )
+
+
+require_postgres(DATABASES["default"]["ENGINE"])  # noqa: F405
+
+# pytest-django creates a `test_`-prefixed database, so the dev database is
+# untouched — but that name is fixed, and Django autoclobbers it on startup.
+# Concurrent suites (worktrees, parallel agents) would drop each other's
+# in-flight database, so allow each to claim its own.
+if test_db_name := os.environ.get("TEST_DB_NAME"):
+    DATABASES["default"]["TEST"] = {"NAME": test_db_name}  # noqa: F405
 
 SECRET_KEY = "not-so-secret-in-tests"  # pragma: allowlist secret

--- a/webserver/main/test_settings.py
+++ b/webserver/main/test_settings.py
@@ -7,14 +7,9 @@ from main.settings import *  # noqa: F403
 
 def require_postgres(engine: str, database_url: str) -> None:
     """
-    Fail loudly unless the test database is PostgreSQL.
-
-    Dev and production both run PostgreSQL, and main.settings falls back to
-    SQLite when DATABASE_URL is unset. That fallback must never reach the test
-    suite: SQLite does not enforce varchar lengths, folds case only over ASCII
-    in LIKE, and degrades the pg_trgm GIN index on Scene.title to a plain
-    B-tree (TrigramExtension is a no-op there), so bugs that fail in
-    production can pass here.
+    Fail loudly unless the test database is PostgreSQL, as dev and production
+    are. main.settings falls back to SQLite when DATABASE_URL is unset, and
+    that fallback hides bugs that would fail in production.
     """
     if engine == "django.db.backends.postgresql":
         return
@@ -33,14 +28,11 @@ def require_postgres(engine: str, database_url: str) -> None:
 
 require_postgres(DATABASES["default"]["ENGINE"], ENV.DATABASE_URL)  # noqa: F405
 
-# pytest-django creates a `test_`-prefixed database, so the dev database is
-# untouched — but that name is fixed, and Django autoclobbers it. Concurrent
-# suites (worktrees, parallel agents) would drop each other's in-flight
-# database, so allow each to claim its own.
+# The test database name is otherwise fixed, and Django autoclobbers it, so
+# concurrent suites (worktrees, parallel agents) would drop each other's.
 if test_db_name := os.environ.get("TEST_DB_NAME"):
     if not test_db_name.startswith("test_"):
-        # Django drops and recreates this database without prompting, so a name
-        # that isn't clearly a test database could destroy the dev one.
+        # Guards against pointing the autoclobber at the dev database.
         raise ImproperlyConfigured(
             f"TEST_DB_NAME must start with 'test_' (got {test_db_name!r})."
         )

--- a/webserver/openapi.v1.yaml
+++ b/webserver/openapi.v1.yaml
@@ -1341,6 +1341,7 @@ components:
     UserUpdateSchema:
       properties:
         public_nickname:
+          maxLength: 64
           title: Public Nickname
           type: string
       required:

--- a/webserver/pyproject.toml
+++ b/webserver/pyproject.toml
@@ -33,13 +33,9 @@ dev = [
 	"lxml-stubs>=0.5.0,<0.6.0",
 	"factory-boy>=3.3.3,<4.0.0",
 	"types-factory-boy>=0.4.1,<0.5.0",
-	# The runtime dependency is plain `psycopg`, whose pure-Python impl loads
-	# libpq from the system. That fails on a bare macOS host and on a CI runner
-	# with no postgres installed ("no pq wrapper available"), so tests get the
-	# binary wheel, which bundles its own libpq.
-	# Note this is a dev group, but the Dockerfile syncs all groups — so the
-	# dev image and CI use the bundled libpq, and nothing here exercises the
-	# system-libpq path a production deploy uses.
+	# The runtime `psycopg` loads libpq from the system, which a bare macOS host
+	# and the CI runner lack. The binary wheel bundles its own. The Dockerfile
+	# syncs all groups, so the dev image and CI never exercise the system libpq.
 	"psycopg[binary]>=3.2.10",
 ]
 

--- a/webserver/pyproject.toml
+++ b/webserver/pyproject.toml
@@ -34,10 +34,12 @@ dev = [
 	"factory-boy>=3.3.3,<4.0.0",
 	"types-factory-boy>=0.4.1,<0.5.0",
 	# The runtime dependency is plain `psycopg`, whose pure-Python impl loads
-	# libpq from the system. That's fine in the Docker image and on Heroku, but
-	# not on a bare macOS host or a CI runner, where `import psycopg` fails with
-	# "no pq wrapper available". The binary wheel bundles its own libpq so tests
-	# run anywhere; production still uses the system libpq.
+	# libpq from the system. That fails on a bare macOS host and on a CI runner
+	# with no postgres installed ("no pq wrapper available"), so tests get the
+	# binary wheel, which bundles its own libpq.
+	# Note this is a dev group, but the Dockerfile syncs all groups — so the
+	# dev image and CI use the bundled libpq, and nothing here exercises the
+	# system-libpq path a production deploy uses.
 	"psycopg[binary]>=3.2.10",
 ]
 

--- a/webserver/pyproject.toml
+++ b/webserver/pyproject.toml
@@ -33,6 +33,12 @@ dev = [
 	"lxml-stubs>=0.5.0,<0.6.0",
 	"factory-boy>=3.3.3,<4.0.0",
 	"types-factory-boy>=0.4.1,<0.5.0",
+	# The runtime dependency is plain `psycopg`, whose pure-Python impl loads
+	# libpq from the system. That's fine in the Docker image and on Heroku, but
+	# not on a bare macOS host or a CI runner, where `import psycopg` fails with
+	# "no pq wrapper available". The binary wheel bundles its own libpq so tests
+	# run anywhere; production still uses the system libpq.
+	"psycopg[binary]>=3.2.10",
 ]
 
 [build-system]

--- a/webserver/scenes/models_test.py
+++ b/webserver/scenes/models_test.py
@@ -1,6 +1,6 @@
 import pytest
 from django.core.exceptions import ValidationError
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError
 from scenes.models import Scene, is_reserved_key_error
 from scenes.factories import SceneFactory
 
@@ -22,12 +22,8 @@ def test_reserved_key_rejected_by_full_clean(bad_key):
 @pytest.mark.parametrize("bad_key", ["app", "a"])
 def test_reserved_key_rejected_by_db_constraint(bad_key):
     # bulk_create bypasses full_clean(); the DB CHECK constraint must still reject.
-    # The atomic() block is required, not decorative: on postgres the
-    # IntegrityError aborts the surrounding transaction, so without a savepoint
-    # to roll back to, the assertion below fails with TransactionManagementError.
-    with pytest.raises(IntegrityError), transaction.atomic():
+    with pytest.raises(IntegrityError):
         Scene.objects.bulk_create([Scene(**_valid_scene_kwargs(bad_key))])
-    assert not Scene.objects.filter(key=bad_key).exists()
 
 
 @pytest.mark.django_db

--- a/webserver/scenes/models_test.py
+++ b/webserver/scenes/models_test.py
@@ -1,6 +1,6 @@
 import pytest
 from django.core.exceptions import ValidationError
-from django.db import IntegrityError
+from django.db import IntegrityError, transaction
 from scenes.models import Scene, is_reserved_key_error
 from scenes.factories import SceneFactory
 
@@ -22,8 +22,12 @@ def test_reserved_key_rejected_by_full_clean(bad_key):
 @pytest.mark.parametrize("bad_key", ["app", "a"])
 def test_reserved_key_rejected_by_db_constraint(bad_key):
     # bulk_create bypasses full_clean(); the DB CHECK constraint must still reject.
-    with pytest.raises(IntegrityError):
+    # The atomic() block is required, not decorative: on postgres the
+    # IntegrityError aborts the surrounding transaction, so without a savepoint
+    # to roll back to, the assertion below fails with TransactionManagementError.
+    with pytest.raises(IntegrityError), transaction.atomic():
         Scene.objects.bulk_create([Scene(**_valid_scene_kwargs(bad_key))])
+    assert not Scene.objects.filter(key=bad_key).exists()
 
 
 @pytest.mark.django_db

--- a/webserver/uv.lock
+++ b/webserver/uv.lock
@@ -291,6 +291,7 @@ dev = [
     { name = "lxml" },
     { name = "lxml-stubs" },
     { name = "mypy" },
+    { name = "psycopg", extra = ["binary"] },
     { name = "pytest" },
     { name = "pytest-django" },
     { name = "types-dj-database-url" },
@@ -323,6 +324,7 @@ dev = [
     { name = "lxml", specifier = ">=5.4.0,<6.0.0" },
     { name = "lxml-stubs", specifier = ">=0.5.0,<0.6.0" },
     { name = "mypy", specifier = ">=1.0.0,<2.0.0" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.2.10" },
     { name = "pytest", specifier = ">=9.0.3,<9.1.0" },
     { name = "pytest-django", specifier = ">=4.5.2,<5.0.0" },
     { name = "types-dj-database-url", specifier = ">=1.3.0.4,<2.0.0" },
@@ -397,6 +399,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a9/f1/0258a123c045afaf3c3b60c22ccff077bceeb24b8dc2c593270899353bd0/psycopg-3.2.10.tar.gz", hash = "sha256:0bce99269d16ed18401683a8569b2c5abd94f72f8364856d56c0389bcd50972a", size = 160380, upload-time = "2025-09-08T09:13:37.775Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/90/422ffbbeeb9418c795dae2a768db860401446af0c6768bc061ce22325f58/psycopg-3.2.10-py3-none-any.whl", hash = "sha256:ab5caf09a9ec42e314a21f5216dbcceac528e0e05142e42eea83a3b28b320ac3", size = 206586, upload-time = "2025-09-08T09:07:50.121Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.2.10"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/34/91c127fdedf8b270b1e3acc9f849d07ee8b80194379590c6f48dcc842924/psycopg_binary-3.2.10-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:1dee2f4d2adc9adacbfecf8254bd82f6ac95cff707e1b9b99aa721cd1ef16b47", size = 3983963, upload-time = "2025-09-08T09:09:38.454Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/03/1d10ce2bf70cf549a8019639dc0c49be03e41092901d4324371a968b8c01/psycopg_binary-3.2.10-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8b45e65383da9c4a42a56f817973e521e893f4faae897fe9f1a971f9fe799742", size = 4069171, upload-time = "2025-09-08T09:09:44.395Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/5e/39cb924d6e119145aa5fc5532f48e79c67e13a76675e9366c327098db7b5/psycopg_binary-3.2.10-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:484d2b1659afe0f8f1cef5ea960bb640e96fa864faf917086f9f833f5c7a8034", size = 4610780, upload-time = "2025-09-08T09:09:53.073Z" },
+    { url = "https://files.pythonhosted.org/packages/20/05/5a1282ebc4e39f5890abdd4bb7edfe9d19e4667497a1793ad288a8b81826/psycopg_binary-3.2.10-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3bb4046973264ebc8cb7e20a83882d68577c1f26a6f8ad4fe52e4468cd9a8eee", size = 4700479, upload-time = "2025-09-08T09:09:58.183Z" },
+    { url = "https://files.pythonhosted.org/packages/af/7a/e1c06e558ca3f37b7e6b002e555ebcfce0bf4dee6f3ae589a7444e16ce17/psycopg_binary-3.2.10-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:14bcbcac0cab465d88b2581e43ec01af4b01c9833e663f1352e05cb41be19e44", size = 4391772, upload-time = "2025-09-08T09:10:04.406Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/d6/56f449c86988c9a97dc6c5f31d3689cfe8aedb37f2a02bd3e3882465d385/psycopg_binary-3.2.10-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:70bb7f665587dfd79e69f48b34efe226149454d7aab138ed22d5431d703de2f6", size = 3858214, upload-time = "2025-09-08T09:10:09.693Z" },
+    { url = "https://files.pythonhosted.org/packages/93/56/f9eed67c9a1701b1e315f3687ff85f2f22a0a7d0eae4505cff65ef2f2679/psycopg_binary-3.2.10-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:d2fe9eaa367f6171ab1a21a7dcb335eb2398be7f8bb7e04a20e2260aedc6f782", size = 3528051, upload-time = "2025-09-08T09:10:13.423Z" },
+    { url = "https://files.pythonhosted.org/packages/25/cc/636709c72540cb859566537c0a03e46c3d2c4c4c2e13f78df46b6c4082b3/psycopg_binary-3.2.10-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:299834cce3eec0c48aae5a5207fc8f0c558fd65f2ceab1a36693329847da956b", size = 3580117, upload-time = "2025-09-08T09:10:17.81Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/a8/a2c822fa06b0dbbb8ad4b0221da2534f77bac54332d2971dbf930f64be5a/psycopg_binary-3.2.10-cp312-cp312-win_amd64.whl", hash = "sha256:e037aac8dc894d147ef33056fc826ee5072977107a3fdf06122224353a057598", size = 2878872, upload-time = "2025-09-08T09:10:22.162Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### What are the relevant issues?

N/A

### Description

The backend test suite was running against SQLite while dev and production both run PostgreSQL.

`main/test_settings.py` imported the real settings and then unconditionally overwrote the database:

```python
DATABASES["default"] = {"ENGINE": "django.db.backends.sqlite3", "NAME": "mydatabase"}
```

So the postgres `DATABASE_URL` supplied by docker-compose was read and immediately discarded. Anything engine-specific — enforced `varchar` lengths, transaction poisoning after an `IntegrityError`, case-sensitive `LIKE`, JSON lookups, ordering — was untested.

**Changes:**

- **`webserver/main/test_settings.py`** — drop the override so tests inherit `DATABASE_URL`, and refuse to start on any non-postgres engine. The guard is load-bearing, not belt-and-braces: `main/settings.py` falls back to `sqlite:///db.sqlite3` when `DATABASE_URL` is unset, so deleting the override on its own would have preserved the same silent-SQLite run whenever the env was missing.
- **`.github/workflows/test.yaml`** — the `webserver-tests` job had no database service at all, so it would have tripped that new guard. Adds a postgres service matching docker-compose, plus `DATABASE_URL`.
- **`CLAUDE.md`** — document that backend tests need postgres and run via `just be test`.

- **`webserver/pyproject.toml`** — `psycopg[binary]` joins the dev group. The runtime dep is plain `psycopg`, whose pure-Python impl loads `libpq` from the system, so `import psycopg` fails with `no pq wrapper available` on a bare macOS host, and CI was relying on the runner image happening to ship `libpq`.
- **`docker-compose.yml` + CI** — postgres pinned to **18.6** in both. Compose's `db` healthcheck gains `-h 127.0.0.1` (matching CI's, for the reason in Additional context below), and a named `db-data` volume so the dev database survives container recreation.

> ⚠️ **Pulling this branch empties your local dev database.** The 16.x data lives in an anonymous volume mounted at the postgres 16 `VOLUME` path (`/var/lib/postgresql/data`); postgres 18 moved that to `/var/lib/postgresql` and stores data under a major-versioned `PGDATA` (`/var/lib/postgresql/18/docker`), so the old volume is orphaned rather than reused. The db comes up healthy and **empty** rather than failing loudly. Repopulate with:
>
> ```bash
> docker compose run --rm webserver uv run ./manage.py migrate
> docker compose run --rm webserver uv run ./manage.py seed_test_data
> ```
>
> The old volume is left intact if you need to recover anything from it first. Going forward the `db-data` named volume added here keeps the data across `docker compose down`/recreation, and because `PGDATA` is major-versioned, a future major's `initdb` lands beside the old files rather than on top of them.

### It found a real bug immediately

`PATCH /v1/auth/users/me/` with a nickname over 64 characters returned a **500**:

```
django.db.utils.DataError: value too long for type character varying(64)
```

`UserUpdateSchema.public_nickname` was declared as a bare `str` while `CustomUser.public_nickname` is `varchar(64)`. SQLite tolerated it by silently storing 65 characters; postgres raises. Signup already capped it (`authentication/forms.py`), so only the PATCH path was exposed. Now bounded by `NICKNAME_MAX_LENGTH`, read off the model via `_meta` rather than hardcoding 64 a third time, so neither the API schema nor the signup form can drift from the column. Covered by a new test.

Every other one of the 143 existing tests passed on postgres unmodified: no JSON lookups (the three `JSONField`s are only read/written whole), no raw SQL beyond a portable `DROP TABLE IF EXISTS`, no `.extra()`, no ordering or case-sensitivity assertions. Suite is now **146 passing**.

### What SQLite was actually hiding

Not just "laxer semantics" — the schema itself differed. `scenes/models.py` declares a `pg_trgm` GIN index on `Scene.title`, installed by `scenes/migrations/0004_trigram_extension.py`:

| | postgres | sqlite |
|---|---|---|
| `title_gin_trgm_index` | `USING gin (title gin_trgm_ops)` | plain B-tree, same name |
| `TrigramExtension` | installs `pg_trgm` | no-op |

So that index and extension were never exercised. Chasing this down surfaced #1235 — the index is unused even on postgres, because Django compiles `__icontains` to `UPPER(title) LIKE UPPER(...)`, which can't use an index on bare `title`. Filed separately; no fix here.

### How can this be tested?

```bash
just be test    # 146 passed, now against postgres
```

To confirm the engine actually changed:

```bash
docker compose exec -T webserver uv run python -c "
import os, django
os.environ['DJANGO_SETTINGS_MODULE']='main.test_settings'
django.setup()
from django.conf import settings
print(settings.DATABASES['default']['ENGINE'])"
# django.db.backends.postgresql   (was django.db.backends.sqlite3)
```

To confirm the guard fires rather than silently falling back:

```bash
docker compose exec -T -e DATABASE_URL= webserver uv run pytest -q scenes/models_test.py
# ImproperlyConfigured: The test suite requires PostgreSQL, but DATABASE_URL resolved to
# 'django.db.backends.sqlite3'. Run the tests inside the webserver container (`just be test` ...)
```

CI exercises the new service container on this PR.

Five review passes are folded in — three on the original change, then two branch-wide after the postgres 18 bump. Their non-obvious findings:

- `TEST_DB_NAME` was unvalidated, so `TEST_DB_NAME=math3d` would have pointed the suite at the **dev** database, which Django drops and recreates without prompting. It now requires a `test_` prefix.
- The `atomic()` wrapper originally added to `scenes/models_test.py` was reverted: `main`'s version already passes on postgres, so the wrapper existed only to make legal an assertion the same commit added — and that assertion pinned transaction rollback semantics, not app behavior.

- The test database name is fixed and Django autoclobbers it, so **two backend suites running at once drop each other's database mid-run** — new with postgres, since SQLite used `:memory:`. `TEST_DB_NAME` now lets a worktree or parallel agent claim its own. Documented, since this repo's worktree workflow makes it likely.
- The guard is unit-tested via an extracted `require_postgres()`. It can't be tested in place: importing `test_settings` under pytest resolves `main.settings` through `sys.modules`, so the existing `load_settings` harness would pass vacuously.

### Additional context

`pytest-django` creates a separate `test_`-prefixed database, so the dev database is untouched.

Both health checks pass an explicit host (`-h localhost` in CI, `-h 127.0.0.1` in compose) rather than being a bare `pg_isready` on purpose: the official postgres image runs a temporary unix-socket-only server during init, which a socket-based check reports as healthy before the real TCP server is accepting connections. Compose was missing this, and the 18.6 bump forces a fresh `initdb` for everyone — so `depends_on: service_healthy` could release into a `connection refused` on the very next `manage.py migrate`.

Two related things deliberately **not** changed here:

- The SQLite fallback in `main/settings.py` still exists for non-test use. Everything real sets `DATABASE_URL` (compose, Heroku), so it only affects host-run `manage.py`, where it silently creates a `db.sqlite3`. Removing it is defensible on the same grounds but is outside "tests should use postgres".
- CI runs postgres as the `postgres` superuser, which is more privilege than the app holds in production — `pytest-django` needs `CREATEDB`. A missing-grant bug would therefore not surface in CI.

**On the version pin:** Heroku Postgres is currently on **15** and needs its own upgrade to 18. So dev/CI are deliberately ahead of prod for now. Testing 15-vs-18 compatibility is a non-goal here — next.math3d.org is not public-facing yet, so the skew costs nothing until the Heroku upgrade lands.

Follow-ups filed rather than folded in: #1235 (the trigram index is unused by title search), #1236 (should `ModelSchema` derive these bounds generally), #1238 (`TimestampedModel.save()` discards kwargs), #1239 (require `DATABASE_URL` and delete the SQLite fallback, which would obsolete this PR's guard entirely), #1240 (the client never enforces the nickname bounds this PR added server-side, so a too-long nickname now fails silently instead of 500ing).

### Checklist:

- [ ] N/A

