### PR TITLE
refactor(deploy): source Worker vars from GitHub Actions variables

### DIFF
--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -132,20 +132,32 @@ jobs:
           name: frontend-build
           path: packages/app/dist/
 
+      # Runtime vars are injected here from GitHub Actions variables (single
+      # source of truth), not committed in wrangler.jsonc. SITE_ORIGIN reuses the
+      # SAME VITE_SITE_ORIGIN the build step bakes into the static head, so the
+      # Worker's og:url can't drift from it.
       - name: Deploy to Cloudflare Workers
         working-directory: packages/app
-        run: yarn wrangler deploy
+        run: >-
+          yarn wrangler deploy
+          --var API_BASE:"$API_BASE"
+          --var SITE_ORIGIN:"$SITE_ORIGIN"
+          --var SCREENSHOTS_ORIGIN:"$SCREENSHOTS_ORIGIN"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          API_BASE: ${{ vars.VITE_API_BASE_URL }}
+          SITE_ORIGIN: ${{ vars.VITE_SITE_ORIGIN }}
+          SCREENSHOTS_ORIGIN: ${{ vars.SCREENSHOTS_ORIGIN }}
 
   # Experimental, var-gated (SCREENSHOTS_ORIGIN) render Worker — deployed in its OWN
   # job, in PARALLEL with the app deploy, and marked continue-on-error so it can
-  # NEVER gate the core app's ship path. The feature is dark until SCREENSHOTS_ORIGIN
-  # is set in packages/app/wrangler.jsonc, and its infra (R2 bucket, Browser
-  # Rendering entitlement, token scopes) is provisioned out-of-band — so until
-  # then this step is expected to fail harmlessly. When the feature graduates,
-  # drop continue-on-error so real regressions surface. See packages/screenshots/README.md.
+  # NEVER gate the core app's ship path. The feature is dark until the
+  # SCREENSHOTS_ORIGIN GitHub Actions variable is set (injected into the app
+  # Worker via --var above), and its infra (R2 bucket, Browser Rendering
+  # entitlement, token scopes) is provisioned out-of-band — so until then this
+  # step is expected to fail harmlessly. When the feature graduates, drop
+  # continue-on-error so real regressions surface. See packages/screenshots/README.md.
   deploy-screenshots:
     needs: build
     if: ${{ !inputs.dry_run && inputs.environment == 'production' }}
@@ -167,9 +179,14 @@ jobs:
           corepack enable
           yarn install --immutable
 
+      # FRAME_ORIGIN reuses the SAME VITE_SITE_ORIGIN variable as the app build
+      # and app Worker, so all three copies of the site origin stay in lockstep.
       - name: Deploy screenshots render Worker
         working-directory: packages/screenshots
-        run: yarn wrangler deploy
+        run: >-
+          yarn wrangler deploy
+          --var FRAME_ORIGIN:"$FRAME_ORIGIN"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          FRAME_ORIGIN: ${{ vars.VITE_SITE_ORIGIN }}

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -132,17 +132,17 @@ jobs:
           name: frontend-build
           path: packages/app/dist/
 
-      # Runtime vars are injected here from GitHub Actions variables (single
-      # source of truth), not committed in wrangler.jsonc. SITE_ORIGIN reuses the
-      # SAME VITE_SITE_ORIGIN the build step bakes into the static head, so the
-      # Worker's og:url can't drift from it.
+      # Reuse the build's VITE_* vars so the Worker values can't drift from the
+      # static head. SCREENSHOTS_ORIGIN may be empty (feature dark); the other
+      # two are required, so fail loudly rather than ship an empty binding.
       - name: Deploy to Cloudflare Workers
         working-directory: packages/app
-        run: >-
-          yarn wrangler deploy
-          --var API_BASE:"$API_BASE"
-          --var SITE_ORIGIN:"$SITE_ORIGIN"
-          --var SCREENSHOTS_ORIGIN:"$SCREENSHOTS_ORIGIN"
+        run: |
+          [ -n "$API_BASE" ] && [ -n "$SITE_ORIGIN" ] || { echo "::error::API_BASE and SITE_ORIGIN must be set (GitHub Actions variables VITE_API_BASE_URL / VITE_SITE_ORIGIN)"; exit 1; }
+          yarn wrangler deploy \
+            --var API_BASE:"$API_BASE" \
+            --var SITE_ORIGIN:"$SITE_ORIGIN" \
+            --var SCREENSHOTS_ORIGIN:"$SCREENSHOTS_ORIGIN"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
@@ -179,13 +179,11 @@ jobs:
           corepack enable
           yarn install --immutable
 
-      # FRAME_ORIGIN reuses the SAME VITE_SITE_ORIGIN variable as the app build
-      # and app Worker, so all three copies of the site origin stay in lockstep.
       - name: Deploy screenshots render Worker
         working-directory: packages/screenshots
-        run: >-
-          yarn wrangler deploy
-          --var FRAME_ORIGIN:"$FRAME_ORIGIN"
+        run: |
+          [ -n "$FRAME_ORIGIN" ] || { echo "::error::FRAME_ORIGIN must be set (GitHub Actions variable VITE_SITE_ORIGIN)"; exit 1; }
+          yarn wrangler deploy --var FRAME_ORIGIN:"$FRAME_ORIGIN"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ node_modules
 
 # wrangler build cache
 **/.wrangler/
+# wrangler local dev vars (real secrets/values; commit the .example instead)
+**/.dev.vars
 
 #Python
 __pycache__

--- a/packages/app/.dev.vars.example
+++ b/packages/app/.dev.vars.example
@@ -1,6 +1,4 @@
 # Local `wrangler dev` vars for the app Worker. Copy to `.dev.vars` (gitignored).
-# In production these come from GitHub Actions variables via `wrangler deploy
-# --var` (see .github/workflows/deploy-reusable.yml); this file is dev-only.
 API_BASE=https://api.math3d.org
 SITE_ORIGIN=https://next.math3d.org
 # Set → per-scene og:image; leave empty → static default card.

--- a/packages/app/.dev.vars.example
+++ b/packages/app/.dev.vars.example
@@ -1,0 +1,7 @@
+# Local `wrangler dev` vars for the app Worker. Copy to `.dev.vars` (gitignored).
+# In production these come from GitHub Actions variables via `wrangler deploy
+# --var` (see .github/workflows/deploy-reusable.yml); this file is dev-only.
+API_BASE=https://api.math3d.org
+SITE_ORIGIN=https://next.math3d.org
+# Set → per-scene og:image; leave empty → static default card.
+SCREENSHOTS_ORIGIN=https://math3d-screenshots.christopher-chudzicki.workers.dev

--- a/packages/app/wrangler.jsonc
+++ b/packages/app/wrangler.jsonc
@@ -24,10 +24,6 @@
       "!/index.html"
     ]
   }
-  // Runtime vars (API_BASE, SITE_ORIGIN, SCREENSHOTS_ORIGIN) are NOT set here.
-  // They come from GitHub Actions variables, injected at deploy time via
-  // `wrangler deploy --var` (deploy-reusable.yml). SITE_ORIGIN reuses the same
-  // VITE_SITE_ORIGIN variable that the Vite build bakes into the static head,
-  // so og:url can't drift from it. For local `wrangler dev`, copy
-  // `.dev.vars.example` to `.dev.vars` (gitignored).
+  // Runtime vars are deploy-injected (see deploy-reusable.yml); local dev: copy
+  // `.dev.vars.example` to `.dev.vars`.
 }

--- a/packages/app/wrangler.jsonc
+++ b/packages/app/wrangler.jsonc
@@ -23,15 +23,11 @@
       "!/mockServiceWorker.js",
       "!/index.html"
     ]
-  },
-  "vars": {
-    "API_BASE": "https://api.math3d.org",
-    // Source of truth for the Worker's og:url origin; applied as-is by
-    // `wrangler deploy` (deploy-reusable.yml). Must stay equal to the
-    // production VITE_SITE_ORIGIN so og:url can't drift from the static head.
-    "SITE_ORIGIN": "https://next.math3d.org",
-    // Render Worker origin (packages/screenshots). Set → per-scene og:image;
-    // unset → static default card (pass-1 behavior).
-    "SCREENSHOTS_ORIGIN": "https://math3d-screenshots.christopher-chudzicki.workers.dev"
   }
+  // Runtime vars (API_BASE, SITE_ORIGIN, SCREENSHOTS_ORIGIN) are NOT set here.
+  // They come from GitHub Actions variables, injected at deploy time via
+  // `wrangler deploy --var` (deploy-reusable.yml). SITE_ORIGIN reuses the same
+  // VITE_SITE_ORIGIN variable that the Vite build bakes into the static head,
+  // so og:url can't drift from it. For local `wrangler dev`, copy
+  // `.dev.vars.example` to `.dev.vars` (gitignored).
 }

--- a/packages/screenshots/.dev.vars.example
+++ b/packages/screenshots/.dev.vars.example
@@ -1,6 +1,4 @@
 # Local `wrangler dev` vars for the render Worker. Copy to `.dev.vars` (gitignored).
-# In production FRAME_ORIGIN comes from a GitHub Actions variable via `wrangler
-# deploy --var` (see .github/workflows/deploy-reusable.yml); this file is dev-only.
 # RENDER_DEADLINE_MS stays in wrangler.jsonc. RENDER_SECRET is a Worker secret
 # (`wrangler secret put`), not set here.
 FRAME_ORIGIN=https://next.math3d.org

--- a/packages/screenshots/.dev.vars.example
+++ b/packages/screenshots/.dev.vars.example
@@ -1,0 +1,6 @@
+# Local `wrangler dev` vars for the render Worker. Copy to `.dev.vars` (gitignored).
+# In production FRAME_ORIGIN comes from a GitHub Actions variable via `wrangler
+# deploy --var` (see .github/workflows/deploy-reusable.yml); this file is dev-only.
+# RENDER_DEADLINE_MS stays in wrangler.jsonc. RENDER_SECRET is a Worker secret
+# (`wrangler secret put`), not set here.
+FRAME_ORIGIN=https://next.math3d.org

--- a/packages/screenshots/README.md
+++ b/packages/screenshots/README.md
@@ -78,15 +78,18 @@ bundle uploads with only a warning but the Worker then 500s on every request.
 Two independent var gates, both dark by default:
 
 - **Serving:** the app Worker only points `og:image` at this Worker when
-  `SCREENSHOTS_ORIGIN` is set in `packages/app/wrangler.jsonc`. Unset → the app
-  serves its static default card.
+  `SCREENSHOTS_ORIGIN` is set. It comes from the `SCREENSHOTS_ORIGIN` GitHub
+  Actions variable, injected into the app Worker at deploy time via `wrangler
+deploy --var` (`deploy-reusable.yml`). Unset → the app serves its static
+  default card.
 - **Rendering:** the backend only nudges `POST /render` when its own
   `SCREENSHOTS_ORIGIN` env var is set. Unset → saves behave exactly as before and
   nothing is ever rendered.
 
 To enable end-to-end: deploy this Worker, set `RENDER_SECRET` on both sides,
-smoke-test it, then set `SCREENSHOTS_ORIGIN` to its `*.workers.dev` host in both
-the app Worker and the backend and redeploy.
+smoke-test it, then set `SCREENSHOTS_ORIGIN` to its `*.workers.dev` host — as the
+`SCREENSHOTS_ORIGIN` GitHub Actions variable (app Worker) and the backend env —
+and redeploy.
 
 CI deploys this Worker in its own `deploy-screenshots` job
 (`.github/workflows/deploy-reusable.yml`), in parallel with and non-blocking to
@@ -94,8 +97,8 @@ the app deploy, so a failed/unprovisioned render deploy can never gate a release
 
 ## Teardown (abandoning the experiment)
 
-1. Remove `SCREENSHOTS_ORIGIN` from `packages/app/wrangler.jsonc` and the backend
-   env (if set) and redeploy — the app reverts to the static default card and the
+1. Clear the `SCREENSHOTS_ORIGIN` GitHub Actions variable and the backend env
+   (if set) and redeploy — the app reverts to the static default card and the
    backend stops nudging.
 2. Delete the `deploy-screenshots` job from
    `.github/workflows/deploy-reusable.yml`.

--- a/packages/screenshots/README.md
+++ b/packages/screenshots/README.md
@@ -115,6 +115,7 @@ RENDER_SECRET`.
 ```bash
 yarn workspace screenshots test        # vitest under @cloudflare/vitest-pool-workers
 yarn workspace screenshots typecheck
+cp .dev.vars.example .dev.vars          # once: FRAME_ORIGIN for local dev (gitignored)
 yarn wrangler dev                       # from packages/screenshots (needs nodejs_compat)
 ```
 

--- a/packages/screenshots/src/index.ts
+++ b/packages/screenshots/src/index.ts
@@ -9,8 +9,9 @@
  * immediately.
  *
  * Bindings (wrangler.jsonc): BROWSER (Browser Rendering), SCREENSHOTS_BUCKET (R2
- * bucket `math3d-screenshots`), var FRAME_ORIGIN. Requires the nodejs_compat
- * compatibility flag (@cloudflare/puppeteer imports node builtins).
+ * bucket `math3d-screenshots`). FRAME_ORIGIN is a deploy-injected var (see
+ * deploy-reusable.yml). Requires the nodejs_compat compatibility flag
+ * (@cloudflare/puppeteer imports node builtins).
  *
  * Wired into the app Worker via the single `SCREENSHOTS_ORIGIN` var; unset there =
  * the whole feature is dark. Design + teardown: packages/screenshots/README.md,

--- a/packages/screenshots/wrangler.jsonc
+++ b/packages/screenshots/wrangler.jsonc
@@ -24,11 +24,7 @@
   "r2_buckets": [
     { "binding": "SCREENSHOTS_BUCKET", "bucket_name": "math3d-screenshots" }
   ],
-  // FRAME_ORIGIN is NOT set here: it's the site origin, injected at deploy time
-  // via `wrangler deploy --var` (deploy-reusable.yml) from the same
-  // VITE_SITE_ORIGIN GitHub Actions variable the app build and app Worker use,
-  // so all three copies of the origin stay in lockstep. For local `wrangler
-  // dev`, copy `.dev.vars.example` to `.dev.vars` (gitignored). RENDER_DEADLINE_MS
+  // FRAME_ORIGIN is deploy-injected (see deploy-reusable.yml); RENDER_DEADLINE_MS
   // is a fixed tuning constant with no cross-system twin, so it stays in-file.
   "vars": {
     "RENDER_DEADLINE_MS": 60000

--- a/packages/screenshots/wrangler.jsonc
+++ b/packages/screenshots/wrangler.jsonc
@@ -24,8 +24,13 @@
   "r2_buckets": [
     { "binding": "SCREENSHOTS_BUCKET", "bucket_name": "math3d-screenshots" }
   ],
+  // FRAME_ORIGIN is NOT set here: it's the site origin, injected at deploy time
+  // via `wrangler deploy --var` (deploy-reusable.yml) from the same
+  // VITE_SITE_ORIGIN GitHub Actions variable the app build and app Worker use,
+  // so all three copies of the origin stay in lockstep. For local `wrangler
+  // dev`, copy `.dev.vars.example` to `.dev.vars` (gitignored). RENDER_DEADLINE_MS
+  // is a fixed tuning constant with no cross-system twin, so it stays in-file.
   "vars": {
-    "FRAME_ORIGIN": "https://next.math3d.org",
     "RENDER_DEADLINE_MS": 60000
   }
   // RENDER_SECRET (gates POST /render) is intentionally NOT set here as a


### PR DESCRIPTION
### What are the relevant tickets?

N/A — infra cleanup. Removes the hand-synced duplication of origin URLs between the Vite build and the two Workers' `wrangler.jsonc` files.

### Description (What does it do?)

The **site origin** was committed in three places that all had to stay equal by hand: the `VITE_SITE_ORIGIN` GitHub Actions variable (baked into the static head at build time), `packages/app/wrangler.jsonc` `SITE_ORIGIN` (app Worker runtime, builds per-scene `og:url`), and `packages/screenshots/wrangler.jsonc` `FRAME_ORIGIN` (render Worker runtime). `API_BASE` and `SCREENSHOTS_ORIGIN` were likewise committed in the app `wrangler.jsonc`.

This makes **GitHub Actions variables the single source of truth**. The Worker runtime vars are injected at deploy time via `wrangler deploy --var` (in `deploy-reusable.yml`) instead of being committed:

- `SITE_ORIGIN` (app) and `FRAME_ORIGIN` (render) both resolve from the **same** `VITE_SITE_ORIGIN` the build already uses → the three copies can no longer drift.
- `API_BASE` resolves from `VITE_API_BASE_URL` (same value the SPA build uses).
- `SCREENSHOTS_ORIGIN` gets its **own new** GH variable.

`RENDER_DEADLINE_MS` stays in `wrangler.jsonc` — it's a fixed tuning constant with no cross-system twin, so moving it would add a source without removing any duplication.

### ⚠️ Required before this deploys to production

Add a **`SCREENSHOTS_ORIGIN`** GitHub Actions **variable** (production environment) = `https://math3d-screenshots.christopher-chudzicki.workers.dev`. Without it, the app Worker deploys with an empty `SCREENSHOTS_ORIGIN` and the per-scene og:image feature goes dark (reverts to the static default card). `VITE_SITE_ORIGIN` / `VITE_API_BASE_URL` already exist (the build uses them). When the RC environment is restored, it needs these variables too.

### How can this be tested?

- Existing app-Worker (18) and render-Worker (22) unit tests pass unchanged — they supply their own env.
- `wrangler deploy --dry-run --var …` for both workers resolves every binding (verified locally): app → `API_BASE`/`SITE_ORIGIN`/`SCREENSHOTS_ORIGIN`; render → `FRAME_ORIGIN` + in-file `RENDER_DEADLINE_MS`.
- Local `wrangler dev`: copy the new `.dev.vars.example` → `.dev.vars` (now gitignored) in each package.

### Additional Context

The feature gate for per-scene images moves from "edit `wrangler.jsonc`" to "set/clear the `SCREENSHOTS_ORIGIN` GH variable" — equivalent, and toggling it no longer needs a code change. README and workflow comments updated to match.