### PR TITLE
fix(dev): make DISABLE_CSRF reach the v1 API

### DIFF
--- a/docs/adr/0005-local-google-sign-in-testing.md
+++ b/docs/adr/0005-local-google-sign-in-testing.md
@@ -77,6 +77,7 @@ A **dev-only OAuth client**, in the same Google Cloud project as production. Sep
 ### The work
 
 - **`DISABLE_CSRF` in `webserver/main/env.py`,** and the guarded branch above in `settings.py`.
+- **The same flag passed to django-ninja's cookie auth** in `webserver/main/ninja_auth.py`. Ninja's `SessionAuth` runs its own CSRF check, instantiating `CsrfViewMiddleware` directly rather than reading `MIDDLEWARE`, so dropping the middleware leaves every authenticated write on the v1 API rejecting with `{"detail": "CSRF check Failed"}`.
 - **`README.md` gains a short section** with the `.env` block and what to expect.
 
 Nothing else: no new service, no compose change, no CI change, no frontend change. The block is

--- a/webserver/main/ninja_auth.py
+++ b/webserver/main/ninja_auth.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from django.conf import settings
 from django.http import HttpRequest
 from ninja.security import SessionAuth
 
@@ -18,5 +19,8 @@ class StaffSessionAuth(SessionAuth):
         return None
 
 
-session_auth = SessionAuth()
-staff_auth = StaffSessionAuth()
+# django-ninja's cookie auth runs its own CSRF check, instantiating
+# CsrfViewMiddleware directly (ninja/security/apikey.py) rather than reading
+# MIDDLEWARE, so settings.py dropping the middleware never reaches these views.
+session_auth = SessionAuth(csrf=not settings.DISABLE_CSRF)
+staff_auth = StaffSessionAuth(csrf=not settings.DISABLE_CSRF)

--- a/webserver/main/ninja_auth_test.py
+++ b/webserver/main/ninja_auth_test.py
@@ -1,0 +1,39 @@
+import importlib
+
+import pytest
+
+import main.ninja_auth
+
+
+@pytest.fixture
+def reload_ninja_auth(settings):
+    """
+    The auth objects read DISABLE_CSRF once, when the module is imported, so a
+    settings override only shows up after a reload. Reload again on teardown so
+    the module's objects match the restored settings.
+    """
+
+    def reload_with(disable_csrf: bool):
+        settings.DISABLE_CSRF = disable_csrf
+        return importlib.reload(main.ninja_auth)
+
+    yield reload_with
+    settings.DISABLE_CSRF = False
+    importlib.reload(main.ninja_auth)
+
+
+def test_cookie_auth_enforces_csrf_by_default(reload_ninja_auth):
+    """
+    The v1 API's CSRF enforcement lives in django-ninja, not in MIDDLEWARE, so
+    it needs its own assertion — removing the middleware would not fail here.
+    """
+    reloaded = reload_ninja_auth(False)
+    assert reloaded.session_auth.csrf is True
+    assert reloaded.staff_auth.csrf is True
+
+
+def test_disable_csrf_reaches_cookie_auth(reload_ninja_auth):
+    """Both auth objects, or the flag leaves half the API enforcing (ADR-0005)."""
+    reloaded = reload_ninja_auth(True)
+    assert reloaded.session_auth.csrf is False
+    assert reloaded.staff_auth.csrf is False

--- a/webserver/main/settings.py
+++ b/webserver/main/settings.py
@@ -199,10 +199,12 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 
-# Dropping the middleware is Django's only off switch for CSRF. It exists for
-# one manual test: Google sign-in on bare `localhost`, where a single-label
-# host cannot carry the domain cookie the SPA reads. See ADR-0005.
-if ENV.DISABLE_CSRF:
+# The flag exists for one manual test: Google sign-in on bare `localhost`,
+# where a single-label host cannot carry the domain cookie the SPA reads. See
+# ADR-0005. Dropping the middleware does not cover the v1 API, which runs its
+# own check — main/ninja_auth.py reads the flag too.
+DISABLE_CSRF = ENV.DISABLE_CSRF
+if DISABLE_CSRF:
     if not IS_DEVELOPMENT:
         raise ImproperlyConfigured(
             "DISABLE_CSRF must not be enabled outside development."


### PR DESCRIPTION
### What are the relevant issues?

Follow-up to ADR-0005 (#1278), which added `DISABLE_CSRF`.

### Description

`DISABLE_CSRF` only removes `CsrfViewMiddleware` from `MIDDLEWARE`, and django-ninja does not use that middleware. `SessionAuth` inherits `APIKeyCookie`, whose `_get_key` instantiates `CsrfViewMiddleware` itself:

```python
# ninja/security/apikey.py:48
def _get_key(self, request):
    if self.csrf and not getattr(request, "_ninja_csrf_exempt", False):
        error_response = check_csrf(request)
        if error_response:
            raise HttpError(403, "CSRF check Failed")
```

So with the flag on, every authenticated write on `/v1/` still rejected — `PATCH`/`DELETE` on scenes, `PATCH` and delete on `users/me`, and the staff activation endpoint. Safe methods and the `auth=None` operations were unaffected, which is why signing in with Google and creating a scene both worked and made the gap look narrower than it was.

- Pass the flag to both auth objects in `main/ninja_auth.py`. The existing `IS_DEVELOPMENT` guard in `settings.py` still governs it, so this adds no second escape hatch.
- Expose `DISABLE_CSRF` as a setting, and correct the `settings.py` comment claiming the middleware was Django's only off switch — that belief is what made the flag stop halfway.
- Add `main/ninja_auth.py` to ADR-0005's work list.

### How can this be tested?

With the ADR-0005 `.env` block in place (`DISABLE_CSRF=True`, `APP_BASE_URL=http://localhost:3000`) and `docker compose up -d`: sign in with Google, edit a scene you own, and save. Before this change the `PATCH` fails with `{"detail": "CSRF check Failed"}`.

`main/ninja_auth_test.py` covers both states — enforcing by default, off when the flag is set. The auth objects read the setting at import, so the fixture reloads the module and reloads again on teardown. The default-posture case is not redundant with `authentication/api_test.py::test_me_patch_enforces_csrf`: that one exercises the request path, this one pins that the flag is wired at all.

### Additional context

The flag-on path has no end-to-end request test. Ninja's registered operations capture the auth objects at import, so a module reload cannot reach them, and standing up a throwaway router to work around that would cost more than it pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkxEBcEnCzJSR9vAm33W5n