### PR TITLE
fix(lint): declare the deps we import, and fix the worktree lint gate

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -15,14 +15,14 @@
     "@math3d/mathitem-configs": "workspace:^",
     "@tanstack/react-query": "^5.62.10",
     "openapi-fetch": "^0.17.0",
-    "tiny-invariant": "^1.3.3"
+    "tiny-invariant": "^1.3.3",
+    "type-fest": "5.7.0"
   },
   "devDependencies": {
     "@math3d/eslint-config": "workspace:^",
     "@math3d/tsconfig": "workspace:^",
     "eslint": "^8.57.1",
     "openapi-typescript": "^7.13.0",
-    "type-fest": "5.7.0",
     "vitest": "^4.1.11"
   }
 }

--- a/packages/app-tests-e2e/.eslintrc.cjs
+++ b/packages/app-tests-e2e/.eslintrc.cjs
@@ -1,0 +1,8 @@
+// Nothing depends on this package: it is private, and every file is Playwright
+// spec code or a helper for it. The shared allowlist keys on `*.spec.ts`; these
+// specs are `*.test.ts`, so a glob set here would just re-spell the package.
+module.exports = {
+  rules: {
+    "import/no-extraneous-dependencies": ["error", { devDependencies: true }],
+  },
+};

--- a/packages/app-tests-e2e/package.json
+++ b/packages/app-tests-e2e/package.json
@@ -16,16 +16,16 @@
     "@math3d/mathitem-configs": "workspace:^",
     "@math3d/mock-api": "workspace:^",
     "@playwright/test": "^1.57.0",
+    "@types/mailparser": "^3.4.6",
+    "@types/node": "^24.0.0",
+    "@types/three": "^0.146.0",
     "envalid": "^8.0.0",
     "eslint": "^8.57.1",
+    "mailparser": "^3.9.15",
     "mathlive": "^0.110.0",
     "p-retry": "^6.2.1",
     "sharp": "^0.35.4",
     "three": "^0.147.0",
     "tiny-invariant": "^1.3.3"
-  },
-  "dependencies": {
-    "@types/mailparser": "^3.4.6",
-    "mailparser": "^3.9.15"
   }
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -68,6 +68,7 @@
     "react-redux": "^9.1.0",
     "react-router": "^7.18.0",
     "react-router-dom": "^7.18.3",
+    "redux": "^5.0.1",
     "showdown": "^2.1.0",
     "tarjan-graph": "3.0.0",
     "three": "^0.147.0",

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -65,6 +65,9 @@ module.exports = {
           "**/src/test_util/**/*.ts",
           "**/src/test_util/**/*.tsx",
         ],
+        // Workspace packages are consumed as TS source, so a type-only import
+        // is as load-bearing for a consumer's build as a value import.
+        includeTypes: true,
       },
     ],
     "no-underscore-dangle": ["off"],

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -64,8 +64,6 @@ module.exports = {
           "**/src/playwright/**",
           "**/src/test_util/**/*.ts",
           "**/src/test_util/**/*.tsx",
-          "**/mock-api/**",
-          "**/app-tests-e2e/**",
         ],
       },
     ],

--- a/packages/mathitem-configs/package.json
+++ b/packages/mathitem-configs/package.json
@@ -11,7 +11,6 @@
     "ajv": "^8.12.0",
     "eslint": "^8.57.1",
     "js-yaml": "^4.3.2",
-    "mathjs": "^15.2.0",
     "vitest": "^4.1.11"
   },
   "scripts": {
@@ -24,6 +23,7 @@
     "@math3d/parser": "workspace:^",
     "@math3d/utils": "workspace:^",
     "@math3d/validators": "workspace:^",
+    "mathjs": "^15.2.0",
     "tinycolor2": "^1.6.0"
   }
 }

--- a/packages/mathscope/package.json
+++ b/packages/mathscope/package.json
@@ -7,7 +7,6 @@
     "@math3d/eslint-config": "workspace:^",
     "@math3d/tsconfig": "workspace:^",
     "eslint": "^8.57.1",
-    "mathjs": "^15.2.0",
     "vitest": "^4.1.11"
   },
   "scripts": {
@@ -20,6 +19,7 @@
     "@math3d/mathjs-utils": "workspace:^",
     "@math3d/utils": "workspace:^",
     "just-group-by": "^2.2.0",
+    "mathjs": "^15.2.0",
     "tarjan-graph": "^3.0.0",
     "toposort": "^2.0.2"
   }

--- a/packages/mock-api/package.json
+++ b/packages/mock-api/package.json
@@ -10,16 +10,20 @@
     "./fixtures": "./src/fixtures.ts"
   },
   "main": "./src/index.ts",
-  "devDependencies": {
+  "dependencies": {
     "@faker-js/faker": "^10.6.0",
-    "@math3d/eslint-config": "workspace:^",
+    "@math3d/api": "workspace:^",
     "@math3d/mathitem-configs": "workspace:^",
-    "@math3d/tsconfig": "workspace:^",
     "@mswjs/data": "^0.16.2",
     "@types/lodash-es": "^4.17.12",
-    "eslint": "^8.57.1",
     "lodash-es": "^4.18.1",
     "msw": "^2.0.14",
+    "tiny-invariant": "^1.3.3"
+  },
+  "devDependencies": {
+    "@math3d/eslint-config": "workspace:^",
+    "@math3d/tsconfig": "workspace:^",
+    "eslint": "^8.57.1",
     "vitest": "^4.1.11"
   },
   "scripts": {
@@ -27,8 +31,5 @@
     "typecheck": "tsc --noEmit",
     "test-watch": "vitest",
     "lint": "eslint --max-warnings 0 \"**/*.ts?(x)\""
-  },
-  "dependencies": {
-    "tiny-invariant": "^1.3.3"
   }
 }

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -7,7 +7,6 @@
     "@math3d/eslint-config": "workspace:^",
     "@math3d/tsconfig": "workspace:^",
     "eslint": "^8.57.1",
-    "mathjs": "^15.2.0",
     "vitest": "^4.1.11"
   },
   "scripts": {
@@ -22,6 +21,7 @@
     "@math3d/utils": "workspace:^",
     "@types/lodash-es": "^4.17.12",
     "lodash-es": "4.18.1",
+    "mathjs": "^15.2.0",
     "tiny-invariant": "^1.3.3",
     "yup": "^1.3.2"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4161,6 +4161,7 @@ __metadata:
   resolution: "@math3d/mock-api@workspace:packages/mock-api"
   dependencies:
     "@faker-js/faker": "npm:^10.6.0"
+    "@math3d/api": "workspace:^"
     "@math3d/eslint-config": "workspace:^"
     "@math3d/mathitem-configs": "workspace:^"
     "@math3d/tsconfig": "workspace:^"
@@ -8620,6 +8621,8 @@ __metadata:
     "@math3d/mock-api": "workspace:^"
     "@playwright/test": "npm:^1.57.0"
     "@types/mailparser": "npm:^3.4.6"
+    "@types/node": "npm:^24.0.0"
+    "@types/three": "npm:^0.146.0"
     envalid: "npm:^8.0.0"
     eslint: "npm:^8.57.1"
     mailparser: "npm:^3.9.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8713,6 +8713,7 @@ __metadata:
     react-redux: "npm:^9.1.0"
     react-router: "npm:^7.18.0"
     react-router-dom: "npm:^7.18.3"
+    redux: "npm:^5.0.1"
     rollup-plugin-visualizer: "npm:5.14.0"
     showdown: "npm:^2.1.0"
     tarjan-graph: "npm:3.0.0"


### PR DESCRIPTION
### What are the relevant issues?

N/A — found while working #1290, tracked in witan.

### Description

Two related fixes to `import/no-extraneous-dependencies`, one commit each.

**`yarn lint` was permanently red in any `.claude/worktrees/*` worktree**, with 13 errors in `@math3d/mock-api`, on commits whose CI was green. The shared config allowlisted `**/mock-api/**` and `**/app-tests-e2e/**`, and those two globs match nothing when the checkout sits under a dot-prefixed directory.[^globs] They were also hiding real mis-declarations, so both are now gone:

- `mock-api` declared its runtime imports (`msw`, `@mswjs/data`, `@faker-js/faker`, `lodash-es`, `@math3d/mathitem-configs`) as devDependencies — they move to `dependencies`, since they are imports of the package's published entry points.
- `app-tests-e2e` gets a package-level `.eslintrc.cjs` with `{ devDependencies: true }` instead. Nothing depends on it and every file is spec code or a helper, so calling `@playwright/test` a runtime dependency would be the same lie inverted. Its `dependencies` collapse into the dev set, and `@types/node` / `@types/three` are declared rather than borrowed from `app` by hoisting.

**Type-only imports were never checked at all**, because the rule skips them unless `includeTypes` is set — which is why `@math3d/api` sat undeclared in `mock-api`, in neither section, without lint noticing. Turning it on surfaced eight more:

- `mathjs` in `parser`, `mathscope`, `mathitem-configs`, and `type-fest` in `api` — devDependencies → `dependencies`.
- `redux` in `app` — declared nowhere, resolving only by hoisting from `@reduxjs/toolkit`.

This is the one judgement call worth a reviewer's attention: the option is all-or-nothing,[^alltypes] so it forces type-only deps into `dependencies`. That reads odd for `mathjs`, which none of those packages call at runtime — but every workspace here is consumed as TypeScript source, so a consumer cannot compile without it, and all five are private, so both sections install identically. Say the word if you'd rather have the rule off than the reclassification.

### How can this be tested?

`yarn lint` from a worktree under `.claude/worktrees/` — that is the case that failed. Passing in the main checkout proves little, since the allowlist works there.

`redux` is the one change that could break something quietly: a second copy alongside `@reduxjs/toolkit`'s would leave the store with two Redux instances. It is pinned to `^5.0.1`, the range already resolved, and a wiped-and-reinstalled `node_modules` has one `redux@npm:5.0.1` and no per-workspace `node_modules` at all.

### Additional context

The whole `yarn.lock` diff is four added lines, all inside workspace records — no package resolution changes.

[^globs]: The rule matches the absolute filename against each glob as written, and again joined onto `process.cwd()` (`no-extraneous-dependencies.js:249-256`). Minimatch's `**` will not cross a dotted segment without `{ dot: true }`, which the rule does not expose, so the first branch fails for such a path. The second rescues entries whose trailing segments do the matching (`**/*.spec.ts`, `**/src/test_util/**/*.ts`) because eslint's cwd is the package directory — but not a glob hinging on a directory name mid-path. A dotted checkout's effective allowlist is therefore a strict subset of a normal one's, which is why green there implies green anywhere.

[^alltypes]: `allowDevDeps` is computed once per file (`:292`) and applied to every import in it, so a type-only import can only be exempted by allowlisting its whole file, value imports included. `eslint-plugin-import-x` is the same. The `allowTypeImports` option that does exist in this ecosystem belongs to `@typescript-eslint/no-restricted-imports`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016pUR5b8JEjgPXcJU1HFkct