### PR TITLE
docs: warn that DISABLE_CSRF blocks the E2E suite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,6 +167,7 @@ Troubleshooting:
 
 - "The server at ... serves ..., but this suite is testing ..." from global setup means a stale env var (usually `TEST_APP_URL` exported by another checkout's direnv) is pointing the suite at the wrong server — env vars beat the checkout's env files by design. Unset it or start a fresh shell in this checkout.
 - "sent no X-Checkout-Root header" means the dev server predates the identity header — restart it.
+- The suite cannot run at all while `.env` carries the `DISABLE_CSRF=True` block from README.md's "Testing Google sign-in locally", and both failures point elsewhere. `TEST_APP_URL` still names `math3d.localdev`, which Vite 403s once `allowedHosts` follows a `localhost` `APP_BASE_URL`; that response carries no identity header, so global setup reports "sent no X-Checkout-Root header". Repoint it and the next failure is `Expected csrftoken from provider/token`, because Django sets no CSRF cookie with the middleware removed. Remove the block to run E2E.
 - Widespread `Expected sessionid cookie from login response` failures mean the seeded test users are out of sync with `.env.development` credentials — re-run `seed_test_data` (idempotent).
 - Widespread CORS/CSRF failures from a worktree port mean the backend container predates the multi-port trust config — re-run `docker compose up -d` from an up-to-date main checkout.
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ checkout enforces CSRF and worktrees on `.localdev` cannot authenticate, so
 don't leave it on. `DISABLE_CSRF` refuses to boot unless `IS_DEVELOPMENT` is
 set.
 
+`yarn test-e2e` cannot run against this configuration, and neither failure
+names the cause. Global setup trips on `TEST_APP_URL` first — `.env.development`
+still points it at `math3d.localdev:3000`, which Vite now 403s, because
+`allowedHosts` follows `APP_BASE_URL`. Repointing it reaches the next failure,
+`Expected csrftoken from provider/token`: with the middleware removed, Django
+sets no CSRF cookie for the suite to read.
+
 ### Task Runner
 
 We use [just](https://github.com/casey/just) as a task runner. Run `just` to see available commands.


### PR DESCRIPTION
### What are the relevant issues?

N/A — follow-up to ADR-0005 (#1278) and #1283.

### Description

The README's "Testing Google sign-in locally" block turns CSRF off, which makes `yarn test-e2e` unrunnable, and both failures blame something else:

- `TEST_APP_URL` keeps `.env.development`'s `math3d.localdev:3000` while `APP_BASE_URL` moves to `localhost`, so Vite's `allowedHosts` 403s it. That response carries no `X-Checkout-Root` header — the host check runs ahead of the checkout-identity plugin — so global setup reports the header as *missing*, which CLAUDE.md attributes to a stale dev server.
- Repointing it reaches `Expected csrftoken from provider/token`, whose nearest CLAUDE.md entry is about `sessionid` and seed data.

### How can this be tested?

Read it. The 403-without-identity-header behaviour was verified against a dev server on `APP_BASE_URL=http://localhost:3099`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTmuix4CWxF1vB9Veepgye
