### PR TITLE
feat(sentry): add error and performance monitoring to the SPA and Django API

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -17,6 +17,8 @@ VITE_DISPLAY_AUTH_FLOWS=false
 # slash (index.html appends the path). Per-env override via the
 # VITE_SITE_ORIGIN GitHub Actions variable.
 VITE_SITE_ORIGIN=http://math3d.localdev:3000
+# Sentry is production-only; empty here keeps the SDK inert in dev and CI.
+VITE_SENTRY_DSN=
 ENABLE_REGISTRATION=false
 DISABLE_ALLAUTH_RATE_LIMITS=true
 

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -61,6 +61,7 @@ jobs:
           VITE_APP_VERSION: ${{ inputs.version }}
           VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          # Required whenever the token is set; the build fails without them.
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
 

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -26,6 +26,10 @@ on:
       CLOUDFLARE_API_TOKEN:
         # Only used for production (dual-publish to Cloudflare Workers); rc builds don't deploy.
         required: false
+      SENTRY_AUTH_TOKEN:
+        # Source-map upload for the SPA. Absent ⇒ the Vite plugin is skipped and
+        # the build still succeeds (rc dry runs and forks).
+        required: false
 
 jobs:
   build:
@@ -55,6 +59,10 @@ jobs:
           VITE_DISPLAY_AUTH_FLOWS: ${{ vars.VITE_DISPLAY_AUTH_FLOWS }}
           VITE_SITE_ORIGIN: ${{ vars.VITE_SITE_ORIGIN }}
           VITE_APP_VERSION: ${{ inputs.version }}
+          VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -26,9 +26,10 @@ on:
       CLOUDFLARE_API_TOKEN:
         # Only used for production (dual-publish to Cloudflare Workers); rc builds don't deploy.
         required: false
-      SENTRY_AUTH_TOKEN:
-        # Source-map upload for the SPA. Absent ⇒ the Vite plugin is skipped and
-        # the build still succeeds (rc dry runs and forks).
+      SENTRY_ORG_TOKEN:
+        # Source-map upload for the SPA; must be a Sentry org auth token
+        # (`sntrys_`), which carries its own org. Absent ⇒ the Vite plugin is
+        # skipped and the build still succeeds (rc dry runs and forks).
         required: false
 
 jobs:
@@ -60,9 +61,8 @@ jobs:
           VITE_SITE_ORIGIN: ${{ vars.VITE_SITE_ORIGIN }}
           VITE_APP_VERSION: ${{ inputs.version }}
           VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          # Required whenever the token is set; the build fails without them.
-          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_ORG_TOKEN: ${{ secrets.SENTRY_ORG_TOKEN }}
+          # Required whenever the token is set; the build fails without it.
           SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
 
       - name: Upload build artifacts

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -124,3 +124,4 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -124,4 +124,4 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG_TOKEN: ${{ secrets.SENTRY_ORG_TOKEN }}

--- a/docs/adr/0003-sentry-monitoring.md
+++ b/docs/adr/0003-sentry-monitoring.md
@@ -36,13 +36,21 @@ v11 upgrade: v11 replaces `sendDefaultPii` with `dataCollection`, which collects
 carried across that major stops meaning "no PII".
 
 **Source maps are uploaded to Sentry _and_ served publicly.** Math3d is open
-source, and public maps make browser devtools match what Sentry shows. Scope
-`SENTRY_AUTH_TOKEN` to the repository or to the `production` GitHub Environment
-only: `deploy-reusable.yml`'s build job binds `environment: ${{ inputs.environment }}`,
-which puts that environment's secrets in scope — this is how the existing
-environment-scoped AWS and Heroku secrets resolve. A token scoped to `rc` would
-therefore reach rc builds and upload rc source maps into the production project,
-despite `release-rc.yml` deliberately not forwarding it.
+source, and public maps make browser devtools match what Sentry shows. Upload
+uses Sentry's web API, not the DSN — the DSN is a runtime ingest credential and
+the Vite plugin has no DSN option at all — so the build needs its own
+credentials. `SENTRY_ORG_TOKEN` must be an _organization_ auth token (`sntrys_`),
+which carries its own org; that is why only `SENTRY_PROJECT` accompanies it. The
+build rejects any other token type rather than letting the plugin skip the
+upload with a warning.
+
+Scope `SENTRY_ORG_TOKEN` to the repository or to the `production` GitHub
+Environment only: `deploy-reusable.yml`'s build job binds
+`environment: ${{ inputs.environment }}`, which puts that environment's secrets
+in scope — this is how the existing environment-scoped AWS and Heroku secrets
+resolve. A token scoped to `rc` would therefore reach rc builds and upload rc
+source maps into the production project, despite `release-rc.yml` deliberately
+not forwarding it.
 
 **DSNs are deploy-injected, never committed.** The SPA's arrives as a
 build-time `VITE_` var, Django's is a Heroku config var, and the Workers take

--- a/docs/adr/0003-sentry-monitoring.md
+++ b/docs/adr/0003-sentry-monitoring.md
@@ -20,11 +20,12 @@ design is needed.
 **Four Sentry projects, four DSNs** — one per surface, for separate issue
 streams and alert rules.
 
-**Production only.** Dev, CI, and tests leave the DSN unset, which is each
-SDK's own disabled state. No `if (PROD)` branching.
+**Production only.** Dev, CI, and tests leave the DSN unset — each SDK's own
+no-op state. No `if (PROD)` branching.
 
-**`tracesSampleRate` / `traces_sample_rate` = 1.0 everywhere.** The quota
-supports it.
+**`tracesSampleRate` / `traces_sample_rate` = 1.0 everywhere.** The Sponsored
+Business plan's quota has the headroom for full sampling, so no sampling
+design is needed.
 
 **No PII, no user identification.** `send_default_pii=False` (Python) /
 `sendDefaultPii: false` (JS) set explicitly, not relied on as a default. No
@@ -69,9 +70,10 @@ isolation.
 
 ## Alternatives considered
 
-- **A shared `@math3d/sentry` package:** three different SDKs (`@sentry/react`,
-  `sentry-sdk[django]`, `@sentry/cloudflare`) across four risk profiles give a
-  shared wrapper little to abstract. Rejected.
+- **A shared `@math3d/sentry` package:** three SDKs (`@sentry/react`,
+  `sentry-sdk[django]`, `@sentry/cloudflare` — the two Workers share the
+  Cloudflare SDK but count as separate surfaces) across four surfaces with
+  different risk profiles give a shared wrapper little to abstract. Rejected.
 - **Stitch frontend and backend traces now:** the cost (an extra round trip
   before every new scene load) is paid on every request; the benefit (a
   linked waterfall) matters only once backend latency itself is the thing

--- a/docs/adr/0003-sentry-monitoring.md
+++ b/docs/adr/0003-sentry-monitoring.md
@@ -20,19 +20,28 @@ design is needed.
 **Four Sentry projects, four DSNs** — one per surface, for separate issue
 streams and alert rules.
 
-**Production only.** Dev, CI, and tests leave the DSN unset — each SDK's own
-no-op state. No `if (PROD)` branching.
+**Production only.** Dev, CI, and tests leave the DSN unset, and both surfaces
+guard `init()` on the DSN rather than relying on an SDK's no-op state. No
+`if (PROD)` branching.
 
-**`tracesSampleRate` / `traces_sample_rate` = 1.0 everywhere.** The Sponsored
-Business plan's quota has the headroom for full sampling, so no sampling
-design is needed.
+**Full tracing.** The SPA sets `tracesSampleRate: 1`; Django reads
+`SENTRY_TRACES_SAMPLE_RATE`, which defaults to 1.0, so the backend can be
+dialed back by config alone if traffic ever changes that calculus.
 
 **No PII, no user identification.** `send_default_pii=False` (Python) /
 `sendDefaultPii: false` (JS) set explicitly, not relied on as a default. No
-`set_user` / `setUser` code on any surface.
+`set_user` / `setUser` code on any surface. Revisit this on the `@sentry/react`
+v11 upgrade: v11 replaces `sendDefaultPii` with `dataCollection`, which collects
+`userInfo`, `cookies`, and `httpBodies` by default, so a `sendDefaultPii: false`
+carried across that major stops meaning "no PII".
 
 **Source maps are uploaded to Sentry _and_ served publicly.** Math3d is open
-source, and public maps make browser devtools match what Sentry shows.
+source, and public maps make browser devtools match what Sentry shows. Scope
+`SENTRY_AUTH_TOKEN` to the repository or to the `production` GitHub Environment
+only: `deploy-reusable.yml`'s build job binds `environment: ${{ inputs.environment }}`,
+and a called job's own environment secrets win over what the caller forwards, so
+a token scoped to `rc` would upload rc source maps into the production project
+despite `release-rc.yml` deliberately not forwarding it.
 
 **DSNs are deploy-injected, never committed.** The SPA's arrives as a
 build-time `VITE_` var, Django's is a Heroku config var, and the Workers take
@@ -64,9 +73,11 @@ isolation.
   infers the client IP from the connection regardless. Suppressing it is a
   per-project dashboard toggle ("Prevent Storing of IP Addresses"), left as an
   optional follow-up.
-- Malformed `SENTRY_DSN` fails the same way any other bad config value does:
-  `EnvConfig` validates it at boot, so a typo surfaces as
-  `ImproperlyConfigured` rather than crashing gunicorn mid-request.
+- Malformed `SENTRY_DSN` fails the same way any other bad config value does.
+  `sentry_sdk.init()` runs at `settings.py` import time, so an unvalidated typo
+  would already fail the boot — with a raw `BadDsn`. `EnvConfig` validating it
+  first buys a uniform `ImproperlyConfigured` naming the field, not an earlier
+  failure.
 
 ## Alternatives considered
 

--- a/docs/adr/0003-sentry-monitoring.md
+++ b/docs/adr/0003-sentry-monitoring.md
@@ -1,0 +1,82 @@
+# 0003 — Sentry monitoring (errors + traces)
+
+**Status:** Accepted (2026-08-21)
+
+## Context
+
+Math3d has no error or performance monitoring across its four deployed
+surfaces — the React SPA, the Django backend, the app Cloudflare Worker (serves
+the SPA, injects OG metadata), and the screenshots Cloudflare Worker. A crash
+in the SPA, a 500 in the API, or a failed render in a Worker is invisible
+unless a user reports it or someone is tailing logs live at the moment it
+happens.
+
+The Sentry account is a Sponsored Business plan (5M errors, 1B spans per
+month). At math3d's traffic that quota is not a constraint, so no sampling
+design is needed.
+
+## Decision
+
+**Four Sentry projects, four DSNs** — one per surface, for separate issue
+streams and alert rules.
+
+**Production only.** Dev, CI, and tests leave the DSN unset, which is each
+SDK's own disabled state. No `if (PROD)` branching.
+
+**`tracesSampleRate` / `traces_sample_rate` = 1.0 everywhere.** The quota
+supports it.
+
+**No PII, no user identification.** `send_default_pii=False` (Python) /
+`sendDefaultPii: false` (JS) set explicitly, not relied on as a default. No
+`set_user` / `setUser` code on any surface.
+
+**Source maps are uploaded to Sentry _and_ served publicly.** Math3d is open
+source, and public maps make browser devtools match what Sentry shows.
+
+**DSNs are deploy-injected, never committed.** The SPA's arrives as a
+build-time `VITE_` var, Django's is a Heroku config var, and the Workers take
+theirs via `wrangler deploy --var` — matching the existing convention for
+`API_BASE` / `SITE_ORIGIN` / `FRAME_ORIGIN`. No DSN enters the repo.
+
+**Two-phase rollout.** Phase 1 covers the SPA and Django — the surfaces
+carrying the real bugs (math evaluation, scene loading, auth), and each
+deploys independently of the Workers. Phase 2 covers the two Workers, as a
+separate PR with its own `wrangler dev` validation and revert: a Worker that
+uploads with only a warning can still fail to start and 500 every request,
+including the app Worker fronting all navigations, so that change ships in
+isolation.
+
+## Consequences
+
+- Traces are per-surface, not stitched across the frontend↔backend boundary.
+  Stitching would require adding `sentry-trace` and `baggage` to
+  `CORS_ALLOW_HEADERS`, turning today's simple GETs into preflighted ones —
+  and the preflight cache is keyed on the full URL, not the route pattern, so
+  every distinct scene key would cost an extra round trip on the first-render
+  path. `traceparent` doesn't avoid this either: it isn't on the fixed
+  CORS-safelisted header set, and whatwg/fetch#911 (the proposal to add it)
+  is still open. Both surfaces still report their own errors and performance
+  data; what's lost is a single linked frontend→backend waterfall.
+- Anonymous traffic has no "users affected" count, since no user identity is
+  attached to events.
+- `send_default_pii=False` does not stop IP collection — Sentry's server
+  infers the client IP from the connection regardless. Suppressing it is a
+  per-project dashboard toggle ("Prevent Storing of IP Addresses"), left as an
+  optional follow-up.
+- Malformed `SENTRY_DSN` fails the same way any other bad config value does:
+  `EnvConfig` validates it at boot, so a typo surfaces as
+  `ImproperlyConfigured` rather than crashing gunicorn mid-request.
+
+## Alternatives considered
+
+- **A shared `@math3d/sentry` package:** three different SDKs (`@sentry/react`,
+  `sentry-sdk[django]`, `@sentry/cloudflare`) across four risk profiles give a
+  shared wrapper little to abstract. Rejected.
+- **Stitch frontend and backend traces now:** the cost (an extra round trip
+  before every new scene load) is paid on every request; the benefit (a
+  linked waterfall) matters only once backend latency itself is the thing
+  under investigation, which it isn't today — the backend is a thin CRUD API
+  and most interesting latency is client-side. Deferred, not rejected.
+- **Ship all four surfaces in one PR:** couples the two lower-risk surfaces to
+  a Worker change that can take the whole site down if it fails to start.
+  Rejected in favor of the two-phase split.

--- a/docs/adr/0003-sentry-monitoring.md
+++ b/docs/adr/0003-sentry-monitoring.md
@@ -26,7 +26,7 @@ guard `init()` on the DSN rather than relying on an SDK's no-op state. No
 
 **Full tracing.** The SPA sets `tracesSampleRate: 1`; Django reads
 `SENTRY_TRACES_SAMPLE_RATE`, which defaults to 1.0, so the backend can be
-dialed back by config alone if traffic ever changes that calculus.
+dialed back by config alone.
 
 **No PII, no user identification.** `send_default_pii=False` (Python) /
 `sendDefaultPii: false` (JS) set explicitly, not relied on as a default. No
@@ -39,8 +39,9 @@ carried across that major stops meaning "no PII".
 source, and public maps make browser devtools match what Sentry shows. Scope
 `SENTRY_AUTH_TOKEN` to the repository or to the `production` GitHub Environment
 only: `deploy-reusable.yml`'s build job binds `environment: ${{ inputs.environment }}`,
-and a called job's own environment secrets win over what the caller forwards, so
-a token scoped to `rc` would upload rc source maps into the production project
+which puts that environment's secrets in scope — this is how the existing
+environment-scoped AWS and Heroku secrets resolve. A token scoped to `rc` would
+therefore reach rc builds and upload rc source maps into the production project,
 despite `release-rc.yml` deliberately not forwarding it.
 
 **DSNs are deploy-injected, never committed.** The SPA's arrives as a

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -12,4 +12,4 @@ acceptance** — to change a decision, add a new ADR that supersedes the old one
 | ------------------------------------------------- | ------------------------------------------------- | -------- |
 | [0001](0001-server-side-scene-screenshots.md)     | Server-side scene screenshots via a render Worker | Accepted |
 | [0002](0002-browser-rendering-cost-protection.md) | Cost protection for paid-tier Browser Rendering   | Accepted |
-| [0003](0003-sentry-monitoring.md)                 | Sentry monitoring for errors and traces           | Accepted |
+| [0003](0003-sentry-monitoring.md)                 | Sentry monitoring (errors + traces)               | Accepted |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -12,3 +12,4 @@ acceptance** — to change a decision, add a new ADR that supersedes the old one
 | ------------------------------------------------- | ------------------------------------------------- | -------- |
 | [0001](0001-server-side-scene-screenshots.md)     | Server-side scene screenshots via a render Worker | Accepted |
 | [0002](0002-browser-rendering-cost-protection.md) | Cost protection for paid-tier Browser Rendering   | Accepted |
+| [0003](0003-sentry-monitoring.md)                 | Sentry monitoring for errors and traces           | Accepted |

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -48,6 +48,7 @@
     "@mui/utils": "^7.3.4",
     "@popperjs/core": "2.11.8",
     "@reduxjs/toolkit": "^2.2.3",
+    "@sentry/react": "^10.70.0",
     "@tanstack/react-query": "^5.62.10",
     "@testing-library/dom": "^10.4.0",
     "@types/lodash-es": "^4.17.12",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -87,6 +87,7 @@
     "@math3d/test-utils": "workspace:^",
     "@math3d/tsconfig": "workspace:^",
     "@mswjs/data": "^0.16.2",
+    "@sentry/vite-plugin": "^5.4.0",
     "@storybook/addon-actions": "6.5.16",
     "@storybook/addon-essentials": "6.5.16",
     "@storybook/addon-links": "6.5.16",

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -1,4 +1,5 @@
 import "./globals.css";
+// Import `./sentry` first: Sentry.init() as a side effect must run before React, router, and MSW.
 // eslint-disable-next-line import/order
 import { createRouter } from "./sentry";
 

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -1,8 +1,9 @@
 import "./globals.css";
+// eslint-disable-next-line import/order
+import { createRouter } from "./sentry";
 
 import React from "react";
 import { createRoot } from "react-dom/client";
-import { createBrowserRouter } from "react-router-dom";
 import math from "@math3d/custom-mathjs";
 import { createQueryClient } from "./services/react-query/react-query";
 import { theme } from "./mui";
@@ -39,7 +40,7 @@ prepare().then(() => {
   }
   const queryClient = createQueryClient();
 
-  const router = createBrowserRouter(routes);
+  const router = createRouter(routes);
 
   root.render(
     <React.StrictMode>

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -1,5 +1,6 @@
 import "./globals.css";
-// Import `./sentry` first: Sentry.init() as a side effect must run before React, router, and MSW.
+// Import `./sentry` here: its Sentry.init() side effect then runs before the
+// rest of the app's modules evaluate, and before the first render.
 // eslint-disable-next-line import/order
 import { createRouter } from "./sentry";
 

--- a/packages/app/src/pages/ErrorPage/ErrorPage.spec.tsx
+++ b/packages/app/src/pages/ErrorPage/ErrorPage.spec.tsx
@@ -2,9 +2,12 @@ import React from "react";
 import { describe, test, expect, vi } from "vitest";
 import { render } from "@testing-library/react";
 import { createMemoryRouter, RouterProvider } from "react-router";
+import * as Sentry from "@sentry/react";
 import { screen, waitFor } from "@/test_util";
 import ErrorPage, { normalizeError } from "./ErrorPage";
 import copy from "./errorPage.copy";
+
+vi.mock("@sentry/react", () => ({ captureException: vi.fn() }));
 
 const Boom: React.FC = () => {
   throw new Error("Cannot read properties of undefined (reading 'type')");
@@ -27,6 +30,43 @@ describe("ErrorPage as a route errorElement", () => {
       screen.getByText(/Cannot read properties of undefined/),
     ).toBeInTheDocument();
     expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+});
+
+describe("Sentry reporting", () => {
+  test("reports a thrown render error", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const router = createMemoryRouter([
+      { path: "/", element: <Boom />, errorElement: <ErrorPage /> },
+    ]);
+    render(<RouterProvider router={router} />);
+    await waitFor(() => {
+      expect(Sentry.captureException).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Cannot read properties of undefined (reading 'type')",
+        }),
+      );
+    });
+    consoleError.mockRestore();
+  });
+
+  test("does not report a route error response", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    // A 404 from the router is an HTTP response, not an exception.
+    const router = createMemoryRouter(
+      [{ path: "/", element: <div>home</div>, errorElement: <ErrorPage /> }],
+      { initialEntries: ["/nope"] },
+    );
+    render(<RouterProvider router={router} />);
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: copy.title })).toBeVisible();
+    });
+    expect(Sentry.captureException).not.toHaveBeenCalled();
     consoleError.mockRestore();
   });
 });

--- a/packages/app/src/pages/ErrorPage/ErrorPage.spec.tsx
+++ b/packages/app/src/pages/ErrorPage/ErrorPage.spec.tsx
@@ -14,10 +14,8 @@ const Boom: React.FC = () => {
   throw new Error("Cannot read properties of undefined (reading 'type')");
 };
 
-// React + React Router log caught render errors; every test below triggers
-// one, so silence console.error for all of them. A file-scoped spy managed
-// by beforeEach/afterEach (rather than per-test mockRestore calls) ensures
-// restoration still happens if an assertion throws mid-test.
+// Silence the console.error React and React Router emit for caught render
+// errors. File-scoped so restoration survives an assertion throwing mid-test.
 let consoleError: MockInstance<typeof console.error>;
 
 beforeEach(() => {
@@ -55,6 +53,8 @@ describe("Sentry reporting", () => {
         expect.objectContaining({
           message: "Cannot read properties of undefined (reading 'type')",
         }),
+        // Unhandled: the error took the user to the fallback page.
+        { mechanism: { type: "react-router.errorElement", handled: false } },
       );
     });
   });

--- a/packages/app/src/pages/ErrorPage/ErrorPage.spec.tsx
+++ b/packages/app/src/pages/ErrorPage/ErrorPage.spec.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { describe, test, expect, vi } from "vitest";
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import type { MockInstance } from "vitest";
 import { render } from "@testing-library/react";
 import { createMemoryRouter, RouterProvider } from "react-router";
 import * as Sentry from "@sentry/react";
@@ -13,12 +14,22 @@ const Boom: React.FC = () => {
   throw new Error("Cannot read properties of undefined (reading 'type')");
 };
 
+// React + React Router log caught render errors; every test below triggers
+// one, so silence console.error for all of them. A file-scoped spy managed
+// by beforeEach/afterEach (rather than per-test mockRestore calls) ensures
+// restoration still happens if an assertion throws mid-test.
+let consoleError: MockInstance<typeof console.error>;
+
+beforeEach(() => {
+  consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  consoleError.mockRestore();
+});
+
 describe("ErrorPage as a route errorElement", () => {
   test("renders the branded fallback when a route throws", async () => {
-    // React + React Router log the caught render error; that's expected here.
-    const consoleError = vi
-      .spyOn(console, "error")
-      .mockImplementation(() => {});
     const router = createMemoryRouter([
       { path: "/", element: <Boom />, errorElement: <ErrorPage /> },
     ]);
@@ -30,15 +41,11 @@ describe("ErrorPage as a route errorElement", () => {
       screen.getByText(/Cannot read properties of undefined/),
     ).toBeInTheDocument();
     expect(consoleError).toHaveBeenCalled();
-    consoleError.mockRestore();
   });
 });
 
 describe("Sentry reporting", () => {
   test("reports a thrown render error", async () => {
-    const consoleError = vi
-      .spyOn(console, "error")
-      .mockImplementation(() => {});
     const router = createMemoryRouter([
       { path: "/", element: <Boom />, errorElement: <ErrorPage /> },
     ]);
@@ -50,13 +57,9 @@ describe("Sentry reporting", () => {
         }),
       );
     });
-    consoleError.mockRestore();
   });
 
   test("does not report a route error response", async () => {
-    const consoleError = vi
-      .spyOn(console, "error")
-      .mockImplementation(() => {});
     // A 404 from the router is an HTTP response, not an exception.
     const router = createMemoryRouter(
       [{ path: "/", element: <div>home</div>, errorElement: <ErrorPage /> }],
@@ -67,7 +70,6 @@ describe("Sentry reporting", () => {
       expect(screen.getByRole("heading", { name: copy.title })).toBeVisible();
     });
     expect(Sentry.captureException).not.toHaveBeenCalled();
-    consoleError.mockRestore();
   });
 });
 

--- a/packages/app/src/pages/ErrorPage/ErrorPage.tsx
+++ b/packages/app/src/pages/ErrorPage/ErrorPage.tsx
@@ -45,10 +45,13 @@ const ErrorPage: React.FC = () => {
   // In an effect, not the render body: the body re-runs on every render and
   // would re-report the same error each time.
   useEffect(() => {
-    // Route error responses are HTTP statuses (404, loader failures), not
-    // exceptions — reporting them would be noise.
+    // Route error responses carry an HTTP status, not an exception; skip them.
     if (isRouteErrorResponse(error)) return;
-    Sentry.captureException(error);
+    // Not `handled: true` (captureException's default): this error took the
+    // user to the fallback page.
+    Sentry.captureException(error, {
+      mechanism: { type: "react-router.errorElement", handled: false },
+    });
   }, [error]);
   const { message, stack } = normalizeError(error);
   return <ErrorView message={message} stack={stack} />;

--- a/packages/app/src/pages/ErrorPage/ErrorPage.tsx
+++ b/packages/app/src/pages/ErrorPage/ErrorPage.tsx
@@ -1,5 +1,6 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { useRouteError, isRouteErrorResponse } from "react-router";
+import * as Sentry from "@sentry/react";
 import copy from "./errorPage.copy";
 import ErrorView from "./ErrorView";
 
@@ -41,6 +42,14 @@ const normalizeError = (error: unknown): NormalizedError => {
  */
 const ErrorPage: React.FC = () => {
   const error = useRouteError();
+  // In an effect, not the render body: the body re-runs on every render and
+  // would re-report the same error each time.
+  useEffect(() => {
+    // Route error responses are HTTP statuses (404, loader failures), not
+    // exceptions — reporting them would be noise.
+    if (isRouteErrorResponse(error)) return;
+    Sentry.captureException(error);
+  }, [error]);
   const { message, stack } = normalizeError(error);
   return <ErrorView message={message} stack={stack} />;
 };

--- a/packages/app/src/sentry.spec.ts
+++ b/packages/app/src/sentry.spec.ts
@@ -1,0 +1,47 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import * as Sentry from "@sentry/react";
+
+vi.mock("@sentry/react", () => ({
+  init: vi.fn(),
+  reactRouterV7BrowserTracingIntegration: vi.fn(() => ({ name: "mock" })),
+  wrapCreateBrowserRouterV7: vi.fn((create) => create),
+}));
+
+describe("Sentry init", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  test("does not initialize when no DSN is configured", async () => {
+    vi.stubEnv("VITE_SENTRY_DSN", "");
+    await import("./sentry");
+    expect(Sentry.init).not.toHaveBeenCalled();
+  });
+
+  test("initializes with tracing and no PII when a DSN is configured", async () => {
+    vi.stubEnv("VITE_SENTRY_DSN", "https://abc123@o1.ingest.sentry.io/42");
+    vi.stubEnv("VITE_APP_VERSION", "1.2.3");
+    await import("./sentry");
+    expect(Sentry.init).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dsn: "https://abc123@o1.ingest.sentry.io/42",
+        environment: "production",
+        release: "1.2.3",
+        sendDefaultPii: false,
+        tracesSampleRate: 1,
+      }),
+    );
+  });
+
+  test("wraps the real createBrowserRouter for route instrumentation", async () => {
+    await import("./sentry");
+    const { createBrowserRouter } = await import("react-router-dom");
+    expect(Sentry.wrapCreateBrowserRouterV7).toHaveBeenCalledWith(
+      createBrowserRouter,
+    );
+  });
+});

--- a/packages/app/src/sentry.spec.ts
+++ b/packages/app/src/sentry.spec.ts
@@ -1,5 +1,12 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
 import * as Sentry from "@sentry/react";
+import { useEffect } from "react";
+import {
+  createRoutesFromChildren,
+  matchRoutes,
+  useLocation,
+  useNavigationType,
+} from "react-router";
 
 vi.mock("@sentry/react", () => ({
   init: vi.fn(),
@@ -10,7 +17,6 @@ vi.mock("@sentry/react", () => ({
 describe("Sentry init", () => {
   beforeEach(() => {
     vi.resetModules();
-    vi.clearAllMocks();
   });
   afterEach(() => {
     vi.unstubAllEnvs();
@@ -33,7 +39,21 @@ describe("Sentry init", () => {
         release: "1.2.3",
         sendDefaultPii: false,
         tracesSampleRate: 1,
+        integrations: [{ name: "mock" }],
       }),
+    );
+    expect(Sentry.reactRouterV7BrowserTracingIntegration).toHaveBeenCalledWith(
+      expect.objectContaining({
+        useEffect,
+        useLocation,
+        useNavigationType,
+        createRoutesFromChildren,
+        matchRoutes,
+      }),
+    );
+    // The wrapper reads state that init() installs, so init must run first.
+    expect(vi.mocked(Sentry.init).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(Sentry.wrapCreateBrowserRouterV7).mock.invocationCallOrder[0],
     );
   });
 

--- a/packages/app/src/sentry.ts
+++ b/packages/app/src/sentry.ts
@@ -31,7 +31,7 @@ if (dsn) {
   });
 }
 
-// Scene URLs are `/:sceneKey`, so unwrapped routing would name one transaction
-// per scene key. The wrapper reports the matched route pattern instead.
+// Scene URLs are `/:sceneKey`; the wrapper names transactions by matched route
+// pattern. Must stay below init(), or it returns createBrowserRouter unwrapped.
 export const createRouter =
   Sentry.wrapCreateBrowserRouterV7(createBrowserRouter);

--- a/packages/app/src/sentry.ts
+++ b/packages/app/src/sentry.ts
@@ -1,0 +1,37 @@
+import * as Sentry from "@sentry/react";
+import { useEffect } from "react";
+import {
+  createRoutesFromChildren,
+  matchRoutes,
+  useLocation,
+  useNavigationType,
+} from "react-router";
+import { createBrowserRouter } from "react-router-dom";
+import { APP_VERSION } from "@/version";
+
+const dsn = import.meta.env.VITE_SENTRY_DSN;
+
+// Unset DSN ⇒ no-op. Production is the only environment that supplies one.
+if (dsn) {
+  Sentry.init({
+    dsn,
+    environment: "production",
+    release: APP_VERSION,
+    sendDefaultPii: false,
+    tracesSampleRate: 1,
+    integrations: [
+      Sentry.reactRouterV7BrowserTracingIntegration({
+        useEffect,
+        useLocation,
+        useNavigationType,
+        createRoutesFromChildren,
+        matchRoutes,
+      }),
+    ],
+  });
+}
+
+// Scene URLs are `/:sceneKey`, so unwrapped routing would name one transaction
+// per scene key. The wrapper reports the matched route pattern instead.
+export const createRouter =
+  Sentry.wrapCreateBrowserRouterV7(createBrowserRouter);

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -5,6 +5,7 @@ import react from "@vitejs/plugin-react";
 import viteTsconfigPaths from "vite-tsconfig-paths";
 import { Schema, ValidateEnv } from "@julr/vite-plugin-validate-env";
 import compileTime from "vite-plugin-compile-time";
+import { sentryVitePlugin } from "@sentry/vite-plugin";
 import type { PluginOption } from "vite";
 import fs from "fs/promises";
 import { realpathSync } from "node:fs";
@@ -89,6 +90,7 @@ export default defineConfig({
       VITE_SITE_ORIGIN: Schema.string(),
       VITE_APP_VERSION: Schema.string.optional(),
       VITE_DISPLAY_AUTH_FLOWS: Schema.string.optional(),
+      VITE_SENTRY_DSN: Schema.string.optional(),
     }),
     react(),
     viteTsconfigPaths(),
@@ -103,7 +105,32 @@ export default defineConfig({
     docsHotReload(
       path.resolve(__dirname, "./src/pages/HelpPage/data.compile.ts"),
     ),
+    // Only when a token is present: `yarn build` runs tokenless in e2e.yml and
+    // in the rc dry_run, and the jsdom vitest project inherits this array.
+    ...(process.env.SENTRY_AUTH_TOKEN
+      ? [
+          sentryVitePlugin({
+            org: process.env.SENTRY_ORG,
+            project: process.env.SENTRY_PROJECT,
+            authToken: process.env.SENTRY_AUTH_TOKEN,
+            // The plugin creates its own release and would otherwise name it
+            // after the git HEAD SHA, while the SDK reports VITE_APP_VERSION.
+            ...(process.env.VITE_APP_VERSION
+              ? { release: { name: process.env.VITE_APP_VERSION } }
+              : {}),
+            // The plugin throws by default; a Sentry outage must not fail a release.
+            errorHandler: (err) => {
+              // eslint-disable-next-line no-console
+              console.warn("Sentry source map upload failed:", err);
+            },
+          }),
+        ]
+      : []),
   ],
+  build: {
+    // Uploaded to Sentry AND shipped to the CDN — math3d is open source.
+    sourcemap: true,
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -69,26 +69,30 @@ const appUrl = new URL(process.env.APP_BASE_URL ?? "http://localhost:3000");
 // Only when a token is present: `yarn build` runs tokenless in e2e.yml and in
 // the rc dry_run, and the jsdom vitest project inherits this plugins array.
 const sentryPlugins = (): PluginOption[] => {
-  const authToken = process.env.SENTRY_AUTH_TOKEN;
+  const authToken = process.env.SENTRY_ORG_TOKEN;
   if (!authToken) return [];
   // A token means this is a release build, so an incomplete upload config is a
   // bug: `errorHandler` below would otherwise reduce it to a warning.
   const release = process.env.VITE_APP_VERSION;
-  const org = process.env.SENTRY_ORG;
   const project = process.env.SENTRY_PROJECT;
-  if (!release || !org || !project) {
+  if (!release || !project) {
     const missing = [
       !release && "VITE_APP_VERSION",
-      !org && "SENTRY_ORG",
       !project && "SENTRY_PROJECT",
     ].filter(Boolean);
     throw new Error(
-      `SENTRY_AUTH_TOKEN is set but source-map upload is misconfigured (missing: ${missing.join(", ")}); Sentry would show minified stack traces for this release.`,
+      `SENTRY_ORG_TOKEN is set but source-map upload is misconfigured (missing: ${missing.join(", ")}); Sentry would show minified stack traces for this release.`,
+    );
+  }
+  // An org token carries its own org, which is why no SENTRY_ORG is needed; the
+  // plugin skips the org requirement on exactly this prefix.
+  if (!authToken.startsWith("sntrys_")) {
+    throw new Error(
+      "SENTRY_ORG_TOKEN must be a Sentry organization auth token (prefix `sntrys_`); other token types also need an org slug, which this build does not supply.",
     );
   }
   return [
     sentryVitePlugin({
-      org,
       project,
       authToken,
       release: { name: release },

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -71,20 +71,25 @@ const appUrl = new URL(process.env.APP_BASE_URL ?? "http://localhost:3000");
 const sentryPlugins = (): PluginOption[] => {
   const authToken = process.env.SENTRY_AUTH_TOKEN;
   if (!authToken) return [];
-  // Without this, the plugin names its release after the git HEAD SHA, which
-  // the runtime SDK (reporting VITE_APP_VERSION) would never match — a silent
-  // break in source-map-to-event correlation. The token only exists in CI
-  // release builds, so fail loudly rather than ship that mismatch.
+  // A token means this is a release build, so an incomplete upload config is a
+  // bug: `errorHandler` below would otherwise reduce it to a warning.
   const release = process.env.VITE_APP_VERSION;
-  if (!release) {
+  const org = process.env.SENTRY_ORG;
+  const project = process.env.SENTRY_PROJECT;
+  if (!release || !org || !project) {
+    const missing = [
+      !release && "VITE_APP_VERSION",
+      !org && "SENTRY_ORG",
+      !project && "SENTRY_PROJECT",
+    ].filter(Boolean);
     throw new Error(
-      "SENTRY_AUTH_TOKEN is set but VITE_APP_VERSION is not: uploaded source maps would be tagged with a git SHA the runtime SDK never reports.",
+      `SENTRY_AUTH_TOKEN is set but source-map upload is misconfigured (missing: ${missing.join(", ")}); Sentry would show minified stack traces for this release.`,
     );
   }
   return [
     sentryVitePlugin({
-      org: process.env.SENTRY_ORG,
-      project: process.env.SENTRY_PROJECT,
+      org,
+      project,
       authToken,
       release: { name: release },
       // The plugin throws by default; a Sentry outage must not fail a release.
@@ -139,12 +144,9 @@ export default defineConfig({
   ],
   build: {
     // Uploaded to Sentry AND shipped to the CDN — math3d is open source.
+    // Expect a "Sourcemap is likely to be incorrect" warning: it comes from
+    // vite-plugin-compile-time, whose output never appears in a stack trace.
     sourcemap: true,
-    // Expected: vite-plugin-compile-time's "compile-time:import" transform
-    // (for HelpPage/data.compile.ts) emits no map for its own step, so
-    // Rollup warns "Sourcemap is likely to be incorrect" during build. That
-    // file becomes static help-page data before this app runs, so it never
-    // appears in a Sentry stack trace.
   },
   resolve: {
     alias: {

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -66,6 +66,36 @@ const checkoutIdentity = (): PluginOption => {
 // from direnv loading .env.development; in CI it comes from a GitHub var.
 const appUrl = new URL(process.env.APP_BASE_URL ?? "http://localhost:3000");
 
+// Only when a token is present: `yarn build` runs tokenless in e2e.yml and in
+// the rc dry_run, and the jsdom vitest project inherits this plugins array.
+const sentryPlugins = (): PluginOption[] => {
+  const authToken = process.env.SENTRY_AUTH_TOKEN;
+  if (!authToken) return [];
+  // Without this, the plugin names its release after the git HEAD SHA, which
+  // the runtime SDK (reporting VITE_APP_VERSION) would never match — a silent
+  // break in source-map-to-event correlation. The token only exists in CI
+  // release builds, so fail loudly rather than ship that mismatch.
+  const release = process.env.VITE_APP_VERSION;
+  if (!release) {
+    throw new Error(
+      "SENTRY_AUTH_TOKEN is set but VITE_APP_VERSION is not: uploaded source maps would be tagged with a git SHA the runtime SDK never reports.",
+    );
+  }
+  return [
+    sentryVitePlugin({
+      org: process.env.SENTRY_ORG,
+      project: process.env.SENTRY_PROJECT,
+      authToken,
+      release: { name: release },
+      // The plugin throws by default; a Sentry outage must not fail a release.
+      errorHandler: (err) => {
+        // eslint-disable-next-line no-console
+        console.warn("Sentry source map upload failed:", err);
+      },
+    }),
+  ];
+};
+
 export default defineConfig({
   server: {
     port: Number(appUrl.port) || 3000,
@@ -105,31 +135,16 @@ export default defineConfig({
     docsHotReload(
       path.resolve(__dirname, "./src/pages/HelpPage/data.compile.ts"),
     ),
-    // Only when a token is present: `yarn build` runs tokenless in e2e.yml and
-    // in the rc dry_run, and the jsdom vitest project inherits this array.
-    ...(process.env.SENTRY_AUTH_TOKEN
-      ? [
-          sentryVitePlugin({
-            org: process.env.SENTRY_ORG,
-            project: process.env.SENTRY_PROJECT,
-            authToken: process.env.SENTRY_AUTH_TOKEN,
-            // The plugin creates its own release and would otherwise name it
-            // after the git HEAD SHA, while the SDK reports VITE_APP_VERSION.
-            ...(process.env.VITE_APP_VERSION
-              ? { release: { name: process.env.VITE_APP_VERSION } }
-              : {}),
-            // The plugin throws by default; a Sentry outage must not fail a release.
-            errorHandler: (err) => {
-              // eslint-disable-next-line no-console
-              console.warn("Sentry source map upload failed:", err);
-            },
-          }),
-        ]
-      : []),
+    ...sentryPlugins(),
   ],
   build: {
     // Uploaded to Sentry AND shipped to the CDN — math3d is open source.
     sourcemap: true,
+    // Expected: vite-plugin-compile-time's "compile-time:import" transform
+    // (for HelpPage/data.compile.ts) emits no map for its own step, so
+    // Rollup warns "Sourcemap is likely to be incorrect" during build. That
+    // file becomes static help-page data before this app runs, so it never
+    // appears in a Sentry stack trace.
   },
   resolve: {
     alias: {

--- a/webserver/main/env.py
+++ b/webserver/main/env.py
@@ -13,6 +13,7 @@ from urllib.parse import urlparse
 from django.utils.http import is_same_domain
 from pydantic import field_validator, model_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
+from sentry_sdk.utils import BadDsn, Dsn
 
 
 class EnvConfig(BaseSettings):
@@ -60,6 +61,9 @@ class EnvConfig(BaseSettings):
     ENABLE_REGISTRATION: bool = False
     CSRF_COOKIE_DOMAIN: str = ""
     DISABLE_ALLAUTH_RATE_LIMITS: bool = False
+    # Sentry. Unset ⇒ the SDK is a no-op, which is how dev, CI, and tests run.
+    SENTRY_DSN: str = ""
+    SENTRY_TRACES_SAMPLE_RATE: float = 1.0
 
     @field_validator("ALLOWED_HOSTS", "CORS_ALLOWED_ORIGINS", mode="before")
     @classmethod
@@ -86,6 +90,17 @@ class EnvConfig(BaseSettings):
                 f"{value!r} must be a bare origin — scheme://host[:port] with no "
                 "path, e.g. https://next.math3d.org"
             )
+        return value
+
+    @field_validator("SENTRY_DSN")
+    @classmethod
+    def _validate_sentry_dsn(cls, value: str) -> str:
+        if not value:
+            return value
+        try:
+            Dsn(value)
+        except BadDsn as exc:
+            raise ValueError(f"{value!r} is not a valid Sentry DSN: {exc}") from exc
         return value
 
     @model_validator(mode="after")

--- a/webserver/main/env_test.py
+++ b/webserver/main/env_test.py
@@ -30,3 +30,24 @@ def test_screenshots_origin_rejects_non_bare_origin():
 
 def test_render_secret_defaults_empty():
     assert _base().RENDER_SECRET == ""
+
+
+def test_sentry_dsn_defaults_empty():
+    assert _base().SENTRY_DSN == ""
+
+
+def test_sentry_traces_sample_rate_defaults_to_one():
+    assert _base().SENTRY_TRACES_SAMPLE_RATE == 1.0
+
+
+def test_sentry_dsn_accepts_a_valid_dsn():
+    dsn = "https://abc123@o1.ingest.sentry.io/42"
+    assert _base(SENTRY_DSN=dsn).SENTRY_DSN == dsn
+
+
+def test_sentry_dsn_rejects_a_malformed_dsn():
+    # sentry_sdk.init() raises BadDsn at settings-import time, which would be an
+    # unhandled gunicorn boot failure; this validator turns it into the same
+    # ImproperlyConfigured path as every other bad config value.
+    with pytest.raises(ValidationError):
+        _base(SENTRY_DSN="not-a-dsn")

--- a/webserver/main/env_test.py
+++ b/webserver/main/env_test.py
@@ -36,15 +36,6 @@ def test_sentry_dsn_defaults_empty():
     assert _base().SENTRY_DSN == ""
 
 
-def test_sentry_traces_sample_rate_defaults_to_one():
-    assert _base().SENTRY_TRACES_SAMPLE_RATE == 1.0
-
-
-def test_sentry_dsn_accepts_a_valid_dsn():
-    dsn = "https://abc123@o1.ingest.sentry.io/42"
-    assert _base(SENTRY_DSN=dsn).SENTRY_DSN == dsn
-
-
 def test_sentry_dsn_rejects_a_malformed_dsn():
     # sentry_sdk.init() raises BadDsn at settings-import time, which would be an
     # unhandled gunicorn boot failure; this validator turns it into the same

--- a/webserver/main/settings.py
+++ b/webserver/main/settings.py
@@ -17,6 +17,7 @@ import logging
 from django.core.exceptions import ImproperlyConfigured
 
 import dj_database_url
+import sentry_sdk
 from pydantic import ValidationError
 
 from main.env import EnvConfig
@@ -37,6 +38,17 @@ try:
     ENV = EnvConfig()
 except ValidationError as exc:
     raise ImproperlyConfigured(str(exc)) from exc
+
+# Unset DSN ⇒ no-op (dev, CI, tests). EnvConfig already validated the DSN
+# above, so a malformed value fails as ImproperlyConfigured, not BadDsn here.
+if ENV.SENTRY_DSN:
+    sentry_sdk.init(
+        dsn=ENV.SENTRY_DSN,
+        environment="production",
+        release=ENV.APP_VERSION,
+        send_default_pii=False,
+        traces_sample_rate=ENV.SENTRY_TRACES_SAMPLE_RATE,
+    )
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent

--- a/webserver/main/settings_test.py
+++ b/webserver/main/settings_test.py
@@ -355,3 +355,29 @@ def test_screenshots_config_reads_env_and_caps(monkeypatch):
     assert module.RENDER_SECRET == "shh"  # pragma: allowlist secret
     assert module.RENDER_MONTHLY_CAP == 1500
     assert module.RENDER_DAILY_CAP == 150
+
+
+def test_sentry_not_initialized_without_a_dsn(monkeypatch):
+    """Dev, CI, and tests run with no DSN — init must be a no-op there."""
+    init_calls = []
+    monkeypatch.setattr("sentry_sdk.init", lambda **kwargs: init_calls.append(kwargs))
+    load_settings(monkeypatch, IS_DEVELOPMENT="True")
+    assert init_calls == []
+
+
+def test_sentry_initialized_with_no_pii_and_full_tracing(monkeypatch):
+    init_calls = []
+    monkeypatch.setattr("sentry_sdk.init", lambda **kwargs: init_calls.append(kwargs))
+    load_settings(
+        monkeypatch,
+        IS_DEVELOPMENT="True",
+        SENTRY_DSN="https://abc123@o1.ingest.sentry.io/42",
+        APP_VERSION="1.2.3",
+    )
+    assert len(init_calls) == 1
+    kwargs = init_calls[0]
+    assert kwargs["send_default_pii"] is False
+    assert kwargs["traces_sample_rate"] == 1.0
+    assert kwargs["environment"] == "production"
+    assert kwargs["release"] == "1.2.3"
+    assert kwargs["dsn"] == "https://abc123@o1.ingest.sentry.io/42"

--- a/webserver/main/test_settings.py
+++ b/webserver/main/test_settings.py
@@ -1,8 +1,11 @@
 import os
 
+import sentry_sdk
 from django.core.exceptions import ImproperlyConfigured
 
 from main.settings import *  # noqa: F403
+
+sentry_sdk.init(dsn=None)  # tests never report, even if SENTRY_DSN is set
 
 
 def require_postgres(engine: str, database_url: str) -> None:

--- a/webserver/pyproject.toml
+++ b/webserver/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
 	"django-allauth>=65.0,<66.0",
 	"django-ninja>=1.6.2,<2.0",
 	"pydantic-settings>=2.15.0,<3.0",
+	"sentry-sdk[django]>=2.68.0,<3.0.0",
 ]
 
 [dependency-groups]

--- a/webserver/scenes/screenshots.py
+++ b/webserver/scenes/screenshots.py
@@ -78,7 +78,7 @@ def nudge_render(key: str) -> None:
     except Exception:
         # Log-attribution only (a distinct line from a reserve failure), NOT the
         # isolation guard — maybe_render's outer try is what protects the save.
-        logger.warning("nudge_render failed for key=%s", key, exc_info=True)
+        logger.error("nudge_render failed for key=%s", key, exc_info=True)
 
 
 def maybe_render(key: str) -> None:
@@ -94,7 +94,7 @@ def maybe_render(key: str) -> None:
             return
         nudge_render(key)
     except Exception:
-        logger.warning("maybe_render failed for key=%s", key, exc_info=True)
+        logger.error("maybe_render failed for key=%s", key, exc_info=True)
 
 
 def schedule_render(key: str) -> None:

--- a/webserver/scenes/screenshots_test.py
+++ b/webserver/scenes/screenshots_test.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 import threading
 from unittest import mock
 
@@ -165,10 +166,44 @@ def test_nudge_render_sends_named_user_agent(settings):
     assert req.get_header("User-agent") == BACKEND_USER_AGENT
 
 
-def test_nudge_render_swallows_transport_error(settings):
+@pytest.fixture
+def scenes_caplog(caplog):
+    """`scenes` has propagate=False, so caplog's root handler never sees it."""
+    logger = logging.getLogger("scenes")
+    logger.addHandler(caplog.handler)
+    try:
+        with caplog.at_level(logging.DEBUG):
+            yield caplog
+    finally:
+        logger.removeHandler(caplog.handler)
+
+
+def test_nudge_render_swallows_transport_error(settings, scenes_caplog):
     settings.SCREENSHOTS_ORIGIN = "https://s.math3d.org"
     settings.RENDER_SECRET = "shh"  # pragma: allowlist secret
     with mock.patch(
         "scenes.screenshots.urllib.request.urlopen", side_effect=OSError("refused")
     ):
         screenshots.nudge_render("abc")  # must not raise
+    (record,) = [r for r in scenes_caplog.records if r.levelno == logging.ERROR]
+    assert record.name == "scenes.screenshots"
+    assert record.getMessage() == "nudge_render failed for key=abc"
+
+
+def test_maybe_render_logs_failures_at_error_level(
+    settings, monkeypatch, scenes_caplog
+):
+    """
+    The save path must still succeed, but the failure has to reach Sentry —
+    which only promotes ERROR and above to events.
+    """
+    settings.SCREENSHOTS_ORIGIN = "https://screenshots.example.org"
+    settings.RENDER_SECRET = "secret"  # pragma: allowlist secret
+    monkeypatch.setattr(
+        "scenes.screenshots.reserve_render_slot",
+        lambda: (_ for _ in ()).throw(RuntimeError("ledger exploded")),
+    )
+    screenshots.maybe_render("some-key")  # must not raise
+    (record,) = [r for r in scenes_caplog.records if r.levelno == logging.ERROR]
+    assert record.name == "scenes.screenshots"
+    assert record.getMessage() == "maybe_render failed for key=some-key"

--- a/webserver/scenes/screenshots_test.py
+++ b/webserver/scenes/screenshots_test.py
@@ -144,7 +144,18 @@ def test_maybe_render_nudges_when_granted(settings):
     nudge.assert_called_once_with("abc")
 
 
-def test_maybe_render_swallows_reserve_exception(settings):
+@pytest.fixture
+def scenes_caplog(caplog):
+    """`scenes` has propagate=False, so caplog's root handler never sees it."""
+    logger = logging.getLogger("scenes")
+    logger.addHandler(caplog.handler)
+    try:
+        yield caplog
+    finally:
+        logger.removeHandler(caplog.handler)
+
+
+def test_maybe_render_swallows_reserve_exception(settings, scenes_caplog):
     # The isolation invariant: a failure inside maybe_render must not propagate
     # (it runs inline in the save's request cycle — an escape would 500 the save).
     settings.SCREENSHOTS_ORIGIN = "https://s.math3d.org"
@@ -153,6 +164,9 @@ def test_maybe_render_swallows_reserve_exception(settings):
         screenshots, "reserve_render_slot", side_effect=RuntimeError("db down")
     ):
         screenshots.maybe_render("abc")  # must not raise
+    (record,) = [r for r in scenes_caplog.records if r.levelno == logging.ERROR]
+    assert record.name == "scenes.screenshots"
+    assert record.getMessage() == "maybe_render failed for key=abc"
 
 
 def test_nudge_render_sends_named_user_agent(settings):
@@ -166,18 +180,6 @@ def test_nudge_render_sends_named_user_agent(settings):
     assert req.get_header("User-agent") == BACKEND_USER_AGENT
 
 
-@pytest.fixture
-def scenes_caplog(caplog):
-    """`scenes` has propagate=False, so caplog's root handler never sees it."""
-    logger = logging.getLogger("scenes")
-    logger.addHandler(caplog.handler)
-    try:
-        with caplog.at_level(logging.DEBUG):
-            yield caplog
-    finally:
-        logger.removeHandler(caplog.handler)
-
-
 def test_nudge_render_swallows_transport_error(settings, scenes_caplog):
     settings.SCREENSHOTS_ORIGIN = "https://s.math3d.org"
     settings.RENDER_SECRET = "shh"  # pragma: allowlist secret
@@ -188,22 +190,3 @@ def test_nudge_render_swallows_transport_error(settings, scenes_caplog):
     (record,) = [r for r in scenes_caplog.records if r.levelno == logging.ERROR]
     assert record.name == "scenes.screenshots"
     assert record.getMessage() == "nudge_render failed for key=abc"
-
-
-def test_maybe_render_logs_failures_at_error_level(
-    settings, monkeypatch, scenes_caplog
-):
-    """
-    The save path must still succeed, but the failure has to reach Sentry —
-    which only promotes ERROR and above to events.
-    """
-    settings.SCREENSHOTS_ORIGIN = "https://screenshots.example.org"
-    settings.RENDER_SECRET = "secret"  # pragma: allowlist secret
-    monkeypatch.setattr(
-        "scenes.screenshots.reserve_render_slot",
-        lambda: (_ for _ in ()).throw(RuntimeError("ledger exploded")),
-    )
-    screenshots.maybe_render("some-key")  # must not raise
-    (record,) = [r for r in scenes_caplog.records if r.levelno == logging.ERROR]
-    assert record.name == "scenes.screenshots"
-    assert record.getMessage() == "maybe_render failed for key=some-key"

--- a/webserver/uv.lock
+++ b/webserver/uv.lock
@@ -279,6 +279,7 @@ dependencies = [
     { name = "psycopg" },
     { name = "pydantic-settings" },
     { name = "pyyaml" },
+    { name = "sentry-sdk", extra = ["django"] },
     { name = "tqdm" },
     { name = "whitenoise" },
 ]
@@ -312,6 +313,7 @@ requires-dist = [
     { name = "psycopg", specifier = ">=3.2.10" },
     { name = "pydantic-settings", specifier = ">=2.15.0,<3.0" },
     { name = "pyyaml", specifier = ">=6.0,<7.0" },
+    { name = "sentry-sdk", extras = ["django"], specifier = ">=2.68.0,<3.0.0" },
     { name = "tqdm", specifier = ">=4.64.1,<5.0.0" },
     { name = "whitenoise", specifier = ">=6.11.0" },
 ]
@@ -570,6 +572,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "sentry-sdk"
+version = "2.68.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/94/23b7dd072acb9628907bd3f4fbf61794a7b12a9db8f33c1276f70ae5ac92/sentry_sdk-2.68.0.tar.gz", hash = "sha256:648c58e9887311a03470a41539e24bdbbf64a30ca4f5336f7e3dcc87276400b3", size = 1008854, upload-time = "2026-08-13T09:06:21.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/9b/e2421d08956d0bc4691d995393d835e563886bff499d8fb10fdefae85a8d/sentry_sdk-2.68.0-py3-none-any.whl", hash = "sha256:538e56c2d03679d42f7c0cb5f1af73a7a510b00abc7e296c13ac49b107b713a4", size = 518670, upload-time = "2026-08-13T09:06:19.735Z" },
+]
+
+[package.optional-dependencies]
+django = [
+    { name = "django" },
 ]
 
 [[package]]

--- a/yarn.lock
+++ b/yarn.lock
@@ -64,6 +64,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/code-frame@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/code-frame@npm:7.29.7"
+  dependencies:
+    "@babel/helper-validator-identifier": "npm:^7.29.7"
+    js-tokens: "npm:^4.0.0"
+    picocolors: "npm:^1.1.1"
+  checksum: 10/84da552e51a55795a50b3589116edb2f9e368a647d266380683775f18effd9acd4521b0246bebd0b049a7f32af1f87b1e8475d3bcb665f876bd04ade8da99697
+  languageName: node
+  linkType: hard
+
 "@babel/compat-data@npm:^7.17.7, @babel/compat-data@npm:^7.20.5, @babel/compat-data@npm:^7.22.5, @babel/compat-data@npm:^7.25.9":
   version: 7.26.3
   resolution: "@babel/compat-data@npm:7.26.3"
@@ -75,6 +86,13 @@ __metadata:
   version: 7.28.4
   resolution: "@babel/compat-data@npm:7.28.4"
   checksum: 10/95b7864e6b210c84c069743966da448c0cb50015a4de5e18dd755776a0b5e53c4653e74f26700aed8de922eaa3b8844fc5fc5b29bc64830249d2abe914aec832
+  languageName: node
+  linkType: hard
+
+"@babel/compat-data@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/compat-data@npm:7.29.7"
+  checksum: 10/ad2272714087f68970977f6e2b53597a8503fc9c3028c4a91686474bd77a707dd00903cdde4b73788972016d1bad4dc3fa4e5ff38e1ed8f1c3bde1095352973a
   languageName: node
   linkType: hard
 
@@ -122,6 +140,29 @@ __metadata:
     json5: "npm:^2.2.3"
     semver: "npm:^6.3.1"
   checksum: 10/65767bfdb1f02e80d3af4f138066670ef8fdd12293de85ef151758a901c191c797e86d2e99b11c4cdfca33c72385ecaf38bbd7fa692791ec44c77763496b9b93
+  languageName: node
+  linkType: hard
+
+"@babel/core@npm:^7.18.5":
+  version: 7.29.7
+  resolution: "@babel/core@npm:7.29.7"
+  dependencies:
+    "@babel/code-frame": "npm:^7.29.7"
+    "@babel/generator": "npm:^7.29.7"
+    "@babel/helper-compilation-targets": "npm:^7.29.7"
+    "@babel/helper-module-transforms": "npm:^7.29.7"
+    "@babel/helpers": "npm:^7.29.7"
+    "@babel/parser": "npm:^7.29.7"
+    "@babel/template": "npm:^7.29.7"
+    "@babel/traverse": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+    "@jridgewell/remapping": "npm:^2.3.5"
+    convert-source-map: "npm:^2.0.0"
+    debug: "npm:^4.1.0"
+    gensync: "npm:^1.0.0-beta.2"
+    json5: "npm:^2.2.3"
+    semver: "npm:^6.3.1"
+  checksum: 10/38e71cf81db790b0bb2a3a0c8140c2b1c87576b61dc6be676de4fab8c3be871af590a739e8c489fe8e8f9a8e5899fa11e35e59e9e09d40b259c6a675f2f98928
   languageName: node
   linkType: hard
 
@@ -174,6 +215,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/generator@npm:^7.29.7, @babel/generator@npm:^7.29.8":
+  version: 7.29.8
+  resolution: "@babel/generator@npm:7.29.8"
+  dependencies:
+    "@babel/parser": "npm:^7.29.8"
+    "@babel/types": "npm:^7.29.8"
+    "@jridgewell/gen-mapping": "npm:^0.3.12"
+    "@jridgewell/trace-mapping": "npm:^0.3.28"
+    jsesc: "npm:^3.0.2"
+  checksum: 10/679c3d1302936f391260acee4059e0c3cd5bff6341772f0b85bb142feab1a253d0e155aad0e9c8531e024d6239a2cc5169d1e294c6890901e7d4ab0f7c9eaaaa
+  languageName: node
+  linkType: hard
+
 "@babel/helper-annotate-as-pure@npm:^7.18.6, @babel/helper-annotate-as-pure@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/helper-annotate-as-pure@npm:7.22.5"
@@ -215,6 +269,19 @@ __metadata:
     lru-cache: "npm:^5.1.1"
     semver: "npm:^6.3.1"
   checksum: 10/bd53c30a7477049db04b655d11f4c3500aea3bcbc2497cf02161de2ecf994fec7c098aabbcebe210ffabc2ecbdb1e3ffad23fb4d3f18723b814f423ea1749fe8
+  languageName: node
+  linkType: hard
+
+"@babel/helper-compilation-targets@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-compilation-targets@npm:7.29.7"
+  dependencies:
+    "@babel/compat-data": "npm:^7.29.7"
+    "@babel/helper-validator-option": "npm:^7.29.7"
+    browserslist: "npm:^4.24.0"
+    lru-cache: "npm:^5.1.1"
+    semver: "npm:^6.3.1"
+  checksum: 10/af9ed4299ad5cfbe48432a964f37cbbfc200bbeb0f8ba9cbc86448503fa929382d5161d32096274752230c9feb919c9ef595559498833da656fc6a8e24a62383
   languageName: node
   linkType: hard
 
@@ -308,6 +375,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-globals@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-globals@npm:7.29.7"
+  checksum: 10/e53203e87ae24a45f59639edea0c429bc3c63c6d74f1862fe60a35032d89478e7511d2f34855da0fcb65782668d72e59e93d1de5bc00121ba9bc1aa38f1f0ad3
+  languageName: node
+  linkType: hard
+
 "@babel/helper-hoist-variables@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/helper-hoist-variables@npm:7.22.5"
@@ -346,6 +420,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-module-imports@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-module-imports@npm:7.29.7"
+  dependencies:
+    "@babel/traverse": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+  checksum: 10/28ec6f7efd99588d6eebfb25c9f1ccc34cb0cdb0839c4c0f08b3ec0105ccaefbe7e8b4f651f3f55a4f5c4fcb1d979bd32a9b8ee23e3e62163ea22aaa7ee0dfa1
+  languageName: node
+  linkType: hard
+
 "@babel/helper-module-transforms@npm:^7.12.1, @babel/helper-module-transforms@npm:^7.22.5, @babel/helper-module-transforms@npm:^7.26.0":
   version: 7.26.0
   resolution: "@babel/helper-module-transforms@npm:7.26.0"
@@ -369,6 +453,19 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: 10/598fdd8aa5b91f08542d0ba62a737847d0e752c8b95ae2566bc9d11d371856d6867d93e50db870fb836a6c44cfe481c189d8a2b35ca025a224f070624be9fa87
+  languageName: node
+  linkType: hard
+
+"@babel/helper-module-transforms@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-module-transforms@npm:7.29.7"
+  dependencies:
+    "@babel/helper-module-imports": "npm:^7.29.7"
+    "@babel/helper-validator-identifier": "npm:^7.29.7"
+    "@babel/traverse": "npm:^7.29.7"
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 10/33251b1fb44d726194a974a0078b1269511d130a2609357ff829b479e9e4dca96ecd5384c534a477095f665ffb01503d3e680699c2002e5b62e6ca1a272f1892
   languageName: node
   linkType: hard
 
@@ -471,6 +568,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-string-parser@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-string-parser@npm:7.29.7"
+  checksum: 10/4d8ef0ef7105f3d9fe4361137c8f42e5b4c7a52b5380b962762f2a528a1ba89064e2c6236090716ce34b63707b886ae0ebf36b2c2fcc2851f27e652febfc3648
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-identifier@npm:^7.22.5, @babel/helper-validator-identifier@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/helper-validator-identifier@npm:7.25.9"
@@ -485,6 +589,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-validator-identifier@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-validator-identifier@npm:7.29.7"
+  checksum: 10/2efa42701eb05babf26dff3332109c9e5e1a3400a71fb9e68ee27af28235036a2a72c2494c04bdab3f909075f42a58b2e8271074372bc7f8e79ec02bd364d7a7
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-option@npm:^7.22.5, @babel/helper-validator-option@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/helper-validator-option@npm:7.25.9"
@@ -496,6 +607,13 @@ __metadata:
   version: 7.27.1
   resolution: "@babel/helper-validator-option@npm:7.27.1"
   checksum: 10/db73e6a308092531c629ee5de7f0d04390835b21a263be2644276cb27da2384b64676cab9f22cd8d8dbd854c92b1d7d56fc8517cf0070c35d1c14a8c828b0903
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-option@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-validator-option@npm:7.29.7"
+  checksum: 10/aeb6aa966f59300d3cc2fea7c68e1dfd7ad011fc10e535c8e2b2de3094b27c859428dc7220f16420350f8b1cde99da120b673be04bcb0c2f37b56258c96bed58
   languageName: node
   linkType: hard
 
@@ -531,6 +649,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helpers@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helpers@npm:7.29.7"
+  dependencies:
+    "@babel/template": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+  checksum: 10/b4d1ef12c19e896585c009ba29677839097ff04f8b11a2430d335c3fb6bd667b4f9e96a3b185a083fdde6b1137eabbbf2600c32425cb69cefc81d81d5cfe425d
+  languageName: node
+  linkType: hard
+
 "@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.12.11, @babel/parser@npm:^7.12.7, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.23.6, @babel/parser@npm:^7.25.9, @babel/parser@npm:^7.26.0, @babel/parser@npm:^7.26.3":
   version: 7.26.3
   resolution: "@babel/parser@npm:7.26.3"
@@ -550,6 +678,17 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: 10/f54c46213ef180b149f6a17ea765bf40acc1aebe2009f594e2a283aec69a190c6dda1fdf24c61a258dbeb903abb8ffb7a28f1a378f8ab5d333846ce7b7e23bf1
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.29.7, @babel/parser@npm:^7.29.8":
+  version: 7.29.8
+  resolution: "@babel/parser@npm:7.29.8"
+  dependencies:
+    "@babel/types": "npm:^7.29.8"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 10/dbd14ebbba0fa3019acd2712b0db3ffd594d0850d4fc487667287b5702893f54a7911570ea842f0cff4dc492a2412e3287dfabfe00c6b78efa7becb1255f3f86
   languageName: node
   linkType: hard
 
@@ -1867,6 +2006,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/template@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/template@npm:7.29.7"
+  dependencies:
+    "@babel/code-frame": "npm:^7.29.7"
+    "@babel/parser": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+  checksum: 10/da92f7a5b61e05d2fb3934a44f18cec6006ee3c595116c17a3b44cb9756ecd43205c7360dbfa326fa8f4d00aaeb9e777342a881070d11c2305e9c694bc3ca6ff
+  languageName: node
+  linkType: hard
+
 "@babel/traverse@npm:^7.1.6, @babel/traverse@npm:^7.12.11, @babel/traverse@npm:^7.12.9, @babel/traverse@npm:^7.13.0, @babel/traverse@npm:^7.22.5, @babel/traverse@npm:^7.23.7, @babel/traverse@npm:^7.25.9, @babel/traverse@npm:^7.26.4":
   version: 7.26.4
   resolution: "@babel/traverse@npm:7.26.4"
@@ -1897,6 +2047,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/traverse@npm:^7.29.7":
+  version: 7.29.8
+  resolution: "@babel/traverse@npm:7.29.8"
+  dependencies:
+    "@babel/code-frame": "npm:^7.29.7"
+    "@babel/generator": "npm:^7.29.8"
+    "@babel/helper-globals": "npm:^7.29.7"
+    "@babel/parser": "npm:^7.29.8"
+    "@babel/template": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.8"
+    debug: "npm:^4.3.1"
+  checksum: 10/91f0b4799d27b50ffd5c2ab4ba537065221196858e0899275d8474489c57dd0b53150508b2c0d9b308520e5985bde63049a401d32aa1ac4f1e10e466e2a3f447
+  languageName: node
+  linkType: hard
+
 "@babel/types@npm:^7.0.0, @babel/types@npm:^7.12.11, @babel/types@npm:^7.12.7, @babel/types@npm:^7.2.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.22.5, @babel/types@npm:^7.23.6, @babel/types@npm:^7.25.9, @babel/types@npm:^7.26.0, @babel/types@npm:^7.26.3, @babel/types@npm:^7.4.4":
   version: 7.26.3
   resolution: "@babel/types@npm:7.26.3"
@@ -1914,6 +2079,16 @@ __metadata:
     "@babel/helper-string-parser": "npm:^7.27.1"
     "@babel/helper-validator-identifier": "npm:^7.27.1"
   checksum: 10/db50bf257aafa5d845ad16dae0587f57d596e4be4cbb233ea539976a4c461f9fbcc0bf3d37adae3f8ce5dcb4001462aa608f3558161258b585f6ce6ce21a2e45
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.29.7, @babel/types@npm:^7.29.8":
+  version: 7.29.8
+  resolution: "@babel/types@npm:7.29.8"
+  dependencies:
+    "@babel/helper-string-parser": "npm:^7.29.7"
+    "@babel/helper-validator-identifier": "npm:^7.29.7"
+  checksum: 10/ff2becf0f8b432f0820f286fb9319d7f3819b2d0eb95bc26957fbc6250a3ca0ae3656feb98ecb5f171f9e04b34a4c08f5036447f17459ed7bfc32ff649d9b71e
   languageName: node
   linkType: hard
 
@@ -4876,6 +5051,125 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sentry/bundler-plugins@npm:^10.64.0":
+  version: 10.70.0
+  resolution: "@sentry/bundler-plugins@npm:10.70.0"
+  dependencies:
+    "@babel/core": "npm:^7.18.5"
+    "@sentry/cli": "npm:^2.58.6"
+    "@sentry/core": "npm:10.70.0"
+    dotenv: "npm:^17.4.2"
+    find-up: "npm:^5.0.0"
+    glob: "npm:^13.0.6"
+    magic-string: "npm:~0.30.8"
+  peerDependencies:
+    rollup: ">=3.2.0"
+    webpack: ">=5.0.0"
+  peerDependenciesMeta:
+    rollup:
+      optional: true
+    webpack:
+      optional: true
+  checksum: 10/7fe35dc40b63e76b85ff212a402d7f61bfc9174fe3461e97a11ccee0b500a9c2e5520f7e8786ab356d43d24b239d18cd866a98eb0bcb5e52a77d0ff4bbf8a400
+  languageName: node
+  linkType: hard
+
+"@sentry/cli-darwin@npm:2.58.6":
+  version: 2.58.6
+  resolution: "@sentry/cli-darwin@npm:2.58.6"
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
+"@sentry/cli-linux-arm64@npm:2.58.6":
+  version: 2.58.6
+  resolution: "@sentry/cli-linux-arm64@npm:2.58.6"
+  conditions: (os=linux | os=freebsd | os=android) & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@sentry/cli-linux-arm@npm:2.58.6":
+  version: 2.58.6
+  resolution: "@sentry/cli-linux-arm@npm:2.58.6"
+  conditions: (os=linux | os=freebsd | os=android) & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@sentry/cli-linux-i686@npm:2.58.6":
+  version: 2.58.6
+  resolution: "@sentry/cli-linux-i686@npm:2.58.6"
+  conditions: (os=linux | os=freebsd | os=android) & (cpu=x86 | cpu=ia32)
+  languageName: node
+  linkType: hard
+
+"@sentry/cli-linux-x64@npm:2.58.6":
+  version: 2.58.6
+  resolution: "@sentry/cli-linux-x64@npm:2.58.6"
+  conditions: (os=linux | os=freebsd | os=android) & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@sentry/cli-win32-arm64@npm:2.58.6":
+  version: 2.58.6
+  resolution: "@sentry/cli-win32-arm64@npm:2.58.6"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@sentry/cli-win32-i686@npm:2.58.6":
+  version: 2.58.6
+  resolution: "@sentry/cli-win32-i686@npm:2.58.6"
+  conditions: os=win32 & (cpu=x86 | cpu=ia32)
+  languageName: node
+  linkType: hard
+
+"@sentry/cli-win32-x64@npm:2.58.6":
+  version: 2.58.6
+  resolution: "@sentry/cli-win32-x64@npm:2.58.6"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@sentry/cli@npm:^2.58.6":
+  version: 2.58.6
+  resolution: "@sentry/cli@npm:2.58.6"
+  dependencies:
+    "@sentry/cli-darwin": "npm:2.58.6"
+    "@sentry/cli-linux-arm": "npm:2.58.6"
+    "@sentry/cli-linux-arm64": "npm:2.58.6"
+    "@sentry/cli-linux-i686": "npm:2.58.6"
+    "@sentry/cli-linux-x64": "npm:2.58.6"
+    "@sentry/cli-win32-arm64": "npm:2.58.6"
+    "@sentry/cli-win32-i686": "npm:2.58.6"
+    "@sentry/cli-win32-x64": "npm:2.58.6"
+    https-proxy-agent: "npm:^5.0.0"
+    node-fetch: "npm:^2.6.7"
+    progress: "npm:^2.0.3"
+    proxy-from-env: "npm:^1.1.0"
+    which: "npm:^2.0.2"
+  dependenciesMeta:
+    "@sentry/cli-darwin":
+      optional: true
+    "@sentry/cli-linux-arm":
+      optional: true
+    "@sentry/cli-linux-arm64":
+      optional: true
+    "@sentry/cli-linux-i686":
+      optional: true
+    "@sentry/cli-linux-x64":
+      optional: true
+    "@sentry/cli-win32-arm64":
+      optional: true
+    "@sentry/cli-win32-i686":
+      optional: true
+    "@sentry/cli-win32-x64":
+      optional: true
+  bin:
+    sentry-cli: bin/sentry-cli
+  checksum: 10/bde9b40876eb4974b7bdb757e79e9b1016cc0a60cbb6563baf4c640e4aa679c9fb67660f0ee13c6267d2d0c24377f2feeff6f8e11a885546a85d1580a5c56f41
+  languageName: node
+  linkType: hard
+
 "@sentry/conventions@npm:^0.16.0":
   version: 0.16.0
   resolution: "@sentry/conventions@npm:0.16.0"
@@ -4931,6 +5225,15 @@ __metadata:
     "@sentry/browser-utils": "npm:10.70.0"
     "@sentry/core": "npm:10.70.0"
   checksum: 10/92dd9d33ebddb5fcb39f7c369cf4414d70e7c17b770fd91ba04d96297c536d71656b11c7e676c80886e35d12bc097aab59dc2fd42f0113801b7d81bd2ddf07d5
+  languageName: node
+  linkType: hard
+
+"@sentry/vite-plugin@npm:^5.4.0":
+  version: 5.4.0
+  resolution: "@sentry/vite-plugin@npm:5.4.0"
+  dependencies:
+    "@sentry/bundler-plugins": "npm:^10.64.0"
+  checksum: 10/0582bae87d0dbb641c6831ca5e29f13c3134dbee7115dd32eef0b6fe59dc3f4b740fcfb57d5caa27a2b358a933982678189e2af1bf39fda91aca51d733bd90ef
   languageName: node
   linkType: hard
 
@@ -8075,6 +8378,7 @@ __metadata:
     "@popperjs/core": "npm:2.11.8"
     "@reduxjs/toolkit": "npm:^2.2.3"
     "@sentry/react": "npm:^10.70.0"
+    "@sentry/vite-plugin": "npm:^5.4.0"
     "@storybook/addon-actions": "npm:6.5.16"
     "@storybook/addon-essentials": "npm:6.5.16"
     "@storybook/addon-links": "npm:6.5.16"
@@ -8746,6 +9050,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"balanced-match@npm:^4.0.2":
+  version: 4.0.4
+  resolution: "balanced-match@npm:4.0.4"
+  checksum: 10/fb07bb66a0959c2843fc055838047e2a95ccebb837c519614afb067ebfdf2fa967ca8d712c35ced07f2cd26fc6f07964230b094891315ad74f11eba3d53178a0
+  languageName: node
+  linkType: hard
+
 "bare-events@npm:^2.5.4, bare-events@npm:^2.7.0":
   version: 2.9.1
   resolution: "bare-events@npm:2.9.1"
@@ -8985,6 +9296,15 @@ __metadata:
   dependencies:
     balanced-match: "npm:^1.0.0"
   checksum: 10/a61e7cd2e8a8505e9f0036b3b6108ba5e926b4b55089eeb5550cd04a471fe216c96d4fe7e4c7f995c728c554ae20ddfc4244cad10aef255e72b62930afd233d1
+  languageName: node
+  linkType: hard
+
+"brace-expansion@npm:^5.0.8":
+  version: 5.0.9
+  resolution: "brace-expansion@npm:5.0.9"
+  dependencies:
+    balanced-match: "npm:^4.0.2"
+  checksum: 10/d8683d612919212c7cf298861acd1c15101e7e2ad186e7ae9747390e5b3fc9e9b55ce71107570d32985784d9d88fbbe438d725863aed7b0f3d08d5f080535eec
   languageName: node
   linkType: hard
 
@@ -10864,6 +11184,13 @@ __metadata:
   version: 5.1.0
   resolution: "dotenv-expand@npm:5.1.0"
   checksum: 10/d52af2a6e4642979ae4221408f1b75102508dbe4f5bac1c0613f92a3cf3880d5c31f86b2f5cff3273f7c23e10421e75028546e8b6cd0376fcd20e3803b374e15
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:^17.4.2":
+  version: 17.4.2
+  resolution: "dotenv@npm:17.4.2"
+  checksum: 10/ca1b6f54d58e39914901e1518958e86083aca8deb5aa2e7f2a51acd53291d97852479b0ab26ed949b6a45a0e9adcc7b0d1c3c72375e8ea670f7005e341c6daba
   languageName: node
   linkType: hard
 
@@ -13229,6 +13556,17 @@ __metadata:
   bin:
     glob: dist/esm/bin.mjs
   checksum: 10/38bdb2c9ce75eb5ed168f309d4ed05b0798f640b637034800a6bf306f39d35409bf278b0eaaffaec07591085d3acb7184a201eae791468f0f617771c2486a6a8
+  languageName: node
+  linkType: hard
+
+"glob@npm:^13.0.6":
+  version: 13.0.6
+  resolution: "glob@npm:13.0.6"
+  dependencies:
+    minimatch: "npm:^10.2.2"
+    minipass: "npm:^7.1.3"
+    path-scurry: "npm:^2.0.2"
+  checksum: 10/201ad69e5f0aa74e1d8c00a481581f8b8c804b6a4fbfabeeb8541f5d756932800331daeba99b58fb9e4cd67e12ba5a7eba5b82fb476691588418060b84353214
   languageName: node
   linkType: hard
 
@@ -15667,6 +16005,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lru-cache@npm:^11.0.0":
+  version: 11.5.2
+  resolution: "lru-cache@npm:11.5.2"
+  checksum: 10/122789c66605ddf29df58ff279e9e2c9499499d0b80b895ec524496f14bcde045d1582e3e38008f3457226d98067556719573b352119d6be8bdb1f8849f85681
+  languageName: node
+  linkType: hard
+
 "lru-cache@npm:^5.1.1":
   version: 5.1.1
   resolution: "lru-cache@npm:5.1.1"
@@ -15728,7 +16073,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"magic-string@npm:^0.30.21":
+"magic-string@npm:^0.30.21, magic-string@npm:~0.30.8":
   version: 0.30.21
   resolution: "magic-string@npm:0.30.21"
   dependencies:
@@ -16253,6 +16598,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimatch@npm:^10.2.2":
+  version: 10.2.6
+  resolution: "minimatch@npm:10.2.6"
+  dependencies:
+    brace-expansion: "npm:^5.0.8"
+  checksum: 10/a5e43f7c57d6061a77da320b42aa35ffff826030cf67c83c0eee47a26ede4d66486935881492b968c609bf27a7d48cc4b9f54b2806643cd8fb792fcf9240cc1b
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^3.0.2, minimatch@npm:^3.0.4, minimatch@npm:^3.0.5, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
@@ -16349,6 +16703,13 @@ __metadata:
   version: 7.0.4
   resolution: "minipass@npm:7.0.4"
   checksum: 10/e864bd02ceb5e0707696d58f7ce3a0b89233f0d686ef0d447a66db705c0846a8dc6f34865cd85256c1472ff623665f616b90b8ff58058b2ad996c5de747d2d18
+  languageName: node
+  linkType: hard
+
+"minipass@npm:^7.1.2, minipass@npm:^7.1.3":
+  version: 7.1.3
+  resolution: "minipass@npm:7.1.3"
+  checksum: 10/175e4d5e20980c3cd316ae82d2c031c42f6c746467d8b1905b51060a0ba4461441a0c25bb67c025fd9617f9a3873e152c7b543c6b5ac83a1846be8ade80dffd6
   languageName: node
   linkType: hard
 
@@ -17511,6 +17872,16 @@ __metadata:
     lru-cache: "npm:^9.1.1 || ^10.0.0"
     minipass: "npm:^5.0.0 || ^6.0.2 || ^7.0.0"
   checksum: 10/eebfb8304fef1d4f7e1486df987e4fd77413de4fce16508dea69fcf8eb318c09a6b15a7a2f4c22877cec1cb7ecbd3071d18ca9de79eeece0df874a00f1f0bdc8
+  languageName: node
+  linkType: hard
+
+"path-scurry@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "path-scurry@npm:2.0.2"
+  dependencies:
+    lru-cache: "npm:^11.0.0"
+    minipass: "npm:^7.1.2"
+  checksum: 10/2b4257422bcb870a4c2d205b3acdbb213a72f5e2250f61c80f79c9d014d010f82bdf8584441612c8e1fa4eb098678f5704a66fa8377d72646bad4be38e57a2c3
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4852,6 +4852,88 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sentry/browser-utils@npm:10.70.0":
+  version: 10.70.0
+  resolution: "@sentry/browser-utils@npm:10.70.0"
+  dependencies:
+    "@sentry/conventions": "npm:^0.16.0"
+    "@sentry/core": "npm:10.70.0"
+  checksum: 10/a9ff168ccf59a63befabd4d37f953168c7927748a302a5c07a27bbb81b85b4d0f49a8bdd03a4e60375bb5109bf4a4913b1c7f26c45ca267014b2619b28e847a0
+  languageName: node
+  linkType: hard
+
+"@sentry/browser@npm:10.70.0":
+  version: 10.70.0
+  resolution: "@sentry/browser@npm:10.70.0"
+  dependencies:
+    "@sentry/browser-utils": "npm:10.70.0"
+    "@sentry/conventions": "npm:^0.16.0"
+    "@sentry/core": "npm:10.70.0"
+    "@sentry/feedback": "npm:10.70.0"
+    "@sentry/replay": "npm:10.70.0"
+    "@sentry/replay-canvas": "npm:10.70.0"
+  checksum: 10/8b51c9e44f724ded90fec81973fa50e70f58867b0a03dee3b3449e6a228c2ad43d961df61d33df0e0251baf133d4cb05d292868c9b516ba9c40e26b00899072d
+  languageName: node
+  linkType: hard
+
+"@sentry/conventions@npm:^0.16.0":
+  version: 0.16.0
+  resolution: "@sentry/conventions@npm:0.16.0"
+  checksum: 10/21c5bdbde32ff5058954a87f7d6b40b670cdd08c10a1c6787fedc3b94b89804b0df92817e5a37d0ed60e8f1ce6747d01b840f05a5e8940742f9a1dcb0f2d490e
+  languageName: node
+  linkType: hard
+
+"@sentry/core@npm:10.70.0":
+  version: 10.70.0
+  resolution: "@sentry/core@npm:10.70.0"
+  dependencies:
+    "@sentry/conventions": "npm:^0.16.0"
+  checksum: 10/b580108cedde8ae38ddcb68144c2c35090d1c81ee7074c88aebfb11571246d7e31982969e952cbd0232fc5e9d5533a0c25150a31bd8e499270a846f31b4ce544
+  languageName: node
+  linkType: hard
+
+"@sentry/feedback@npm:10.70.0":
+  version: 10.70.0
+  resolution: "@sentry/feedback@npm:10.70.0"
+  dependencies:
+    "@sentry/core": "npm:10.70.0"
+  checksum: 10/a7e77ada01c315fbc0626ec2ec2e6c36f2f6f532cdf4cc1991bb1666a4474a6054b590424e80fabc228882db2c766c7adc2a4579452c1ac20a748289650bf7e4
+  languageName: node
+  linkType: hard
+
+"@sentry/react@npm:^10.70.0":
+  version: 10.70.0
+  resolution: "@sentry/react@npm:10.70.0"
+  dependencies:
+    "@sentry/browser": "npm:10.70.0"
+    "@sentry/conventions": "npm:^0.16.0"
+    "@sentry/core": "npm:10.70.0"
+  peerDependencies:
+    react: ^16.14.0 || 17.x || 18.x || 19.x
+  checksum: 10/0d16c5564e4e45863af5d4d9af3cd957cafc0f330de3713af9df7f95d6396897453905703e67947f978cad2c0449c69e981eec122b7bd53b09c17d40bb75940d
+  languageName: node
+  linkType: hard
+
+"@sentry/replay-canvas@npm:10.70.0":
+  version: 10.70.0
+  resolution: "@sentry/replay-canvas@npm:10.70.0"
+  dependencies:
+    "@sentry/core": "npm:10.70.0"
+    "@sentry/replay": "npm:10.70.0"
+  checksum: 10/952a9b0ac42d517803ebf5b3b4b01a89297de63bcc4a1adc384c80ea5c4d5fae927364fdd1102ea1c87587d6de80a99a91ecf862052e7ef3070d8b71bcf245e8
+  languageName: node
+  linkType: hard
+
+"@sentry/replay@npm:10.70.0":
+  version: 10.70.0
+  resolution: "@sentry/replay@npm:10.70.0"
+  dependencies:
+    "@sentry/browser-utils": "npm:10.70.0"
+    "@sentry/core": "npm:10.70.0"
+  checksum: 10/92dd9d33ebddb5fcb39f7c369cf4414d70e7c17b770fd91ba04d96297c536d71656b11c7e676c80886e35d12bc097aab59dc2fd42f0113801b7d81bd2ddf07d5
+  languageName: node
+  linkType: hard
+
 "@sicmutils/glsl-parser@npm:^2.0.1":
   version: 2.0.1
   resolution: "@sicmutils/glsl-parser@npm:2.0.1"
@@ -7992,6 +8074,7 @@ __metadata:
     "@mui/utils": "npm:^7.3.4"
     "@popperjs/core": "npm:2.11.8"
     "@reduxjs/toolkit": "npm:^2.2.3"
+    "@sentry/react": "npm:^10.70.0"
     "@storybook/addon-actions": "npm:6.5.16"
     "@storybook/addon-essentials": "npm:6.5.16"
     "@storybook/addon-links": "npm:6.5.16"


### PR DESCRIPTION
### What are the relevant issues?

N/A

### Description

Adds Sentry error and performance monitoring to the two Phase 1 surfaces: the React SPA
(`@sentry/react` + `@sentry/vite-plugin`) and the Django API (`sentry-sdk[django]`). The two
Cloudflare Workers are Phase 2 and are untouched here.

Each surface initializes its own SDK with its own DSN. **An unset DSN is the whole off-switch** —
dev, CI, and tests supply none, so both surfaces skip `init()` behind an explicit `if` and no
`IS_PROD` branching exists anywhere.

Decisions worth flagging for review:

- **No PII.** `send_default_pii=False` / `sendDefaultPii: false` set explicitly, and no
  `set_user` / `setUser` call on any surface. Note that `send_default_pii=False` does *not* stop IP
  collection — that is a per-project dashboard toggle, not a code setting.
- **Full tracing** (`traces_sample_rate` 1.0). Django's is the tunable `SENTRY_TRACES_SAMPLE_RATE`;
  the SPA's is hardcoded.
- **FE↔BE trace stitching is deliberately skipped.** `sentry-trace`/`baggage` are not
  CORS-safelisted, and preflight caching is keyed per full URL — so every distinct scene URL would
  need its own `OPTIONS` round-trip. Not worth it for the join. No `tracePropagationTargets`, and
  `CORS_ALLOW_HEADERS` is untouched.
- **Source maps are uploaded to Sentry _and_ served publicly.** Math3d is open source, so there is
  nothing to hide and public maps make devtools match what Sentry shows.
- **Route errors** caught by the `errorElement` are reported with an explicit
  `mechanism: { handled: false }`, so they aren't filtered out of Sentry's unhandled-error views.
- **Swallowed render-nudge failures** in `scenes/screenshots.py` moved `WARNING` → `ERROR`. Sentry's
  logging integration only promotes `ERROR`+ to events; at `WARNING` these stayed invisible.

The reasoning is recorded in `docs/adr/0003-sentry-monitoring.md`.

### How can this be tested?

Everything green locally on this branch:

- `yarn lint` 13/13, `yarn typecheck` 12/12, `yarn test` 12/12 packages (282 passing)
- `just be test` 171 passed, `just be typecheck` clean on 97 files
- `yarn test-e2e` 49 passed / 1 skipped

Nothing in this branch does anything without a DSN, so CI and local dev behave exactly as before.
After the config below is provisioned, the real check is a production deploy: trigger
`?test-sync-error` on the deployed SPA and confirm the issue arrives in Sentry **with an unminified
stack trace** (that last part is what proves the source-map upload worked).

### Additional context

**This does nothing until the following are provisioned, and the first production release will fail
loudly without them** — that is deliberate, since the alternative is shipping a release whose
Sentry issues are unreadable:

| Where | Name | Notes |
| --- | --- | --- |
| GitHub `production` env **vars** | `VITE_SENTRY_DSN` | the SPA project's DSN |
| GitHub `production` env **vars** | `SENTRY_PROJECT` | the SPA project's **slug**, not the DSN's numeric ID |
| GitHub **secret** | `SENTRY_ORG_TOKEN` | must be an *organization* auth token (`sntrys_`) |
| Heroku config var | `SENTRY_DSN` | the python-django project's DSN |

Two things to get right:

1. **Scope `SENTRY_ORG_TOKEN` to the repository or to `production` — never to `rc`.**
   `deploy-reusable.yml`'s build job binds `environment: ${{ inputs.environment }}`, which puts that
   environment's secrets in scope. A token scoped to `rc` would reach rc builds and upload rc source
   maps into the production project, even though `release-rc.yml` deliberately does not forward it.
2. **It must be an org token.** An org token carries its own org, which is why there is no
   `SENTRY_ORG` var. The build rejects any other token type rather than letting the plugin warn and
   silently skip the upload.

Renaming the token from the conventional `SENTRY_AUTH_TOKEN` diverges from the name `sentry-cli`
reads by default. Nothing here uses `sentry-cli`; the rename makes the org-token requirement
self-documenting.

**Review provenance:** built task-by-task with a review gate per task, then a five-lens whole-branch
review (correctness/integration, spec compliance, test quality, CI/deploy, repo fit + prose), one
consolidated fix round, and a scoped re-review that approved 12/12 items.

### Checklist:

- [ ] Provision the four config values above before the first production release
- [ ] Turn off IP collection in each Sentry project's settings if "no PII" should include IPs
