### PR TITLE
fix(scenes): forward save() kwargs in TimestampedModel

### DIFF
--- a/webserver/scenes/legacy_scene_utils/migrate_scene.py
+++ b/webserver/scenes/legacy_scene_utils/migrate_scene.py
@@ -124,8 +124,8 @@ def migrate_scene(legacy_scene: LegacyScene):
             "Skipping migration of legacy scene with reserved key %r", legacy_scene.key
         )
         return None
-    # These are auto_now_add, auto_now columns and can't be modified
-    # in save()
+    # TimestampedModel.save() overwrites modified_date on every write (and
+    # created_date on insert), so backdate with a queryset update.
     Scene.objects.filter(pk=scene.id).update(
         created_date=legacy_scene.dehydrated["metadata"]["creationDate"].replace(
             '"', ""

--- a/webserver/scenes/models.py
+++ b/webserver/scenes/models.py
@@ -137,6 +137,8 @@ class Scene(TimestampedModel):
         ordering = ["id"]
 
     def save(self, **kwargs):
+        # full_clean() validates every field, so update_fields narrows the write
+        # but not the validation: an invalid `items` blocks a title-only save.
         self.full_clean()
         return super().save(**kwargs)
 

--- a/webserver/scenes/models.py
+++ b/webserver/scenes/models.py
@@ -84,13 +84,17 @@ class TimestampedModel(models.Model):
         abstract = True
 
     def save(self, **kwargs):
+        update_fields = kwargs.get("update_fields")
+        if update_fields is not None and not update_fields:
+            # Django's documented no-op: no write, no signals. Bump the
+            # timestamps anyway and the instance would disagree with its row.
+            return super().save(**kwargs)
         now = timezone.now()
         if not self.id:
             self.created_date = now
         self.modified_date = now
-        # Django writes only the listed columns, so carry the bump along.
-        # Empty stays empty -- that is Django's documented no-op.
-        if update_fields := kwargs.get("update_fields"):
+        if update_fields:
+            # Django writes only the listed columns, so carry the bump along.
             kwargs["update_fields"] = {*update_fields, "modified_date"}
         return super().save(**kwargs)
 

--- a/webserver/scenes/models.py
+++ b/webserver/scenes/models.py
@@ -83,12 +83,16 @@ class TimestampedModel(models.Model):
     class Meta:
         abstract = True
 
-    def save(self, *args, **kwargs):
+    def save(self, **kwargs):
         now = timezone.now()
         if not self.id:
             self.created_date = now
         self.modified_date = now
-        return super().save()
+        # Django writes only the listed columns, so carry the bump along.
+        # Empty stays empty -- that is Django's documented no-op.
+        if update_fields := kwargs.get("update_fields"):
+            kwargs["update_fields"] = {*update_fields, "modified_date"}
+        return super().save(**kwargs)
 
 
 class Scene(TimestampedModel):
@@ -132,9 +136,9 @@ class Scene(TimestampedModel):
         ]
         ordering = ["id"]
 
-    def save(self, *args, **kwargs):
+    def save(self, **kwargs):
         self.full_clean()
-        return super().save(*args, **kwargs)
+        return super().save(**kwargs)
 
 
 class RenderDay(models.Model):

--- a/webserver/scenes/models_test.py
+++ b/webserver/scenes/models_test.py
@@ -88,11 +88,12 @@ def test_save_update_fields_narrows_the_update():
 
 
 @pytest.mark.django_db
-def test_save_with_empty_update_fields_skips_the_write():
+def test_save_with_empty_update_fields_skips_the_db_write():
     scene = SceneFactory.create()
     before = scene.modified_date
 
     scene.save(update_fields=[])
 
+    assert scene.modified_date == before  # in memory, not only in the row
     scene.refresh_from_db()
     assert scene.modified_date == before

--- a/webserver/scenes/models_test.py
+++ b/webserver/scenes/models_test.py
@@ -56,3 +56,43 @@ def test_is_reserved_key_error_false_for_invalid_items():
     with pytest.raises(ValidationError) as exc_info:
         Scene(**kwargs).save()
     assert not is_reserved_key_error(exc_info.value)
+
+
+@pytest.mark.django_db
+def test_created_modified_timestamps():
+    scene = Scene(**_valid_scene_kwargs("timestamps"))
+    scene.save()
+
+    assert scene.created_date == scene.modified_date
+
+    scene.save()
+
+    assert scene.modified_date > scene.created_date
+
+
+@pytest.mark.django_db
+def test_save_update_fields_narrows_the_update():
+    """save(update_fields=...) must reach Model.save, and carry modified_date."""
+    scene = SceneFactory.create()
+    before = scene.modified_date
+    was_archived = scene.archived
+
+    scene.title = "New title"
+    scene.archived = not was_archived
+    scene.save(update_fields=["title"])
+
+    scene.refresh_from_db()
+    assert scene.title == "New title"
+    assert scene.archived == was_archived  # unlisted, so never written
+    assert scene.modified_date > before
+
+
+@pytest.mark.django_db
+def test_save_with_empty_update_fields_skips_the_write():
+    scene = SceneFactory.create()
+    before = scene.modified_date
+
+    scene.save(update_fields=[])
+
+    scene.refresh_from_db()
+    assert scene.modified_date == before

--- a/webserver/scenes/tests/models_test.py
+++ b/webserver/scenes/tests/models_test.py
@@ -29,21 +29,3 @@ def test_invalid_items_raise_validation_error():
     )
     with pytest.raises(ValidationError):
         scene.save()
-
-
-@pytest.mark.django_db
-def test_created_modified_timestamps():
-    data = default_scene()
-    scene = Scene(
-        key="fake2",
-        items=data["items"],
-        item_order=data["itemOrder"],
-        title=data["title"],
-    )
-    scene.save()
-
-    assert scene.created_date == scene.modified_date
-
-    scene.save()
-
-    assert scene.modified_date > scene.created_date


### PR DESCRIPTION
### What are the relevant issues?

- https://github.com/ChristopherChudzicki/math3d-next/issues/1238

Closes #1238

### Description

`TimestampedModel.save()` accepted `*args, **kwargs` and then called `super().save()` with none of them, so `update_fields`, `using`, `force_insert`, and `force_update` were silently discarded. `Scene.save()` forwards correctly, so anything a caller passed survived one level and died at the next.

1. **Forward the kwargs.** The failure mode was silent rather than loud — `scene.save(update_fields=["title"])` issued a full-row UPDATE instead of a single-column one, and `Scene.objects.using(alias).create(...)` would have written to the *default* database.
2. **Union `modified_date` into a non-empty `update_fields`.** Django writes only the listed columns, so a narrowed save would otherwise drop the timestamp bump the override just applied.
3. **Return early on an empty `update_fields`, before the bump.** Django skips the write *and* the `pre_save`/`post_save` signals in that case, so bumping first left the instance holding a timestamp its row does not have — a lie until `refresh_from_db()`. The guard mirrors Django's own check[^1] so the two cannot drift.
4. **Drop `*args` from both overrides.** `Model.save()` is keyword-only as of Django 6, so a positional call could never have reached it.

`created_date` is deliberately *not* unioned: it is only assigned when the instance has no pk, and a pk-less instance combined with `update_fields` raises `ValueError` before any SQL, so the two conditions are mutually exclusive.

Also adds a comment on `Scene.save()` recording that `update_fields` narrows the write but not the validation — `full_clean()` still checks every field, so a stale `items` can block a title-only save. Pre-existing, but only reachable now that `update_fields` works at all; see the follow-up below.

Also corrects a stale comment in `migrate_scene.py` that described these columns as `auto_now_add`/`auto_now`. They are `default=timezone.now` plus the `save()` override, which is why the backdating there has to go through a queryset update.

### How can this be tested?

Two new tests in `webserver/scenes/models_test.py`:

- `test_save_update_fields_narrows_the_update` — dirties two fields, saves with only one listed, and asserts the unlisted one never reached the DB while `modified_date` did.
- `test_save_with_empty_update_fields_skips_the_db_write` — asserts `update_fields=[]` leaves both the row and the in-memory instance untouched. Named for the DB write specifically, because the *call* is not a no-op: `Scene.save()` still runs `full_clean()` first.

I mutation-tested each rather than assuming they bite. Reverting the union fails the first; reverting to the original `super().save()` fails both; removing the early return fails the second's in-memory assertion.

`test_created_modified_timestamps` moved here from `scenes/tests/models_test.py` so all timestamp behavior sits in one file, in the flat location the other 19 backend test files use. That is the only part of this PR that is not strictly required — happy to put it back if you would rather keep the diff minimal.

### Additional context

**One non-obvious behavior change.** `QuerySet.update_or_create()` takes the `obj.save(using=..., update_fields=...)` branch, so re-migration at `migrate_scene.py:107` goes from a full save to a narrowed one. It is safe: `update_or_create` already adds every field whose class overrides `pre_save`, and `DateTimeField` does, so both timestamps were in that set before this change. The columns now excluded (`key`, `archived`, `author_id`) hold DB-fetched values on that path.

**Considered and rejected: overriding `QuerySet.update()`** to auto-set `modified_date`, since `.update()` bypasses `save()`. The one live call site — the view counter at `scenes/api.py:88-90` — deliberately wants *no* bump, and that is pinned by `test_get_does_not_bump_modified_date`. The other, `migrate_scene.py:129`, already passes both timestamps explicitly. So the override would break one call site and no-op on the other. `times_accessed` is a column written on *reads*, so "`.update()` means a modification" is not an invariant this schema has.

**Known follow-ups, not addressed here:**

- `Scene.save(update_fields=["title"])` still runs `full_clean()`, which validates every field — so a stale stored `items` can block a title-only write. Narrowing it properly means deriving an exclusion set the way `ModelForm._post_clean` does[^2], which is a behavior change with its own test surface and does not belong in a kwargs-forwarding fix. Nothing passes `update_fields` to `Scene.save()` today, so the comment added here documents the trap rather than papering over a live bug.
- Separately, the legacy `times_accessed` incrementers at `scenes/api.py:82-84` and `:136-139` do a full-row `.save()` on `LegacyScene` (rewriting the whole `dehydrated` JSON blob on every view, with a read-modify-write race). That is a different bug and gets its own PR.

[^1]: `django/db/models/base.py:843` — `if update_fields is not None: if not update_fields: return`, tested on the raw value before it is frozenset.

[^2]: `django/forms/models.py:503` — `full_clean(exclude=..., validate_unique=False, validate_constraints=False)`, then the unique and constraint checks separately against their own exclusion sets.
