### PR TITLE
fix(og): send named User-Agent on render nudge

### DIFF
--- a/webserver/scenes/screenshots.py
+++ b/webserver/scenes/screenshots.py
@@ -68,6 +68,9 @@ def nudge_render(key: str) -> None:
         headers={
             "content-type": "application/json",
             "authorization": f"Bearer {settings.RENDER_SECRET}",
+            # Named UA: Cloudflare's Browser Integrity Check 1010-blocks the
+            # default `Python-urllib` UA at the edge, before the Worker.
+            "user-agent": "math3d-backend/1.0",
         },
         method="POST",
     )

--- a/webserver/scenes/screenshots_test.py
+++ b/webserver/scenes/screenshots_test.py
@@ -153,6 +153,17 @@ def test_maybe_render_swallows_reserve_exception(settings):
         screenshots.maybe_render("abc")  # must not raise
 
 
+def test_nudge_render_sends_named_user_agent(settings):
+    # A named UA avoids Cloudflare's Browser Integrity Check, which 1010-blocks
+    # the default `Python-urllib` UA at the edge before the Worker runs.
+    settings.SCREENSHOTS_ORIGIN = "https://s.math3d.org"
+    settings.RENDER_SECRET = "shh"  # pragma: allowlist secret
+    with mock.patch("scenes.screenshots.urllib.request.urlopen") as urlopen:
+        screenshots.nudge_render("abc")
+    req = urlopen.call_args.args[0]
+    assert req.get_header("User-agent") == "math3d-backend/1.0"
+
+
 def test_nudge_render_swallows_transport_error(settings):
     settings.SCREENSHOTS_ORIGIN = "https://s.math3d.org"
     settings.RENDER_SECRET = "shh"  # pragma: allowlist secret


### PR DESCRIPTION
Cloudflare's Browser Integrity Check 1010-blocks the default `Python-urllib` User-Agent at the edge, before the render Worker runs — so backend nudges never reached the Worker (no tail events; edge returned 403/1010). Send a named `math3d-backend/1.0` UA so the server-to-server POST is admitted.


Claude-Session: https://claude.ai/code/session_01YY8L3JDNL9ZJiZ7sWDhSsm

<!-- PR title must be a conventional commit: type(scope?): subject — see https://www.conventionalcommits.org -->

### What are the relevant issues?

<!-- Link to the issue here (closes #, fixes #, etc), or write N/A -->

### Description

<!-- Describe your changes in detail. -->

### Screenshots (if appropriate)

<!-- Remove if irrelevant. -->

### How can this be tested?

<!-- Describe how a reviewer can validate your changes. -->

### Additional context

<!-- Any reviewer questions, deployment notes, etc. -->

### Checklist:

- [ ] e.g. Update secret values in Vault before merging
      --->
