### PR TITLE
fix(webserver): drop the SQLite fallback, require DATABASE_URL in production

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ Feature-based organization in `packages/app/src/features/` (auth, notifications,
 ### Testing
 
 - **Frontend unit tests**: Vitest + Testing Library + MSW mocks. Config in `packages/app/vite.config.ts`
-- **Backend tests**: pytest + pytest-django + factory-boy. Config in `webserver/pyproject.toml`. They run against PostgreSQL, like dev and production — `just be test` supplies `DATABASE_URL`. `main/test_settings.py` refuses to start on any other engine rather than silently falling back to SQLite. See "Running backend tests" below.
+- **Backend tests**: pytest + pytest-django + factory-boy. Config in `webserver/pyproject.toml`. They run against PostgreSQL, like dev and production — `just be test` supplies `DATABASE_URL`. `main/test_settings.py` refuses to start on any other engine, and settings have no SQLite fallback — an unset `DATABASE_URL` leaves Django's dummy backend, which fails on any query. See "Running backend tests" below.
 - **E2E**: Playwright in `packages/app-tests-e2e/`
 
 #### Running backend tests

--- a/webserver/main/env.py
+++ b/webserver/main/env.py
@@ -38,6 +38,8 @@ class EnvConfig(BaseSettings):
     # Shared secret gating the Worker's POST /render. Unset in dev is fine
     # (feature dark). Not required in production — the feature is optional.
     RENDER_SECRET: str = ""
+    # Required in production (below). Unset in dev leaves Django on its dummy
+    # backend: DB-free commands like makemigrations run, queries fail loudly.
     DATABASE_URL: str = ""
     INGESTION_DATABASE_URL: str = ""
     # NoDecode: these env vars hold comma-separated lists, not JSON — skip
@@ -126,6 +128,11 @@ class EnvConfig(BaseSettings):
                     "CSRF_COOKIE_DOMAIN is required in production; without it the "
                     "SPA cannot read the CSRF token and all authenticated writes "
                     "fail."
+                )
+            if not self.DATABASE_URL:
+                raise ValueError(
+                    "DATABASE_URL is required in production; without it Django "
+                    "falls back to a dummy backend that fails on every query."
                 )
         return self
 

--- a/webserver/main/settings.py
+++ b/webserver/main/settings.py
@@ -10,7 +10,6 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.1/ref/settings/
 """
 
-import os
 from pathlib import Path
 import logging
 
@@ -307,10 +306,10 @@ HEADLESS_FRONTEND_URLS = {
 # Database
 # https://docs.djangoproject.com/en/4.1/ref/settings/#databases
 
+# Empty config ⇒ Django's dummy backend: DB-free commands (makemigrations,
+# dump_openapi_*) still run, queries fail loudly. Required in production.
 DATABASES = {
-    "default": dj_database_url.parse(
-        ENV.DATABASE_URL or f"sqlite:///{os.path.join(BASE_DIR, 'db.sqlite3')}"
-    )
+    "default": dj_database_url.parse(ENV.DATABASE_URL) if ENV.DATABASE_URL else {}
 }
 
 

--- a/webserver/main/settings_test.py
+++ b/webserver/main/settings_test.py
@@ -26,6 +26,7 @@ SETTINGS_ENV_VARS = list(EnvConfig.model_fields)
 PROD_ENV = {
     "APP_BASE_URL": "https://app.example.org",
     "CSRF_COOKIE_DOMAIN": ".example.org",
+    "DATABASE_URL": "postgres://u:p@db.example.org:5432/math3d",  # pragma: allowlist secret
 }
 
 
@@ -107,6 +108,32 @@ def test_production_requires_csrf_cookie_domain(monkeypatch):
     del env["CSRF_COOKIE_DOMAIN"]
     with pytest.raises(ImproperlyConfigured, match="CSRF_COOKIE_DOMAIN"):
         load_settings(monkeypatch, **env)
+
+
+def test_production_requires_database_url(monkeypatch):
+    """
+    Unset, Django falls back to its dummy backend, which boots fine and then
+    fails every query — so production must fail at import instead.
+    """
+    env = {**PROD_ENV}
+    del env["DATABASE_URL"]
+    with pytest.raises(ImproperlyConfigured, match="DATABASE_URL"):
+        load_settings(monkeypatch, **env)
+
+
+def test_database_url_configures_the_default_connection(monkeypatch):
+    loaded = load_settings(monkeypatch, **PROD_ENV)
+    assert loaded.DATABASES["default"]["ENGINE"] == "django.db.backends.postgresql"
+
+
+def test_dev_without_database_url_configures_no_engine(monkeypatch):
+    """
+    An empty config is how Django is told to use its dummy backend, which keeps
+    DB-free commands (makemigrations, dump_openapi_*) working while any query
+    fails loudly.
+    """
+    loaded = load_settings(monkeypatch, IS_DEVELOPMENT="True")
+    assert loaded.DATABASES["default"] == {}
 
 
 def test_csrf_cookie_domain_must_cover_spa_host(monkeypatch):

--- a/webserver/main/test_settings.py
+++ b/webserver/main/test_settings.py
@@ -11,15 +11,16 @@ sentry_sdk.init(dsn=None)  # tests never report, even if SENTRY_DSN is set
 def require_postgres(engine: str, database_url: str) -> None:
     """
     Fail loudly unless the test database is PostgreSQL, as dev and production
-    are. main.settings falls back to SQLite when DATABASE_URL is unset, and
-    that fallback hides bugs that would fail in production.
+    are. Another engine hides bugs that would fail in production, and an unset
+    DATABASE_URL leaves Django's dummy backend, which lets the suite start and
+    then fails every query with a generic message.
     """
     if engine == "django.db.backends.postgresql":
         return
     detail = (
         f"DATABASE_URL resolved to {engine!r}"
         if database_url
-        else "DATABASE_URL is not set, so settings fell back to SQLite"
+        else "DATABASE_URL is not set, so there is no configured database"
     )
     raise ImproperlyConfigured(
         f"The test suite requires PostgreSQL, but {detail}. Run the tests inside "
@@ -29,7 +30,7 @@ def require_postgres(engine: str, database_url: str) -> None:
     )
 
 
-require_postgres(DATABASES["default"]["ENGINE"], ENV.DATABASE_URL)  # noqa: F405
+require_postgres(DATABASES["default"].get("ENGINE", ""), ENV.DATABASE_URL)  # noqa: F405
 
 # The test database name is otherwise fixed, and Django autoclobbers it, so
 # concurrent suites (worktrees, parallel agents) would drop each other's.


### PR DESCRIPTION
### What are the relevant issues?

Closes #1239

### Description

`settings.py` fell back to `sqlite:///db.sqlite3` when `DATABASE_URL` was unset. Nothing depended on it — compose, Heroku, and CI all set the var. What it actually did was let `manage.py` run on the wrong engine from a bare host, silently leaving behind a `db.sqlite3` that was not even gitignored.

**An empty `DATABASES` config replaces it**, which Django fills in with its dummy backend: DB-free commands still run (`makemigrations` skips its consistency check on dummy by design; the `dump_openapi_*` commands never touch the database), and any real query raises `ImproperlyConfigured`. So offline schema work keeps working with no database, and database use fails loudly instead of silently succeeding on SQLite.

**`DATABASE_URL` is now required in production.** Fail-on-use is not enough for a deploy — without a boot guard, gunicorn would start fine and 500 on the first request. It joins `APP_BASE_URL` and `CSRF_COOKIE_DOMAIN` in `_require_production_config`, per the convention in `env.py`'s docstring. Dev is deliberately exempt, and that exemption is what keeps `makemigrations` usable with no database.

**One deviation from the issue:** it also proposed deleting `require_postgres()` and its test. I kept them. The dummy backend's `create_test_db` is a no-op, so a `DATABASE_URL`-less `pytest` would otherwise start and fail late with a generic message, and nothing else catches a `DATABASE_URL` that explicitly points at SQLite. The issue's case for deleting it rested on requiring the var unconditionally, which the `makemigrations` constraint rules out. It now reads `ENGINE` via `.get()`, since Django only fills that key in when it processes the setting — indexing it directly `KeyError`s on the empty config.

### How can this be tested?

`just be test` (174 passed) and `just be typecheck` (clean, 97 files).

The behavior that matters is what happens with no `DATABASE_URL`:

```bash
docker compose run --rm -e DATABASE_URL= webserver uv run ./manage.py makemigrations --check --dry-run   # No changes detected
docker compose run --rm -e DATABASE_URL= webserver uv run ./manage.py dump_openapi_v1 --output /tmp/spec.yaml   # Wrote /tmp/spec.yaml
docker compose run --rm -e DATABASE_URL= webserver uv run ./manage.py migrate   # ImproperlyConfigured
docker compose run --rm -e DATABASE_URL= webserver uv run pytest   # ImproperlyConfigured: The test suite requires PostgreSQL...
```

Three tests cover the settings side: the production guard, a real URL parsing to the postgres engine, and dev-with-no-URL yielding `{}` rather than SQLite.

### Additional context

No deployment action needed — Heroku's postgres addon sets `DATABASE_URL`, so the new production guard is satisfied on every existing deploy. A deploy that somehow lacked it would now fail at release phase rather than serve 500s.
