### PR TITLE
refactor(screenshots): centralize backend User-Agent constant

### DIFF
--- a/webserver/main/constants.py
+++ b/webserver/main/constants.py
@@ -1,0 +1,6 @@
+"""Project-wide constant values (non-environment, non-configurable)."""
+
+# Identifies this backend to outbound HTTP peers. Must be a named UA, not
+# urllib's default `Python-urllib`: Cloudflare's Browser Integrity Check
+# 1010-blocks that at the edge, before our render Worker runs.
+BACKEND_USER_AGENT = "math3d-backend"

--- a/webserver/scenes/screenshots.py
+++ b/webserver/scenes/screenshots.py
@@ -14,6 +14,7 @@ from django.conf import settings
 from django.db import connection, transaction
 from django.utils import timezone
 
+from main.constants import BACKEND_USER_AGENT
 from scenes.models import RenderDay, RenderMonth
 
 logger = logging.getLogger(__name__)
@@ -68,9 +69,7 @@ def nudge_render(key: str) -> None:
         headers={
             "content-type": "application/json",
             "authorization": f"Bearer {settings.RENDER_SECRET}",
-            # Named UA: Cloudflare's Browser Integrity Check 1010-blocks the
-            # default `Python-urllib` UA at the edge, before the Worker.
-            "user-agent": "math3d-backend/1.0",
+            "user-agent": BACKEND_USER_AGENT,
         },
         method="POST",
     )

--- a/webserver/scenes/screenshots_test.py
+++ b/webserver/scenes/screenshots_test.py
@@ -6,6 +6,7 @@ import pytest
 from django.db import connection
 from django.utils import timezone
 
+from main.constants import BACKEND_USER_AGENT
 from scenes import screenshots
 from scenes.models import RenderDay, RenderMonth
 from scenes.screenshots import reserve_render_slot
@@ -161,7 +162,7 @@ def test_nudge_render_sends_named_user_agent(settings):
     with mock.patch("scenes.screenshots.urllib.request.urlopen") as urlopen:
         screenshots.nudge_render("abc")
     req = urlopen.call_args.args[0]
-    assert req.get_header("User-agent") == "math3d-backend/1.0"
+    assert req.get_header("User-agent") == BACKEND_USER_AGENT
 
 
 def test_nudge_render_swallows_transport_error(settings):


### PR DESCRIPTION
### What are the relevant tickets?

N/A — follow-up to #1241 (the render-nudge UA fix), which was merged in a hurry with the UA as a magic string at the callsite.

### Description (What does it do?)

Moves the outbound `User-Agent` string out of the `nudge_render` callsite in `scenes/screenshots.py` into a new `main/constants.py` as `BACKEND_USER_AGENT`, so the backend's HTTP identity to external peers has a single home rather than a literal buried in a header dict.

Also drops the `/1.0` version token. It tracked nothing — we don't maintain a backend version here — so it implied a versioning scheme that didn't exist. The UA's only job is to be a stable named identity that clears Cloudflare's Browser Integrity Check (which 1010-blocks urllib's default `Python-urllib` UA at the edge, before the render Worker runs). `math3d-backend` does that; the version was noise.

### How can this be tested?

`test_nudge_render_sends_named_user_agent` now imports `BACKEND_USER_AGENT` and asserts the nudge sends it (no re-hardcoded literal). Run:

\`\`\`
docker compose exec -T webserver uv run pytest scenes/screenshots_test.py -k nudge_render
\`\`\`

### Additional Context

Pure refactor — no behavior change beyond the UA string dropping its `/1.0` suffix, which is cosmetic to the edge (any non-default named UA clears BIC). Note the prod backend still needs a redeploy of `main` before the fixed UA (from #1241) actually ships — this PR doesn't change that.