### PR TITLE
feat(auth): make the session the only gate on account deletion

### DIFF
--- a/packages/api/src/generated-v1/index.ts
+++ b/packages/api/src/generated-v1/index.ts
@@ -299,15 +299,13 @@ export interface components {
       /** Userelative */
       useRelative: string;
     };
-    /** DeleteAccountError */
-    DeleteAccountError: {
-      /** Current Password */
-      current_password: string[];
-    };
     /** DeleteAccountSchema */
     DeleteAccountSchema: {
-      /** Current Password */
-      current_password: string;
+      /**
+       * Current Password
+       * @default
+       */
+      current_password?: string;
     };
     /** ExplicitSurfaceItem */
     ExplicitSurfaceItem: {
@@ -1147,15 +1145,6 @@ export interface operations {
           [name: string]: unknown;
         };
         content?: never;
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["DeleteAccountError"];
-        };
       };
     };
   };

--- a/webserver/authentication/api.py
+++ b/webserver/authentication/api.py
@@ -23,11 +23,10 @@ class UserUpdateSchema(Schema):
 
 
 class DeleteAccountSchema(Schema):
-    current_password: str
-
-
-class DeleteAccountError(Schema):
-    current_password: list[str]
+    # Ignored: the session is the gate. The field stays until the removal PR so
+    # the generated client keeps a property for the SPA's call site to
+    # destructure — ninja would drop an undeclared key either way.
+    current_password: str = ""
 
 
 class ActivationSchema(Schema):
@@ -62,15 +61,9 @@ def patch_me(request: HttpRequest, payload: UserUpdateSchema):
     return user
 
 
-@router.post(
-    "/users/me/delete/",
-    response={204: None, 400: DeleteAccountError},
-    auth=session_auth,
-)
+@router.post("/users/me/delete/", response={204: None}, auth=session_auth)
 def delete_me(request: HttpRequest, payload: DeleteAccountSchema):
     user = cast(CustomUser, request.user)
-    if not user.check_password(payload.current_password):
-        return Status(400, {"current_password": ["Invalid password."]})
     user.delete()
     request.session.flush()
     return Status(204, None)

--- a/webserver/authentication/api_test.py
+++ b/webserver/authentication/api_test.py
@@ -2,7 +2,7 @@ import pytest
 from allauth.account.models import EmailAddress
 from django.test import Client
 
-from authentication.factories import FACTORY_PASSWORD, CustomUserFactory
+from authentication.factories import CustomUserFactory
 from authentication.models import CustomUser
 
 ME_URL = "/v1/auth/users/me/"
@@ -117,39 +117,18 @@ def test_me_patch_enforces_csrf():
 
 
 @pytest.mark.django_db
-def test_delete_missing_password_returns_400():
-    # A schema-validation failure routes through the ValidationError handler (422→400).
+def test_delete_removes_account():
+    """
+    The session is the only gate. Provider accounts have unusable passwords, so
+    a password check would lock every OAuth user out of deleting their own
+    account (ADR-0004).
+    """
     user = CustomUserFactory.create()
     client = Client()
     client.force_login(user)
+
     response = client.post(DELETE_URL, data={}, content_type="application/json")
-    assert response.status_code == 400
 
-
-@pytest.mark.django_db
-def test_delete_wrong_password_returns_400_body():
-    user = CustomUserFactory.create()
-    client = Client()
-    client.force_login(user)
-    response = client.post(
-        DELETE_URL,
-        data={"current_password": "wrong"},  # pragma: allowlist secret
-        content_type="application/json",
-    )
-    assert response.status_code == 400
-    assert response.json() == {"current_password": ["Invalid password."]}
-
-
-@pytest.mark.django_db
-def test_delete_correct_password_removes_account():
-    user = CustomUserFactory.create()
-    client = Client()
-    client.force_login(user)
-    response = client.post(
-        DELETE_URL,
-        data={"current_password": FACTORY_PASSWORD},
-        content_type="application/json",
-    )
     assert response.status_code == 204
     assert not CustomUser.objects.filter(id=user.id).exists()
 
@@ -157,11 +136,7 @@ def test_delete_correct_password_removes_account():
 @pytest.mark.django_db
 def test_delete_requires_auth():
     # delete_me is auth=session_auth; an anonymous POST is rejected.
-    response = Client().post(
-        DELETE_URL,
-        data={"current_password": FACTORY_PASSWORD},
-        content_type="application/json",
-    )
+    response = Client().post(DELETE_URL, data={}, content_type="application/json")
     assert response.status_code == 403
 
 
@@ -173,11 +148,9 @@ def test_delete_flushes_session():
     user = CustomUserFactory.create()
     client = Client()
     client.force_login(user)
-    response = client.post(
-        DELETE_URL,
-        data={"current_password": FACTORY_PASSWORD},
-        content_type="application/json",
-    )
+
+    response = client.post(DELETE_URL, data={}, content_type="application/json")
+
     assert response.status_code == 204
     assert "_auth_user_id" not in client.session
 

--- a/webserver/openapi.v1.yaml
+++ b/webserver/openapi.v1.yaml
@@ -231,24 +231,12 @@ components:
       - useRelative
       title: CameraProperties
       type: object
-    DeleteAccountError:
-      properties:
-        current_password:
-          items:
-            type: string
-          title: Current Password
-          type: array
-      required:
-      - current_password
-      title: DeleteAccountError
-      type: object
     DeleteAccountSchema:
       properties:
         current_password:
+          default: ''
           title: Current Password
           type: string
-      required:
-      - current_password
       title: DeleteAccountSchema
       type: object
     ExplicitSurfaceItem:
@@ -1704,12 +1692,6 @@ paths:
       responses:
         '204':
           description: No Content
-        '400':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DeleteAccountError'
-          description: Bad Request
       security:
       - SessionAuth: []
       summary: Delete Me


### PR DESCRIPTION
<!-- PR title must be a conventional commit: type(scope?): subject — see https://www.conventionalcommits.org -->

### What are the relevant issues?

<!-- Link to the issue here (closes #, fixes #, etc), or write N/A -->

### Description

<!-- Describe your changes in detail. -->

### Screenshots (if appropriate)

<!-- Remove if irrelevant. -->

### How can this be tested?

<!-- Describe how a reviewer can validate your changes. -->

### Additional context

<!-- Any reviewer questions, deployment notes, etc. -->

### Checklist:

- [ ] e.g. Update secret values in Vault before merging
      --->