### PR TITLE
fix(ui): surface the save dialog's failures

### DIFF
--- a/packages/app/src/pages/MainPage/components/SaveButton.spec.tsx
+++ b/packages/app/src/pages/MainPage/components/SaveButton.spec.tsx
@@ -2,7 +2,7 @@ import { test, expect } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "@math3d/mock-api/node";
 import { seedDb, urls } from "@math3d/mock-api";
-import { renderTestApp, screen, user, within } from "@/test_util";
+import { renderTestApp, screen, user, waitFor, within } from "@/test_util";
 
 test("a failed save surfaces the error in the dialog", async () => {
   server.use(
@@ -21,9 +21,27 @@ test("a failed save surfaces the error in the dialog", async () => {
   const dialog = await screen.findByRole("dialog", { name: "Save a Copy" });
   await user.click(within(dialog).getByRole("button", { name: "Save" }));
 
-  // The title is the form's only field, so a server-side failure has no field
-  // to attach to and is invisible unless the root error renders.
+  // useValidatedForm routes every rejected submit to "root", so a server-side
+  // failure is invisible unless the root error renders.
   expect(
     await within(dialog).findByText(/something went wrong/i),
   ).toBeVisible();
+});
+
+test("an empty title is reported instead of silently blocking the save", async () => {
+  const scene = seedDb.withSceneFromItems([]);
+  renderTestApp(`/${scene.key}`, { isAuthenticated: true });
+
+  await user.click(
+    await screen.findByRole("button", { name: "Other Saving Options" }),
+  );
+  await user.click(await screen.findByRole("menuitem", { name: "Duplicate" }));
+
+  const dialog = await screen.findByRole("dialog", { name: "Save a Copy" });
+  const title = within(dialog).getByLabelText("Title");
+  await user.clear(title);
+  await user.click(within(dialog).getByRole("button", { name: "Save" }));
+
+  await waitFor(() => expect(title).toBeInvalid());
+  expect(within(dialog).getByText("Please enter a title.")).toBeVisible();
 });

--- a/packages/app/src/pages/MainPage/components/SaveButton.spec.tsx
+++ b/packages/app/src/pages/MainPage/components/SaveButton.spec.tsx
@@ -1,0 +1,29 @@
+import { test, expect } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "@math3d/mock-api/node";
+import { seedDb, urls } from "@math3d/mock-api";
+import { renderTestApp, screen, user, within } from "@/test_util";
+
+test("a failed save surfaces the error in the dialog", async () => {
+  server.use(
+    http.post(urls.scenes.list, () =>
+      HttpResponse.json({ detail: "boom" }, { status: 500 }),
+    ),
+  );
+  const scene = seedDb.withSceneFromItems([]);
+  renderTestApp(`/${scene.key}`, { isAuthenticated: true });
+
+  await user.click(
+    await screen.findByRole("button", { name: "Other Saving Options" }),
+  );
+  await user.click(await screen.findByRole("menuitem", { name: "Duplicate" }));
+
+  const dialog = await screen.findByRole("dialog", { name: "Save a Copy" });
+  await user.click(within(dialog).getByRole("button", { name: "Save" }));
+
+  // The title is the form's only field, so a server-side failure has no field
+  // to attach to and is invisible unless the root error renders.
+  expect(
+    await within(dialog).findByText(/something went wrong/i),
+  ).toBeVisible();
+});

--- a/packages/app/src/pages/MainPage/components/SaveButton.tsx
+++ b/packages/app/src/pages/MainPage/components/SaveButton.tsx
@@ -24,7 +24,7 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import styles from "./SaveButton.module.css";
 
 const schema = yup.object({
-  title: yup.string().required(),
+  title: yup.string().required("Please enter a title."),
 });
 
 type SaveDialogProps = Pick<BasicDialogProps, "open"> & {
@@ -150,6 +150,9 @@ const SaveDialog: React.FC<SaveDialogProps> = ({
           margin="dense"
           fullWidth
           label="Title"
+          error={!!errors.title?.message}
+          // A space keeps the row height stable when the message appears.
+          helperText={errors.title?.message ?? " "}
           {...register("title")}
         />
         {errors.root?.message ? (

--- a/packages/app/src/pages/MainPage/components/SaveButton.tsx
+++ b/packages/app/src/pages/MainPage/components/SaveButton.tsx
@@ -48,7 +48,12 @@ const SaveDialog: React.FC<SaveDialogProps> = ({
     const title = duplicating ? `Copy of ${scene.title}` : scene.title;
     return { title };
   }, [scene.title, duplicating]);
-  const { register, handleSubmit, reset } = useValidatedForm({
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useValidatedForm({
     schema,
     defaultValues,
   });
@@ -147,6 +152,11 @@ const SaveDialog: React.FC<SaveDialogProps> = ({
           label="Title"
           {...register("title")}
         />
+        {/* The title is the only field, so every server-side failure lands on
+            "root" with nowhere else to surface. */}
+        {errors.root?.message ? (
+          <Alert severity="error">{errors.root.message}</Alert>
+        ) : null}
       </form>
     </BasicDialog>
   );

--- a/packages/app/src/pages/MainPage/components/SaveButton.tsx
+++ b/packages/app/src/pages/MainPage/components/SaveButton.tsx
@@ -152,8 +152,6 @@ const SaveDialog: React.FC<SaveDialogProps> = ({
           label="Title"
           {...register("title")}
         />
-        {/* The title is the only field, so every server-side failure lands on
-            "root" with nowhere else to surface. */}
         {errors.root?.message ? (
           <Alert severity="error">{errors.root.message}</Alert>
         ) : null}

--- a/packages/app/src/pages/auth/DeleteAccountPage.tsx
+++ b/packages/app/src/pages/auth/DeleteAccountPage.tsx
@@ -94,8 +94,6 @@ const DeleteAccountPage: React.FC = () => {
           type="text"
           {...register("confirm")}
         />
-        {/* The confirmation phrase is the only field, so every server-side
-            failure lands on "root" with nowhere else to surface. */}
         {errors.root?.message ? (
           <Alert severity="error">{errors.root.message}</Alert>
         ) : null}


### PR DESCRIPTION
### What are the relevant issues?

Closes the residual half of `tk-setfielderrors-v1-branch-can-never-fire-…`, whose main half (deleting `setFieldErrors`) shipped in #1290.

### Description

Two ways the save/duplicate dialog swallowed a failure, both of which left the dialog open with Save still armed and nothing on screen:

- **Server-side.** It's a `useValidatedForm` consumer that never rendered `errors.root`, so a rejected `POST /v1/scenes/` was visible only in Sentry.
- **Client-side.** The title field rendered no validation state at all — no `error`, no `helperText`, no `aria-invalid` — so clearing the title and pressing Save blocked the submit silently. The yup `required()` now carries a message, and the field renders it.

Also drops a comment I'd written here and copied from `DeleteAccountPage` (where it shipped in #1290): *"the title is the only field, so every server-side failure lands on root"*. That's false twice over — `useValidatedForm` hardcodes `setError("root", …)` regardless of field count, and `errors.title` does get set, by the resolver. Nothing non-obvious survives the correction, so the comments go rather than get reworded.

### How can this be tested?

`SaveButton.spec.tsx` is new: one case stubs the create endpoint to 500 and expects the message; one clears the title and expects the field to go invalid. Each was confirmed to fail against the unfixed component before being kept.

`yarn workspace app test` — 53 files / 280 tests. `yarn typecheck` 13/13, `yarn workspace app lint` clean, `yarn fmt-check` clean.

Not run: `yarn test-e2e` (my `.env`'s `DISABLE_CSRF=True` takes the suite down) — CI is the gate. Repo-wide `yarn lint` also fails on `@math3d/mock-api` and `app-tests-e2e` from any `.claude/worktrees/*` checkout; that's the glob bug #1291 fixed on `main`, which this base predates.

### Additional context

The header's **other** save path — the direct `patchScene` / "Save a Copy" on an existing scene — is still unhandled: on a rejection it leaves an unhandled promise rejection and sticks on a disabled "Saving…" for the life of the page. It has no form to render into, and a bare `catch` would only make it silent, so it's deliberately left for a global error surface: `tk-no-global-surface-for-failed-background-mutation-…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCiQaPMEsXHUzZSHxFr6L7