### PR TITLE
ci: run tests and e2e on pull requests to any branch

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,8 +3,9 @@ name: CI/ End-to-end Tests
 on:
   push:
     branches: [main]
+  # No `branches` filter: a stacked PR targets its parent feature branch, and
+  # these checks must run there too.
   pull_request:
-    branches: [main]
 
 env:
   CI: True

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,8 +4,9 @@ env:
   CI: True
 
 on:
+  # No `branches` filter: a stacked PR targets its parent feature branch, and
+  # these checks must run there too.
   pull_request:
-    branches: [main]
 
 jobs:
   frontend-tests:


### PR DESCRIPTION
### What are the relevant issues?

N/A — found while reviewing the ADR-0004 stack:

- https://github.com/ChristopherChudzicki/math3d-next/pull/1253

### Description

`test.yaml` and `e2e.yml` were both gated on `pull_request: branches: [main]`, so a PR whose base is another feature branch ran neither. In the five-PR ADR-0004 stack only the bottom PR gets `frontend-tests`, `webserver-tests`, `e2e-tests`, and `openapi-generated-client-check`; the four above it get the PR-title lint and pre-commit.ci and nothing else. Every commit in those four reached review with no CI signal.

`pr-title-check.yml` already has no branch filter, which is why it is one of the two that do run.

`pull_request` fires only for open PRs in this repo, so this costs one run per stacked PR, not one per branch push — and the repo is public, so Actions minutes are free.

### How can this be tested?

This PR targets `main`, so its own checks are the old behavior. The new behavior shows up on the ADR-0004 stack once this merges and those branches are rebased — GitHub evaluates a `pull_request` workflow from the PR's merge commit, so the stacked PRs only pick this up after a rebase, not on merge to `main` alone.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkxEBcEnCzJSR9vAm33W5n